### PR TITLE
Single web lib entrypoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
 			},
 		},
 		{
-			"files": ["packages/web_ui/src/**/*.jsx", "plugins/*/web/**/*.jsx"],
+			"files": ["packages/web_ui/src/**/*.jsx", "packages/lib/browser.js", "plugins/*/web/**/*.jsx"],
 			"env": {
 				"browser": true,
 			},

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -49,7 +49,7 @@ Without it the plugin will not recognized by Clusterio.
 Here's an example of it:
 
 ```js
-const libLink = require("@clusterio/lib/link"); // For messages
+const { libLink } = require("@clusterio/lib"); // For messages
 
 module.exports = {
     name: "foo_frobber",

--- a/packages/lib/browser.js
+++ b/packages/lib/browser.js
@@ -1,0 +1,11 @@
+export { default as libConfig } from "./config";
+export { default as libErrors } from "./errors";
+export { default as libFactorio } from "./factorio/exchange_string";
+export { default as libHelpers } from "./helpers";
+export { default as libLink } from "./link";
+export { default as libLogging } from "./logging";
+export { default as libPlugin } from "./plugin";
+export { default as libSchema } from "./schema";
+export { default as libUsers } from "./users";
+
+export { default as RateLimiter } from "./RateLimiter";

--- a/packages/lib/index.js
+++ b/packages/lib/index.js
@@ -1,0 +1,47 @@
+"use strict";
+const libBuildMod = require("./build_mod");
+const libCommand = require("./command");
+const libConfig = require("./config");
+const libDatabase = require("./database");
+const libErrors = require("./errors");
+const libFactorio = require("./factorio");
+const libFileOps = require("./file_ops");
+const libHash = require("./hash");
+const libHelpers = require("./helpers");
+const libLink = require("./link");
+const libLogging = require("./logging");
+const libLoggingUtils = require("./logging_utils");
+const libLuaTools = require("./lua_tools");
+const libPlugin = require("./plugin");
+const libPluginLoader = require("./plugin_loader");
+const libPrometheus = require("./prometheus");
+const libSchema = require("./schema");
+const libSharedCommands = require("./shared_commands");
+const libUsers = require("./users");
+
+const RateLimiter = require("./RateLimiter");
+
+
+module.exports = {
+	libBuildMod,
+	libCommand,
+	libConfig,
+	libDatabase,
+	libErrors,
+	libFactorio,
+	libFileOps,
+	libHash,
+	libHelpers,
+	libLink,
+	libLogging,
+	libLoggingUtils,
+	libLuaTools,
+	libPlugin,
+	libPluginLoader,
+	libPrometheus,
+	libSchema,
+	libSharedCommands,
+	libUsers,
+
+	RateLimiter,
+};

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -4,6 +4,7 @@
   "version": "2.0.0-alpha.8",
   "repository": "https://github.com/clusterio/clusterio",
   "license": "MIT",
+  "browser": "browser.js",
   "keywords": [
     "factorio"
   ],

--- a/packages/master/webpack.config.js
+++ b/packages/master/webpack.config.js
@@ -20,14 +20,7 @@ module.exports = (env = {}) => merge(common(env), {
 		new webpack.container.ModuleFederationPlugin({
 			name: "master",
 			shared: {
-				"@clusterio/lib/config": { singleton: true },
-				"@clusterio/lib/errors": { singleton: true },
-				"@clusterio/lib/helpers": { singleton: true },
-				"@clusterio/lib/link": { singleton: true },
-				"@clusterio/lib/logging": { singleton: true },
-				"@clusterio/lib/plugin": { singleton: true },
-				"@clusterio/lib/schema": { singleton: true },
-				"@clusterio/lib/users": { singleton: true },
+				"@clusterio/lib": { singleton: true },
 				"@clusterio/web_ui": { singleton: true },
 				"antd": { singleton: true },
 				"react": { singleton: true },

--- a/packages/web_ui/src/bootstrap.jsx
+++ b/packages/web_ui/src/bootstrap.jsx
@@ -3,9 +3,8 @@ import "./index.css";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import libConfig from "@clusterio/lib/config";
-import libPlugin from "@clusterio/lib/plugin";
-import { ConsoleTransport, WebConsoleFormat, logger } from "@clusterio/lib/logging";
+import { libConfig, libLogging, libPlugin } from "@clusterio/lib";
+const { ConsoleTransport, WebConsoleFormat, logger } = libLogging;
 
 import App from "./components/App";
 import { Control, ControlConnector } from "./util/websocket";

--- a/packages/web_ui/src/components/App.jsx
+++ b/packages/web_ui/src/components/App.jsx
@@ -2,7 +2,7 @@ import events from "events";
 import React, { useEffect, useState } from "react";
 import { BrowserRouter } from "react-router-dom";
 
-import { logger } from "@clusterio/lib/logging";
+import { libLogging } from "@clusterio/lib";
 
 import ErrorBoundary from "./ErrorBoundary";
 import SiteLayout from "./SiteLayout";
@@ -12,6 +12,7 @@ import LoginForm from "./LoginForm";
 import { Card, Spin, Typography } from "antd";
 
 const { Paragraph } = Typography;
+const { logger } = libLogging;
 
 
 function ErrorCard(props) {

--- a/packages/web_ui/src/components/AssignInstanceModal.jsx
+++ b/packages/web_ui/src/components/AssignInstanceModal.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Button, Form, Modal, Select, Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";

--- a/packages/web_ui/src/components/CreateSaveModal.jsx
+++ b/packages/web_ui/src/components/CreateSaveModal.jsx
@@ -1,8 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Button, Col, Form, Input, Modal, Row, Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
-import { readMapExchangeString } from "@clusterio/lib/factorio/exchange_string";
+import { libFactorio, libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";
@@ -23,7 +22,7 @@ export default function CreateSaveModal(props) {
 		if (values.exchangeString && values.exchangeString.trim()) {
 			let result;
 			try {
-				result = readMapExchangeString(values.exchangeString);
+				result = libFactorio.readMapExchangeString(values.exchangeString);
 			} catch (err) {
 				form.setFields([{ name: "exchangeString", errors: [err.message] }]);
 				return;
@@ -72,7 +71,7 @@ export default function CreateSaveModal(props) {
 		let exchangeString = form.getFieldValue("exchangeString");
 		let result;
 		try {
-			result = readMapExchangeString(exchangeString);
+			result = libFactorio.readMapExchangeString(exchangeString);
 		} catch (err) {
 			form.setFields([{ name: "exchangeString", errors: [err.message] }]);
 			return;

--- a/packages/web_ui/src/components/ErrorPage.jsx
+++ b/packages/web_ui/src/components/ErrorPage.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import PageLayout from "./PageLayout";
 

--- a/packages/web_ui/src/components/InstanceConfigTree.jsx
+++ b/packages/web_ui/src/components/InstanceConfigTree.jsx
@@ -1,8 +1,7 @@
 import React, { useContext } from "react";
 import { Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
-import libConfig from "@clusterio/lib/config";
+import { libConfig, libLink } from "@clusterio/lib";
 
 import BaseConfigTree from "./BaseConfigTree";
 import ControlContext from "./ControlContext";

--- a/packages/web_ui/src/components/InstanceConsole.jsx
+++ b/packages/web_ui/src/components/InstanceConsole.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext, useRef, useState } from "react";
 import { Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 

--- a/packages/web_ui/src/components/InstanceRcon.jsx
+++ b/packages/web_ui/src/components/InstanceRcon.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Input, Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";

--- a/packages/web_ui/src/components/InstanceViewPage.jsx
+++ b/packages/web_ui/src/components/InstanceViewPage.jsx
@@ -3,7 +3,7 @@ import { useHistory, useParams } from "react-router-dom";
 import { Button, Descriptions, Popconfirm, Space, Spin, Typography } from "antd";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";

--- a/packages/web_ui/src/components/InstancesPage.jsx
+++ b/packages/web_ui/src/components/InstancesPage.jsx
@@ -2,8 +2,7 @@ import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Button, Form, Input, Modal, PageHeader, Table } from "antd";
 
-import libLink from "@clusterio/lib/link";
-import libConfig from "@clusterio/lib/config";
+import { libConfig, libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";

--- a/packages/web_ui/src/components/LoadScenarioModal.jsx
+++ b/packages/web_ui/src/components/LoadScenarioModal.jsx
@@ -1,8 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Button, Col, Form, Input, Modal, Row, Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
-import { readMapExchangeString } from "@clusterio/lib/factorio/exchange_string";
+import { libFactorio, libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";
@@ -23,7 +22,7 @@ export default function LoadScenarioModal(props) {
 		if (values.exchangeString && values.exchangeString.trim()) {
 			let result;
 			try {
-				result = readMapExchangeString(values.exchangeString);
+				result = libFactorio.readMapExchangeString(values.exchangeString);
 			} catch (err) {
 				form.setFields([{ name: "exchangeString", errors: [err.message] }]);
 				return;
@@ -71,7 +70,7 @@ export default function LoadScenarioModal(props) {
 		let exchangeString = form.getFieldValue("exchangeString");
 		let result;
 		try {
-			result = readMapExchangeString(exchangeString);
+			result = libFactorio.readMapExchangeString(exchangeString);
 		} catch (err) {
 			form.setFields([{ name: "exchangeString", errors: [err.message] }]);
 			return;

--- a/packages/web_ui/src/components/MasterConfigTree.jsx
+++ b/packages/web_ui/src/components/MasterConfigTree.jsx
@@ -1,8 +1,7 @@
 import React, { useContext } from "react";
 import { Typography } from "antd";
 
-import libLink from "@clusterio/lib/link";
-import libConfig from "@clusterio/lib/config";
+import { libConfig, libLink } from "@clusterio/lib";
 
 import BaseConfigTree from "./BaseConfigTree";
 import ControlContext from "./ControlContext";

--- a/packages/web_ui/src/components/RoleViewPage.jsx
+++ b/packages/web_ui/src/components/RoleViewPage.jsx
@@ -3,8 +3,7 @@ import { useHistory, useParams } from "react-router-dom";
 import { Button, Checkbox, Col, Form, Input, Popconfirm, Row, Space, Spin } from "antd";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 
-import libLink from "@clusterio/lib/link";
-import libUsers from "@clusterio/lib/users";
+import { libLink, libUsers } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";

--- a/packages/web_ui/src/components/RolesPage.jsx
+++ b/packages/web_ui/src/components/RolesPage.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import DataTable from "./data-table";
 import ControlContext from "./ControlContext";

--- a/packages/web_ui/src/components/SavesList.jsx
+++ b/packages/web_ui/src/components/SavesList.jsx
@@ -3,7 +3,7 @@ import { Button, List, Popconfirm, Progress, Space, Table, Tooltip, Upload } fro
 import CaretLeftOutlined from "@ant-design/icons/CaretLeftOutlined";
 import LeftOutlined from "@ant-design/icons/LeftOutlined";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import CreateSaveModal from "./CreateSaveModal";

--- a/packages/web_ui/src/components/SlavesPage.jsx
+++ b/packages/web_ui/src/components/SlavesPage.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useRef, useState } from "react";
 import { Button, Form, Input, Modal, PageHeader, Table } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";

--- a/packages/web_ui/src/components/StartStopInstanceButton.jsx
+++ b/packages/web_ui/src/components/StartStopInstanceButton.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { Button } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";

--- a/packages/web_ui/src/components/UserViewPage.jsx
+++ b/packages/web_ui/src/components/UserViewPage.jsx
@@ -3,7 +3,7 @@ import { useHistory, useParams } from "react-router-dom";
 import { Button, Checkbox, Col, Form, Input, Popconfirm, Popover, Row, Select, Space, Spin, Switch } from "antd";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";

--- a/packages/web_ui/src/components/UsersPage.jsx
+++ b/packages/web_ui/src/components/UsersPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { Spin, Tag } from "antd";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 import DataTable from "./data-table";
 import ControlContext from "./ControlContext";

--- a/packages/web_ui/src/model/instance.jsx
+++ b/packages/web_ui/src/model/instance.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useContext, useState } from "react";
 import ControlContext from "../components/ControlContext";
 
-import libLink from "@clusterio/lib/link";
-import { logger } from "@clusterio/lib/logging";
+import { libLink, libLogging } from "@clusterio/lib";
+const { logger } = libLogging;
 
 
 export function useInstance(id) {

--- a/packages/web_ui/src/model/saves.jsx
+++ b/packages/web_ui/src/model/saves.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useContext, useState } from "react";
 import ControlContext from "../components/ControlContext";
 
-import libLink from "@clusterio/lib/link";
-import { logger } from "@clusterio/lib/logging";
+import { libLink, libLogging } from "@clusterio/lib";
+const { logger } = libLogging;
 
 
 export function useSaves(instanceId) {

--- a/packages/web_ui/src/model/slave.jsx
+++ b/packages/web_ui/src/model/slave.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext, useState } from "react";
 import ControlContext from "../components/ControlContext";
 
-import libLink from "@clusterio/lib/link";
+import { libLink } from "@clusterio/lib";
 
 
 export function useSlave(id) {

--- a/packages/web_ui/src/util/notify.jsx
+++ b/packages/web_ui/src/util/notify.jsx
@@ -1,5 +1,6 @@
 import { notification } from "antd";
-import { logger } from "@clusterio/lib/logging";
+import { libLogging } from "@clusterio/lib";
+const { logger } = libLogging;
 
 
 export default function notify(message, type = "info", description = undefined) {

--- a/packages/web_ui/src/util/websocket.jsx
+++ b/packages/web_ui/src/util/websocket.jsx
@@ -1,7 +1,5 @@
-import libLink from "@clusterio/lib/link";
-import libPlugin from "@clusterio/lib/plugin";
-import libErrors from "@clusterio/lib/errors";
-import { logger } from "@clusterio/lib/logging";
+import { libErrors, libLink, libLogging, libPlugin } from "@clusterio/lib";
+const { logger } = libLogging;
 import packageJson from "../../package.json";
 
 

--- a/plugins/global_chat/info.js
+++ b/plugins/global_chat/info.js
@@ -1,5 +1,5 @@
 "use strict";
-let libLink = require("@clusterio/lib/link");
+let { libLink } = require("@clusterio/lib");
 
 module.exports = {
 	name: "global_chat",

--- a/plugins/global_chat/webpack.config.js
+++ b/plugins/global_chat/webpack.config.js
@@ -25,7 +25,6 @@ module.exports = (env = {}) => merge(common(env), {
 			shared: {
 				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
-				"ajv": { import: false },
 			},
 		}),
 	],

--- a/plugins/global_chat/webpack.config.js
+++ b/plugins/global_chat/webpack.config.js
@@ -23,8 +23,7 @@ module.exports = (env = {}) => merge(common(env), {
 				"./package.json": "./package.json",
 			},
 			shared: {
-				"@clusterio/lib/config": { import: false },
-				"@clusterio/lib/link": { import: false },
+				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
 				"ajv": { import: false },
 			},

--- a/plugins/inventory_sync/info.js
+++ b/plugins/inventory_sync/info.js
@@ -1,7 +1,5 @@
 "use strict";
-const libLink = require("@clusterio/lib/link");
-const libConfig = require("@clusterio/lib/config");
-const libUsers = require("@clusterio/lib/users");
+const { libConfig, libLink, libUsers } = require("@clusterio/lib");
 
 class MasterConfigGroup extends libConfig.PluginConfigGroup { }
 MasterConfigGroup.defaultAccess = ["master", "slave", "control"];

--- a/plugins/inventory_sync/web/index.jsx
+++ b/plugins/inventory_sync/web/index.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 
-import libPlugin from "@clusterio/lib/plugin";
+import { libPlugin } from "@clusterio/lib";
 import { PageLayout, ControlContext } from "@clusterio/web_ui";
 import info from "../info";
 

--- a/plugins/inventory_sync/webpack.config.js
+++ b/plugins/inventory_sync/webpack.config.js
@@ -26,7 +26,6 @@ module.exports = (env = {}) => merge(common(env), {
 			shared: {
 				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
-				"ajv": { import: false },
 				"antd": { import: false },
 				"react": { import: false },
 				"react-dom": { import: false },

--- a/plugins/inventory_sync/webpack.config.js
+++ b/plugins/inventory_sync/webpack.config.js
@@ -24,8 +24,7 @@ module.exports = (env = {}) => merge(common(env), {
 				"./web": "./web/index.jsx",
 			},
 			shared: {
-				"@clusterio/lib/config": { import: false },
-				"@clusterio/lib/link": { import: false },
+				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
 				"ajv": { import: false },
 				"antd": { import: false },

--- a/plugins/player_auth/info.js
+++ b/plugins/player_auth/info.js
@@ -1,6 +1,5 @@
 "use strict";
-let libLink = require("@clusterio/lib/link");
-let libConfig = require("@clusterio/lib/config");
+let { libConfig, libLink } = require("@clusterio/lib");
 
 
 class MasterConfigGroup extends libConfig.PluginConfigGroup {}

--- a/plugins/player_auth/web/index.jsx
+++ b/plugins/player_auth/web/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import libPlugin from "@clusterio/lib/plugin";
+import { libPlugin } from "@clusterio/lib";
 import { notify, notifyErrorHandler } from "@clusterio/web_ui";
 import { Button, Form, Input, Spin, Typography } from "antd";
 

--- a/plugins/player_auth/webpack.config.js
+++ b/plugins/player_auth/webpack.config.js
@@ -24,9 +24,7 @@ module.exports = (env = {}) => merge(common(env), {
 				"./web": "./web/index.jsx",
 			},
 			shared: {
-				"@clusterio/lib/config": { import: false },
-				"@clusterio/lib/link": { import: false },
-				"@clusterio/lib/plugin": { import: false },
+				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
 				"antd": { import: false },
 				"react": { import: false },

--- a/plugins/research_sync/info.js
+++ b/plugins/research_sync/info.js
@@ -1,5 +1,5 @@
 "use strict";
-const libLink = require("@clusterio/lib/link");
+const { libLink } = require("@clusterio/lib");
 
 
 // schema used for syncing technologies to and from the master

--- a/plugins/research_sync/webpack.config.js
+++ b/plugins/research_sync/webpack.config.js
@@ -25,7 +25,6 @@ module.exports = (env = {}) => merge(common(env), {
 			shared: {
 				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
-				"ajv": { import: false },
 			},
 		}),
 	],

--- a/plugins/research_sync/webpack.config.js
+++ b/plugins/research_sync/webpack.config.js
@@ -23,8 +23,7 @@ module.exports = (env = {}) => merge(common(env), {
 				"./package.json": "./package.json",
 			},
 			shared: {
-				"@clusterio/lib/config": { import: false },
-				"@clusterio/lib/link": { import: false },
+				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
 				"ajv": { import: false },
 			},

--- a/plugins/statistics_exporter/info.js
+++ b/plugins/statistics_exporter/info.js
@@ -1,5 +1,5 @@
 "use strict";
-const libConfig = require("@clusterio/lib/config");
+const { libConfig } = require("@clusterio/lib");
 
 class InstanceConfigGroup extends libConfig.PluginConfigGroup {}
 InstanceConfigGroup.defaultAccess = ["master", "slave", "control"];

--- a/plugins/statistics_exporter/webpack.config.js
+++ b/plugins/statistics_exporter/webpack.config.js
@@ -25,7 +25,6 @@ module.exports = (env = {}) => merge(common(env), {
 			shared: {
 				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
-				"ajv": { import: false },
 			},
 		}),
 	],

--- a/plugins/statistics_exporter/webpack.config.js
+++ b/plugins/statistics_exporter/webpack.config.js
@@ -23,8 +23,7 @@ module.exports = (env = {}) => merge(common(env), {
 				"./package.json": "./package.json",
 			},
 			shared: {
-				"@clusterio/lib/config": { import: false },
-				"@clusterio/lib/link": { import: false },
+				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
 				"ajv": { import: false },
 			},

--- a/plugins/subspace_storage/info.js
+++ b/plugins/subspace_storage/info.js
@@ -1,7 +1,5 @@
 "use strict";
-const libLink = require("@clusterio/lib/link");
-const libConfig = require("@clusterio/lib/config");
-const libUsers = require("@clusterio/lib/users");
+const { libConfig, libLink, libUsers } = require("@clusterio/lib");
 
 class MasterConfigGroup extends libConfig.PluginConfigGroup {}
 MasterConfigGroup.defaultAccess = ["master", "slave", "control"];

--- a/plugins/subspace_storage/web/index.jsx
+++ b/plugins/subspace_storage/web/index.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Input, Table, Typography } from "antd";
 
-import libPlugin from "@clusterio/lib/plugin";
+import { libPlugin } from "@clusterio/lib";
 import { notifyErrorHandler, useItemMetadata, useLocale, PageLayout, ControlContext } from "@clusterio/web_ui";
 import info from "../info";
 

--- a/plugins/subspace_storage/webpack.config.js
+++ b/plugins/subspace_storage/webpack.config.js
@@ -24,10 +24,7 @@ module.exports = (env = {}) => merge(common(env), {
 				"./web": "./web/index.jsx",
 			},
 			shared: {
-				"@clusterio/lib/config": { import: false },
-				"@clusterio/lib/link": { import: false },
-				"@clusterio/lib/plugin": { import: false },
-				"@clusterio/lib/users": { import: false },
+				"@clusterio/lib": { import: false },
 				"@clusterio/web_ui": { import: false },
 				"antd": { import: false },
 				"react": { import: false },


### PR DESCRIPTION
In order to import a path inside packages/lib/ in the webpack shared module environment it has to be declared as shared in both the web_ui webpack config and the plugin's webpack config.  This is rather error prone and easy to miss.  Move the burden of specifying which entrypoints are valid in lib to lib itself by changing all imports in the web interface code to import from `@clusterio/lib` instead sub paths.

For web code this means imports is done like this from now on:
```js
import { libConfig, libLink } from "@clusterio/lib";
```
For info.js which has to be loadable by both Node.js and web code the
imports are done as follows:
```js
const { libConfig, libLink } = require("@clusterio/lib");
```
While the Node.js only code can either continue to import sub paths
directly or use the info.js style.