### PR TITLE
Decode master secret from base64

### DIFF
--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -236,7 +236,7 @@ class User {
 	 * @returns {string} JWT access token for the user.
 	 */
 	createToken(secret) {
-		return jwt.sign({ aud: "user", user: this.name }, secret);
+		return jwt.sign({ aud: "user", user: this.name }, Buffer.from(secret, "base64"));
 	}
 
 	/**

--- a/packages/master/master.js
+++ b/packages/master/master.js
@@ -138,7 +138,10 @@ async function handleBootstrapCommand(args, masterConfig) {
 
 	} else if (subCommand === "generate-slave-token") {
 		// eslint-disable-next-line no-console
-		console.log(jwt.sign({ aud: "slave", slave: args.id }, masterConfig.get("master.auth_secret")));
+		console.log(jwt.sign(
+			{ aud: "slave", slave: args.id },
+			Buffer.from(masterConfig.get("master.auth_secret"), "base64")
+		));
 
 	} else if (subCommand === "create-ctl-config") {
 		let admin = userManager.users.get(args.name);

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -126,7 +126,10 @@ class ControlConnection extends BaseConnection {
 	}
 
 	generateSlaveToken(slaveId) {
-		return jwt.sign({ aud: "slave", slave: slaveId }, this._master.config.get("master.auth_secret"));
+		return jwt.sign(
+			{ aud: "slave", slave: slaveId },
+			Buffer.from(this._master.config.get("master.auth_secret"), "base64")
+		);
 	}
 
 	async generateSlaveTokenRequestHandler(message) {

--- a/packages/master/src/WsServer.js
+++ b/packages/master/src/WsServer.js
@@ -184,7 +184,7 @@ ${err.stack}`
 			try {
 				let payload = jwt.verify(
 					data.session_token,
-					this.master.config.get("master.auth_secret"),
+					Buffer.from(this.master.config.get("master.auth_secret"), "base64"),
 					{ audience: this.sessionAud }
 				);
 
@@ -216,7 +216,7 @@ ${err.stack}`
 			if (type === "register_slave") {
 				let tokenPayload = jwt.verify(
 					data.token,
-					this.master.config.get("master.auth_secret"),
+					Buffer.from(this.master.config.get("master.auth_secret"), "base64"),
 					{ audience: "slave" }
 				);
 
@@ -227,7 +227,7 @@ ${err.stack}`
 			} else if (type === "register_control") {
 				let tokenPayload = jwt.verify(
 					data.token,
-					this.master.config.get("master.auth_secret"),
+					Buffer.from(this.master.config.get("master.auth_secret"), "base64"),
 					{ audience: "user" }
 				);
 
@@ -251,7 +251,8 @@ ${err.stack}`
 		let sessionId = this.nextSessionId;
 		this.nextSessionId += 1;
 		let sessionToken = jwt.sign(
-			{ aud: this.sessionAud, sid: sessionId }, this.master.config.get("master.auth_secret")
+			{ aud: this.sessionAud, sid: sessionId },
+			Buffer.from(this.master.config.get("master.auth_secret"), "base64"),
 		);
 		let heartbeatInterval = this.master.config.get("master.heartbeat_interval");
 		let connector = new WsServerConnector(socket, sessionId, heartbeatInterval);

--- a/packages/master/src/routes.js
+++ b/packages/master/src/routes.js
@@ -101,7 +101,11 @@ function validateSlaveToken(req, res, next) {
 	}
 
 	try {
-		jwt.verify(token, req.app.locals.master.config.get("master.auth_secret"), { audience: "slave" });
+		jwt.verify(
+			token,
+			Buffer.from(req.app.locals.master.config.get("master.auth_secret"), "base64"),
+			{ audience: "slave" }
+		);
 
 	} catch (err) {
 		res.sendStatus(401);
@@ -121,7 +125,7 @@ function validateUserToken(req, res, next) {
 	try {
 		let tokenPayload = jwt.verify(
 			token,
-			req.app.locals.master.config.get("master.auth_secret"),
+			Buffer.from(req.app.locals.master.config.get("master.auth_secret"), "base64"),
 			{ audience: "user" }
 		);
 		let user = req.app.locals.master.userManager.users.get(tokenPayload.user);

--- a/plugins/player_auth/master.js
+++ b/plugins/player_auth/master.js
@@ -81,7 +81,7 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 		for (let [player, entry] of this.players) {
 			if (entry.playerCode === playerCode && entry.expires > Date.now()) {
 				let verifyCode = await generateCode(this.master.config.get("player_auth.code_length"));
-				let secret = this.master.config.get("master.auth_secret");
+				let secret = Buffer.from(this.master.config.get("master.auth_secret"), "base64");
 				let verifyToken = jwt.sign(
 					{
 						aud: "player_auth.verify_code",
@@ -124,7 +124,7 @@ class MasterPlugin extends libPlugin.BaseMasterPlugin {
 			return;
 		}
 
-		let secret = this.master.config.get("master.auth_secret");
+		let secret = Buffer.from(this.master.config.get("master.auth_secret"), "base64");
 		try {
 			let payload = jwt.verify(verifyToken, secret, { audience: "player_auth.verify_code" });
 			if (payload.verify_code !== verifyCode) {

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -201,7 +201,7 @@ describe("player_auth", function() {
 									player_code: "player",
 									verify_code: "verify",
 									...tokenParams,
-								}, tokenParams.secret || "TestSecretDoNotUse"),
+								}, Buffer.from(tokenParams.secret || "TestSecretDoNotUse", "base64")),
 							},
 							parse: "json",
 						});
@@ -225,7 +225,7 @@ describe("player_auth", function() {
 								aud: "player_auth.verify_code",
 								player_code: "expired",
 								verify_code: "verify",
-							}, "TestSecretDoNotUse"),
+							}, Buffer.from("TestSecretDoNotUse", "base64")),
 						},
 						parse: "json",
 					});
@@ -244,7 +244,7 @@ describe("player_auth", function() {
 								aud: "player_auth.verify_code",
 								player_code: "unverified",
 								verify_code: "verify",
-							}, "TestSecretDoNotUse"),
+							}, Buffer.from("TestSecretDoNotUse", "base64")),
 						},
 						parse: "json",
 					});
@@ -263,7 +263,7 @@ describe("player_auth", function() {
 								aud: "player_auth.verify_code",
 								player_code: "missing",
 								verify_code: "verify",
-							}, "TestSecretDoNotUse"),
+							}, Buffer.from("TestSecretDoNotUse", "base64")),
 						},
 						parse: "json",
 					});
@@ -282,7 +282,7 @@ describe("player_auth", function() {
 								aud: "player_auth.verify_code",
 								player_code: "player",
 								verify_code: "verify",
-							}, "TestSecretDoNotUse"),
+							}, Buffer.from("TestSecretDoNotUse", "base64")),
 						},
 						parse: "json",
 					});

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -98,7 +98,7 @@ let slaveProcess;
 let control;
 
 let url = "https://localhost:4443/";
-let controlToken = jwt.sign({ aud: "user", user: "test" }, "TestSecretDoNotUse");
+let controlToken = jwt.sign({ aud: "user", user: "test" }, Buffer.from("TestSecretDoNotUse", "base64"));
 let instancesDir = path.join("temp", "test", "instances");
 let databaseDir = path.join("temp", "test", "database");
 let pluginListPath = path.join("temp", "test", "plugin-list.json");

--- a/test/integration/link.js
+++ b/test/integration/link.js
@@ -6,7 +6,7 @@ const jwt = require("jsonwebtoken");
 
 const { TestControlConnector, TestControl, get, exec, url } = require("./index");
 
-let token = jwt.sign({ aud: "user", user: "test" }, "TestSecretDoNotUse");
+let token = jwt.sign({ aud: "user", user: "test" }, Buffer.from("TestSecretDoNotUse", "base64"));
 
 describe("Integration of lib/link", function() {
 	let tlsCa;

--- a/test/master/routes.js
+++ b/test/master/routes.js
@@ -97,7 +97,9 @@ describe("master/src/routes", function() {
 				url: `http://localhost:${port}/api/upload-save?instance_id=123&filename=file.zip`, method: "POST",
 				headers: {
 					"Content-Type": "application/zip",
-					"X-Access-Token": jwt.sign({ aud: "user", user: "invalid" }, "TestSecretDoNotUse"),
+					"X-Access-Token": jwt.sign(
+						{ aud: "user", user: "invalid" }, Buffer.from("TestSecretDoNotUse", "base64")
+					),
 				},
 				data: "totally a zip file",
 			});
@@ -107,7 +109,9 @@ describe("master/src/routes", function() {
 				url: `http://localhost:${port}/api/upload-save?instance_id=123&filename=file.zip`, method: "POST",
 				headers: {
 					"Content-Type": "application/zip",
-					"X-Access-Token": jwt.sign({ aud: "user", user: "test" }, "TestSecretDoNotUse"),
+					"X-Access-Token": jwt.sign(
+						{ aud: "user", user: "test" }, Buffer.from("TestSecretDoNotUse", "base64")
+					),
 				},
 				data: "totally a zip file",
 			});
@@ -119,14 +123,16 @@ describe("master/src/routes", function() {
 				url: `http://localhost:${port}/api/upload-save?instance_id=123&filename=file.zip`, method: "POST",
 				headers: {
 					"Content-Type": "application/zip",
-					"X-Access-Token": jwt.sign({ aud: "user", user: "player" }, "TestSecretDoNotUse"),
+					"X-Access-Token": jwt.sign(
+						{ aud: "user", user: "player" }, Buffer.from("TestSecretDoNotUse", "base64")
+					),
 				},
 				data: "totally a zip file",
 			});
 			assert.equal(response.statusCode, 403);
 		});
 
-		let testToken = jwt.sign({ aud: "user", user: "test" }, "TestSecretDoNotUse");
+		let testToken = jwt.sign({ aud: "user", user: "test" }, Buffer.from("TestSecretDoNotUse", "base64"));
 		it("should respond with 415 if content type is missing or invalid", async function() {
 			let response;
 			response = await phin({


### PR DESCRIPTION
The jsonwebtoken accept strings as input for secrets which is
nonsensical from a cryptographic standpoint as the algorithms all
operate on byte sequences.  Worse still, strings are encoded into bytes
using UTF-8, which disallows certain sequences of bytes from appearing
and potentially weakening the cryptography.

For legacy reasons the master secret was encoded into base64 _and passed
as a string to jsonwebtoken_.  This further weakened the crypto as the
bytes that can appear in base 64 is only 1/4 of the 256 possible values
for bytes.  This could significantly weaken the cryptographic strength
of the tokens.

I have known of this issue for quite some time but has put off actually
fixing it for too long now.  Since the master secret is already
documented as being in base 64, decode it as base 64 and pass it as a
byte Buffer to jsonwebtoken.  This will ensure every byte value is
possible in the byte sequence passed to the jsonwebtoken crypto.

The impact of this change is unfortunately that all tokens will become
invalid and will have to be reissued.