### PR TITLE
Ignore SessionLost from updateInstances

### DIFF
--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -1097,6 +1097,10 @@ class Slave extends libLink.Link {
 			}
 
 			this.updateInstances().catch((err) => {
+				if (err instanceof libErrors.SessionLost) {
+					return undefined;
+				}
+
 				logger.fatal(`Unexpected error updating instances:\n${err.stack}`);
 				return this.shutdown();
 			});


### PR DESCRIPTION
Don't shutdown the slave if the connection session is lost during
updateInstances.  Resolves #418.