### PR TITLE
Fix unable to clear number fields in web UI

### DIFF
--- a/packages/web_ui/src/components/BaseConfigTree.jsx
+++ b/packages/web_ui/src/components/BaseConfigTree.jsx
@@ -190,7 +190,7 @@ export default function BaseConfigTree(props) {
 								request = props.setProp(fieldName, prop, value);
 
 							} else {
-								request = props.setField(field, value);
+								request = props.setField(field, value === null ? "" : String(value));
 							}
 
 							try {

--- a/packages/web_ui/src/components/InstanceConfigTree.jsx
+++ b/packages/web_ui/src/components/InstanceConfigTree.jsx
@@ -22,7 +22,7 @@ export default function InstanceConfigTree(props) {
 		await libLink.messages.setInstanceConfigField.send(control, {
 			instance_id: props.id,
 			field,
-			value: String(value),
+			value,
 		});
 	}
 


### PR DESCRIPTION
Fix setting a nullable numeric field to blank in the web UI return error that the value cannot be a string due to the field returning null and this being converted to the string "null".