### PR TITLE
Update node-factorio-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 Version 1.2.1
 -------------
 
+- Updated node-factorio-api to v0.3.8 to fix mod downloads randomly breaking
+  ([#229][#229].)
+
+[#229]: https://github.com/clusterio/factorioClusterio/issues/229
+
 ### Breaking Changes
 
 - Added authentication to the socket.io server running on the master.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "moment": "^2.22.2",
     "ncp": "^2.0.0",
     "needle": "^2.2.4",
-    "node-factorio-api": "^0.3.5",
+    "node-factorio-api": "^0.3.8",
     "node-forge": "^0.7.1",
     "prom-client": "^10.2.3",
     "rcon-client-fork": "^3.2.0",


### PR DESCRIPTION
Fixes #229

Note that the versions 0.3.6 and 0.3.7 had issues with an old mod_cache.json being present.