### PR TITLE
Rename repository

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,7 +101,7 @@ jobs:
           name: clusterio_docker_image_testing
           path: .
       - name: ls
-        run: ls && ls clusterio_docker_image_testing && ls /home/runner/work/factorioClusterio && ls /home/runner/work/factorioClusterio/factorioClusterio
+        run: ls && ls clusterio_docker_image_testing && ls /home/runner/work/clusterio && ls /home/runner/work/clusterio/clusterio
       - name: Load docker image
         run: docker load -i clusterio_docker_image_testing
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 script:
   - npx lerna bootstrap --hoist --no-ci
   - node packages/lib/build_mod --source-dir packages/slave/lua/clusterio_lib --output-dir temp/test/sharedMods
-  - curl -o temp/test/sharedMods/subspace_storage_1.99.8.zip -L https://github.com/clusterio/factorioClusterioMod/releases/download/1.99.6/subspace_storage_1.99.8.zip
+  - curl -o temp/test/sharedMods/subspace_storage_1.99.8.zip -L https://github.com/clusterio/subspace_storage/releases/download/1.99.6/subspace_storage_1.99.8.zip
   - npx lerna run build
   - npm run-script ci-cover
   - codecov -f coverage/lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,8 +187,8 @@
 - Fixed SIGINT being sent twice to Factorio server when interrupted by CTRL+C on Linux ([#217][#217]).
 - Fixed package.json incorrectly reporting the license as ISC.
 
-[#217]: https://github.com/clusterio/factorioClusterio/issues/217
-[#229]: https://github.com/clusterio/factorioClusterio/issues/229
+[#217]: https://github.com/clusterio/clusterio/issues/217
+[#229]: https://github.com/clusterio/clusterio/issues/229
 
 ### Breaking Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:12 as subspace_storage_builder
 RUN apt update && apt install -y git
 WORKDIR /
-RUN git clone https://github.com/clusterio/factorioClusterioMod.git
-WORKDIR /factorioClusterioMod
+RUN git clone https://github.com/clusterio/subspace_storage.git
+WORKDIR /subspace_storage
 RUN git checkout clusterio-2.0 \
 && npm install \
 && node build
@@ -24,7 +24,7 @@ RUN npm install \
 #RUN npm install @clusterio/plugin-subspace_storage
 #RUN npx clusteriomaster plugin add @clusterio/plugin-subspace_storage
 
-COPY --from=subspace_storage_builder /factorioClusterioMod/dist/ /clusterio/sharedMods/
+COPY --from=subspace_storage_builder /subspace_storage/dist/ /clusterio/sharedMods/
 
 # Build submodules (web UI, libraries, plugins etc)
 RUN npx lerna run build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br/>
 <br/>
 
-# factorioClusterio
+# Clusterio
 
 Discord for development/support/play: https://discord.gg/5XuDkje
 
@@ -128,11 +128,11 @@ If you need it open an issue about it.
 <!--
 Clusterio has *very* limited support for using docker.
 
-    sudo docker build -t clusterio --no-cache --force-rm factorioClusterio
+    sudo docker build -t clusterio --no-cache --force-rm clusterio
 
 	sudo docker run --name master -e MODE=master -p 1234:8080 -d -it --restart=unless-stopped danielvestol/clusterio
 
-	sudo docker run --name slave -e MODE=slave -e INSTANCE=world1 -v /srv/clusterio/instances:/factorioClusterio/instances -p 1235:34167 -it --restart=unless-stopped danielvestol/clusterio
+	sudo docker run --name slave -e MODE=slave -e INSTANCE=world1 -v /srv/clusterio/instances:/clusterio/instances -p 1235:34167 -it --restart=unless-stopped danielvestol/clusterio
 
 The -v flag is used to specify the instance directory.
 Your instances (save files etc) will be stored there.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you are starting a new cluster it's highly recommended to use the 2.0 alpha.
 
 Clusterio is a clustered Factorio server manager that provides the tooling for implementing cross server interactions in Factorio.
 It was previously best known for implementing cross server transfer and cloud storage of items via teleporter chests.
-But this functionality has been pulled out of Clusterio into its own plugin for Clusterio named [Subspace Storage](https://github.com/clusterio/factorioClusterioMod).
+But this functionality has been pulled out of Clusterio into its own plugin for Clusterio named [Subspace Storage](https://github.com/clusterio/subspace_storage).
 
 By itself Clusterio doesn't change the gameplay in any way, you could even use Clusterio to manage completely vanilla Factorio servers.
 Plugins do the work of modding in the visible changes into the game, see the [Plugins section](#plugins) for ready made plugins you can install into a Clusterio cluster.
@@ -70,7 +70,7 @@ These are the plugins supported and maintained by the Clusterio developers:
 - [Global Chat](/plugins/global_chat/README.md): share the in-game chat between servers.
 - [Research Sync](/plugins/research_sync/README.md): synchronize research progress and technologies unlocked between servers.
 - [Statistics Exporter](/plugins/statistics_exporter/README.md): collect in-game statistics from all the servers and makes it available to the Prometheus endpoint on the master server.
-- [Subspace Storage](https://github.com/clusterio/factorioClusterioMod): Provide shared storage that can transport items between servers via teleport chests.
+- [Subspace Storage](https://github.com/clusterio/subspace_storage): Provide shared storage that can transport items between servers via teleport chests.
 - [Player Auth](/plugins/player_auth/README.md): Provides authentication to the cluster via logging into a Factorio server.
 
 There's also plugins developed and maintained by the community:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,7 +41,7 @@ If you already cloned the main GitHub repository you can change your clone to po
 
 To keep your local repository up to to date with the main repository add the main repository as a remote.
 
-    git remote add upstream https://github.com/clusterio/factorioClusterio
+    git remote add upstream https://github.com/clusterio/clusterio
 
 After this running `git fetch upstream` will get the updated branches from the main repository.
 Do not run `git pull upstream` it will mess thing up!

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -2,4 +2,4 @@
 
 Installer for Clusterio.
 
-See [the Clusterio README.md](https://github.com/clusterio/factorioClusterio#readme) the for installation guide.
+See [the Clusterio README.md](https://github.com/clusterio/clusterio#readme) the for installation guide.

--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -518,10 +518,10 @@ if (module === require.main) {
 			logger.error(err.message);
 		} else {
 			logger.fatal(`
-+--------------------------------------------------------------+
-| Unexpected error occured installing clusterio, please report |
-| it to https://github.com/clusterio/factorioClusterio/issues  |
-+--------------------------------------------------------------+
++------------------------------------------------------------+
+| Unexpected error occured installing clusterio, please      |
+| report it to https://github.com/clusterio/clusterio/issues |
++------------------------------------------------------------+
 ${err.stack}`
 			);
 		}

--- a/packages/ctl/README.md
+++ b/packages/ctl/README.md
@@ -88,4 +88,4 @@ Lists up all configuration entries with their currently configured values.
 
 [Managing a cluster](/docs/managing-a-cluster.md) for the available commands used for managing a cluster.
 
-[The Clusterio repository](https://github.com/clusterio/factorioClusterio) for instructions on how to set up a cluster.
+[The Clusterio repository](https://github.com/clusterio/clusterio) for instructions on how to set up a cluster.

--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -1185,10 +1185,10 @@ I           version of clusterio.  Expect things to break. I
 	startControl().catch(err => {
 		if (!(err instanceof libErrors.StartupError)) {
 			logger.fatal(`
-+----------------------------------------------------------------+
-| Unexpected error occured while starting control, please report |
-| it to https://github.com/clusterio/factorioClusterio/issues    |
-+----------------------------------------------------------------+
++------------------------------------------------------------+
+| Unexpected error occured while starting control, please    |
+| report it to https://github.com/clusterio/clusterio/issues |
++------------------------------------------------------------+
 ${err.stack}`
 			);
 		} else {

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -2,4 +2,4 @@
 
 This package contains functionality shared between master, slave, ctl and/or plugins of Clusterio.
 
-See [the Clusterio repository](https://github.com/clusterio/factorioClusterio) for more information on Clusterio.
+See [the Clusterio repository](https://github.com/clusterio/clusterio) for more information on Clusterio.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,7 +2,7 @@
   "name": "@clusterio/lib",
   "description": "Shared library for Clusterio",
   "version": "2.0.0-alpha.7",
-  "repository": "https://github.com/clusterio/factorioClusterio",
+  "repository": "https://github.com/clusterio/clusterio",
   "license": "MIT",
   "keywords": [
     "factorio"

--- a/packages/master/README.md
+++ b/packages/master/README.md
@@ -111,4 +111,4 @@ Runs the master server.
 
 ## See Also
 
-[The Clusterio repository](https://github.com/clusterio/factorioClusterio) for instructions on how to set up a cluster.
+[The Clusterio repository](https://github.com/clusterio/clusterio) for instructions on how to set up a cluster.

--- a/packages/master/master.js
+++ b/packages/master/master.js
@@ -389,10 +389,10 @@ ${err.original.stack}`
 			);
 		} else {
 			logger.fatal(`
-+---------------------------------------------------------------+
-| Unexpected error occured while starting master, please report |
-| it to https://github.com/clusterio/factorioClusterio/issues   |
-+---------------------------------------------------------------+
++------------------------------------------------------------+
+| Unexpected error occured while starting master, please     |
+| report it to https://github.com/clusterio/clusterio/issues |
++------------------------------------------------------------+
 ${err.stack}`
 			);
 		}

--- a/packages/master/src/WsServer.js
+++ b/packages/master/src/WsServer.js
@@ -148,10 +148,10 @@ class WsServer {
 				message, socket, req
 			).catch(err => {
 				logger.error(`
-+----------------------------------------------------------------+
-| Unexpected error occured in WebSocket handshake, please report |
-| it to https://github.com/clusterio/factorioClusterio/issues    |
-+----------------------------------------------------------------+
++------------------------------------------------------------+
+| Unexpected error occured in WebSocket handshake, please    |
+| report it to https://github.com/clusterio/clusterio/issues |
++------------------------------------------------------------+
 ${err.stack}`
 				);
 				wsRejectedConnectionsCounter.inc();

--- a/packages/slave/README.md
+++ b/packages/slave/README.md
@@ -90,4 +90,4 @@ Runs the slave.
 
 ## See Also
 
-[The Clusterio repository](https://github.com/clusterio/factorioClusterio) for instructions on how to set up a cluster.
+[The Clusterio repository](https://github.com/clusterio/clusterio) for instructions on how to set up a cluster.

--- a/packages/slave/lua/clusterio_lib/info.json
+++ b/packages/slave/lua/clusterio_lib/info.json
@@ -16,7 +16,7 @@
     ],
     "title": "Clusterio Library (Alpha)",
     "author": "Clusterio Team",
-    "homepage": "https://github.com/clusterio/factorioClusterio",
+    "homepage": "https://github.com/clusterio/clusterio",
     "description": "Library for interfacing with Clusterio.  Warning: work in progress alpha.",
     "additional_files": {
         "serialize.lua": ["..", "..", "modules", "clusterio", "serialize.lua"]

--- a/packages/slave/lua/export/info.json
+++ b/packages/slave/lua/export/info.json
@@ -3,6 +3,6 @@
     "version": "0.0.0",
     "title": "Icon exporter",
     "author": "Clusterio Team",
-    "homepage": "https://github.com/clusterio/factorioClusterio",
+    "homepage": "https://github.com/clusterio/clusterio",
     "description": "Exports item prototypes on stdout during the data stage."
 }

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -1620,10 +1620,10 @@ class Slave extends libLink.Link {
 		} catch (err) {
 			setBlocking(true);
 			logger.error(`
-+--------------------------------------------------------------------+
-| Unexpected error occured while shutting down slave, please report  |
-| it to https://github.com/clusterio/factorioClusterio/issues        |
-+--------------------------------------------------------------------+
++------------------------------------------------------------+
+| Unexpected error occured while shutting down slave, please |
+| report it to https://github.com/clusterio/clusterio/issues |
++------------------------------------------------------------+
 ${err.stack}`
 			);
 			// eslint-disable-next-line node/no-process-exit
@@ -1905,10 +1905,10 @@ ${err.original.stack}`
 
 		} else {
 			logger.fatal(`
-+--------------------------------------------------------------+
-| Unexpected error occured while starting slave, please report |
-| it to https://github.com/clusterio/factorioClusterio/issues  |
-+--------------------------------------------------------------+
++------------------------------------------------------------+
+| Unexpected error occured while starting slave, please      |
+| report it to https://github.com/clusterio/clusterio/issues |
++------------------------------------------------------------+
 ${err.stack}`
 			);
 		}

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -3,15 +3,15 @@
   "version": "2.0.0-alpha.7",
   "description": "Clusterio plugin forwarding between Factorio servers",
   "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/factorioClusterio#readme",
+  "homepage": "https://github.com/clusterio/clusterio#readme",
   "license": "MIT",
-  "repository": "clusterio/factorioClusterio",
+  "repository": "clusterio/clusterio",
   "scripts": {
     "build": "webpack-cli --env production",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/clusterio/factorioClusterio/issues"
+    "url": "https://github.com/clusterio/clusterio/issues"
   },
   "engines": {
     "node": ">=12"

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -3,15 +3,15 @@
   "version": "2.0.0-alpha.7",
   "description": "Clusterio plugin authenticating logged in players to the web interface",
   "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/factorioClusterio#readme",
+  "homepage": "https://github.com/clusterio/clusterio#readme",
   "license": "MIT",
-  "repository": "clusterio/factorioClusterio",
+  "repository": "clusterio/clusterio",
   "scripts": {
     "build": "webpack-cli --env production",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/clusterio/factorioClusterio/issues"
+    "url": "https://github.com/clusterio/clusterio/issues"
   },
   "engines": {
     "node": ">=12"

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -3,15 +3,15 @@
   "version": "2.0.0-alpha.7",
   "description": "Clusterio plugin for synchronizing research between Factorio servers",
   "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/factorioClusterio#readme",
+  "homepage": "https://github.com/clusterio/clusterio#readme",
   "license": "MIT",
-  "repository": "clusterio/factorioClusterio",
+  "repository": "clusterio/clusterio",
   "scripts": {
     "build": "webpack-cli --env production",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/clusterio/factorioClusterio/issues"
+    "url": "https://github.com/clusterio/clusterio/issues"
   },
   "engines": {
     "node": ">=12"

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -3,15 +3,15 @@
   "version": "2.0.0-alpha.7",
   "description": "Clusterio plugin for gathering statistics from Factorio servers",
   "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/factorioClusterio#readme",
+  "homepage": "https://github.com/clusterio/clusterio#readme",
   "license": "MIT",
-  "repository": "clusterio/factorioClusterio",
+  "repository": "clusterio/clusterio",
   "scripts": {
     "build": "webpack-cli --env production",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/clusterio/factorioClusterio/issues"
+    "url": "https://github.com/clusterio/clusterio/issues"
   },
   "engines": {
     "node": ">=12"

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -5,13 +5,13 @@
   "author": "Hornwitser <github@hornwitser.no>",
   "homepage": "https://github.com/clusterio/clusterio#readme",
   "license": "MIT",
-  "repository": "clusterio/factorioClusterio",
+  "repository": "clusterio/clusterio",
   "scripts": {
     "build": "webpack-cli --env production",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/clusterio/factorioClusterio/issues"
+    "url": "https://github.com/clusterio/clusterio/issues"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
Having the repositories be named factorioClusterio and factorioClusterioMod is something that's irked me since I started on this project. It's Clusterio, no more no less. The mod was also rebranded to subspace_storage long ago so it's due for a rename too.