### PR TITLE
Slave instance UI updates

### DIFF
--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -1152,6 +1152,7 @@ messages.instanceStatusChanged = new Event({
 		"status": { enum: [
 			"stopped", "starting", "running", "stopping", "creating_save", "exporting_data",
 		]},
+		"game_port": { type: ["null", "integer"] },
 	},
 });
 

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -337,6 +337,7 @@ let slaveProperties = {
 	"name": { type: "string" },
 	"id": { type: "integer" },
 	"connected": { type: "boolean" },
+	"public_address": { type: ["null", "string"] },
 };
 
 messages.listSlaves = new Request({
@@ -372,6 +373,7 @@ let instanceProperties = {
 	"name": { type: "string" },
 	"id": { type: "integer" },
 	"assigned_slave": { type: ["null", "integer"] },
+	"game_port": { type: ["null", "integer"] },
 	"status": { enum: [
 		"unknown", "unassigned", "stopped", "starting", "running", "stopping",
 		"creating_save", "exporting_data", "deleted",

--- a/packages/lib/schema.js
+++ b/packages/lib/schema.js
@@ -178,6 +178,7 @@ const clientHandshake = ajv.compile({
 						"version": { type: "string" },
 						"name": { type: "string" },
 						"id": { type: "integer" },
+						"public_address": { type: "string" },
 						"plugins": {
 							type: "object",
 							additionalProperties: { type: "string" },

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -170,7 +170,7 @@ class ControlConnection extends BaseConnection {
 			id,
 			name: instance.config.get("instance.name"),
 			assigned_slave: instance.config.get("instance.assigned_slave"),
-			game_port: instance.game_port,
+			game_port: instance.game_port || null,
 			status: instance.status,
 		};
 	}
@@ -182,7 +182,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
-				game_port: instance.game_port,
+				game_port: instance.game_port || null,
 				status: instance.status,
 			});
 		}
@@ -202,7 +202,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
-				game_port: instance.game_port,
+				game_port: instance.game_port || null,
 				status: instance.status,
 			});
 		}

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -106,6 +106,7 @@ class ControlConnection extends BaseConnection {
 				version: slave.version,
 				id: slave.id,
 				name: slave.name,
+				public_address: slave.public_address,
 				connected: this._master.wsServer.slaveConnections.has(slave.id),
 			});
 		}
@@ -169,6 +170,7 @@ class ControlConnection extends BaseConnection {
 			id,
 			name: instance.config.get("instance.name"),
 			assigned_slave: instance.config.get("instance.assigned_slave"),
+			game_port: instance.config.get("factorio.game_port"),
 			status: instance.status,
 		};
 	}
@@ -180,6 +182,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
+				game_port: instance.config.get("factorio.game_port"),
 				status: instance.status,
 			});
 		}
@@ -199,6 +202,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
+				game_port: instance.config.get("factorio.game_port"),
 				status: instance.status,
 			});
 		}

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -170,7 +170,7 @@ class ControlConnection extends BaseConnection {
 			id,
 			name: instance.config.get("instance.name"),
 			assigned_slave: instance.config.get("instance.assigned_slave"),
-			game_port: instance.config.get("factorio.game_port"),
+			game_port: instance.game_port,
 			status: instance.status,
 		};
 	}
@@ -182,7 +182,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
-				game_port: instance.config.get("factorio.game_port"),
+				game_port: instance.game_port,
 				status: instance.status,
 			});
 		}
@@ -202,7 +202,7 @@ class ControlConnection extends BaseConnection {
 				id: instance.config.get("instance.id"),
 				name: instance.config.get("instance.name"),
 				assigned_slave: instance.config.get("instance.assigned_slave"),
-				game_port: instance.config.get("factorio.game_port"),
+				game_port: instance.game_port,
 				status: instance.status,
 			});
 		}

--- a/packages/master/src/Master.js
+++ b/packages/master/src/Master.js
@@ -368,6 +368,7 @@ class Master {
 			version: slave.version,
 			id: slave.id,
 			name: slave.name,
+			public_address: slave.public_address,
 			connected: this.wsServer.slaveConnections.has(slave.id),
 		};
 

--- a/packages/master/src/SlaveConnection.js
+++ b/packages/master/src/SlaveConnection.js
@@ -88,6 +88,7 @@ class SlaveConnection extends BaseConnection {
 
 		let prev = instance.status;
 		instance.status = message.data.status;
+		instance.game_port = message.data.game_port;
 		logger.verbose(`Instance ${instance.config.get("instance.name")} State: ${instance.status}`);
 		this._master.instanceUpdated(instance);
 		await libPlugin.invokeHook(this._master.plugins, "onInstanceStatusChanged", instance, prev);

--- a/packages/master/src/SlaveConnection.js
+++ b/packages/master/src/SlaveConnection.js
@@ -28,6 +28,7 @@ class SlaveConnection extends BaseConnection {
 			id: this._id,
 			name: this._name,
 			version: this._version,
+			public_address: registerData.public_address,
 			plugins: registerData.plugins,
 		});
 

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -1004,6 +1004,7 @@ class SlaveConnector extends libLink.WebSocketClientConnector {
 			version,
 			id: this.slaveConfig.get("slave.id"),
 			name: this.slaveConfig.get("slave.name"),
+			public_address: this.slaveConfig.get("slave.public_address"),
 			plugins,
 		});
 	}

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -260,7 +260,9 @@ class Instance extends libLink.Link {
 	notifyStatus(status) {
 		this._status = status;
 		libLink.messages.instanceStatusChanged.send(this, {
-			instance_id: this.id, status,
+			instance_id: this.id,
+			status,
+			game_port: this.server ? this.server.gamePort : this.config.get("factorio.game_port") || null,
 		});
 	}
 
@@ -1297,6 +1299,7 @@ class Slave extends libLink.Link {
 		libLink.messages.instanceStatusChanged.send(this, {
 			instance_id,
 			status: instanceConnection ? instanceConnection.status : "stopped",
+			game_port: null,
 		});
 
 		// save a copy of the instance config

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -694,6 +694,8 @@ class Instance extends libLink.Link {
 	}
 
 	async masterConnectionEventEventHandler(message) {
+		this.notifyStatus(this._status);
+
 		await libPlugin.invokeHook(this.plugins, "onMasterConnectionEvent", message.data.event);
 	}
 

--- a/packages/web_ui/src/components/InstanceList.jsx
+++ b/packages/web_ui/src/components/InstanceList.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
-import { Table } from "antd";
+import { notification, Button, Table } from "antd";
+import { CopyOutlined } from "@ant-design/icons";
 
 import { useSlaveList } from "../model/slave";
 import InstanceStatusTag from "./InstanceStatusTag";
 
 const strcmp = new Intl.Collator(undefined, { numerice: "true", sensitivity: "base" }).compare;
-
 
 export default function InstanceList(props) {
 	let history = useHistory();
@@ -44,7 +44,22 @@ export default function InstanceList(props) {
 			key: "public_address",
 			render: instance => {
 				let address = slavePublicAddress(instance["assigned_slave"]);
-				return address ? `${address}:${instance["game_port"] || "unknown"}` : "";
+				let full_address = address + (instance["game_port"] !== null ? `:${instance["game_port"]}` : "");
+				return <>
+					{full_address}
+					<Button
+						type="text"
+						icon={<CopyOutlined/>}
+						onClick={(e) => {
+							e.stopPropagation();
+							navigator.clipboard.writeText(full_address);
+							notification.success({
+								message: "Copied public address!",
+								duration: 1.5,
+							});
+						}}
+					/>
+				</>;
 			},
 			sorter: (a, b) => strcmp(slavePublicAddress(a["assigned_slave"]), slavePublicAddress(b["assigned_slave"])),
 		},

--- a/packages/web_ui/src/components/InstanceList.jsx
+++ b/packages/web_ui/src/components/InstanceList.jsx
@@ -3,6 +3,7 @@ import { useHistory } from "react-router-dom";
 import { Table } from "antd";
 
 import { useSlaveList } from "../model/slave";
+import InstanceStatusTag from "./InstanceStatusTag";
 
 const strcmp = new Intl.Collator(undefined, { numerice: "true", sensitivity: "base" }).compare;
 
@@ -35,6 +36,7 @@ export default function InstanceList(props) {
 		{
 			title: "Status",
 			dataIndex: "status",
+			render: status => <InstanceStatusTag status={status} />,
 			sorter: (a, b) => strcmp(a["status"], b["status"]),
 		},
 	];

--- a/packages/web_ui/src/components/InstanceList.jsx
+++ b/packages/web_ui/src/components/InstanceList.jsx
@@ -19,7 +19,13 @@ export default function InstanceList(props) {
 		}
 		return String(slaveId);
 	}
-
+	function slavePublicAddress(slaveId) {
+		let slave = slaveList.find(s => s.id === slaveId);
+		if (slave) {
+			return slave.public_address;
+		}
+		return null;
+	}
 	let columns = [
 		{
 			title: "Name",
@@ -32,6 +38,15 @@ export default function InstanceList(props) {
 			key: "assigned_slave",
 			render: instance => slaveName(instance["assigned_slave"]),
 			sorter: (a, b) => strcmp(slaveName(a["assigned_slave"]), slaveName(b["assigned_slave"])),
+		},
+		{
+			title: "Public address",
+			key: "public_address",
+			render: instance => {
+				let address = slavePublicAddress(instance["assigned_slave"]);
+				return address ? `${address}:${instance["game_port"] || "unknown"}` : "";
+			},
+			sorter: (a, b) => strcmp(slavePublicAddress(a["assigned_slave"]), slavePublicAddress(b["assigned_slave"])),
 		},
 		{
 			title: "Status",

--- a/packages/web_ui/src/components/InstanceStatusTag.jsx
+++ b/packages/web_ui/src/components/InstanceStatusTag.jsx
@@ -1,0 +1,21 @@
+import { Tag } from "antd";
+import React from "react";
+
+const statusColors = {
+	unknown: "#d46b08",
+	unassigned: "#d4380d",
+	stopped: "#cf1322",
+	starting: "#7cb305",
+	running: "#389e0d",
+	stopping: "#d48806",
+	creating_save: "#096dd9",
+	exporting_data: "#08979c",
+	deleted: "#cf1322",
+};
+
+
+export default function InstanceStatusTag(props) {
+	return <Tag color={statusColors[props.status]}>
+		{props.status}
+	</Tag>;
+}

--- a/packages/web_ui/src/components/InstanceViewPage.jsx
+++ b/packages/web_ui/src/components/InstanceViewPage.jsx
@@ -18,6 +18,7 @@ import SavesList from "./SavesList";
 import { notifyErrorHandler } from "../util/notify";
 import { useInstance } from "../model/instance";
 import { useSlave } from "../model/slave";
+import InstanceStatusTag from "./InstanceStatusTag";
 
 const { Title, Paragraph } = Typography;
 
@@ -116,7 +117,7 @@ export default function InstanceViewPage(props) {
 					buttonContent={assigned ? "Reassign" : "Assign"}
 				/>}
 			</Descriptions.Item>
-			<Descriptions.Item label="Status">{instance["status"]}</Descriptions.Item>
+			<Descriptions.Item label="Status"><InstanceStatusTag status={instance["status"]} /></Descriptions.Item>
 		</Descriptions>
 
 		{

--- a/packages/web_ui/src/components/SlaveViewPage.jsx
+++ b/packages/web_ui/src/components/SlaveViewPage.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Descriptions, PageHeader, Spin, Typography } from "antd";
+import { Descriptions, PageHeader, Spin, Typography, Tag } from "antd";
 import { useParams } from "react-router-dom";
 
 import InstanceList from "./InstanceList";
@@ -44,7 +44,13 @@ export default function SlaveViewPage(props) {
 
 		<Descriptions bordered size="small" column={{ xs: 1, sm: 2, xl: 4 }}>
 			<Descriptions.Item label="Name">{slave["name"]}</Descriptions.Item>
-			<Descriptions.Item label="Connected">{slave["connected"] ? "yes" : "no"}</Descriptions.Item>
+			<Descriptions.Item label="Connected">
+				<Tag
+					color={slave["connected"] ? "#389e0d" : "#cf1322"}
+				>
+					{slave["connected"] ? "Connected" : "Disconnected"}
+				</Tag>
+			</Descriptions.Item>
 			<Descriptions.Item label="Agent">{slave["agent"]}</Descriptions.Item>
 			<Descriptions.Item label="Version">{slave["version"]}</Descriptions.Item>
 		</Descriptions>

--- a/packages/web_ui/src/components/SlavesPage.jsx
+++ b/packages/web_ui/src/components/SlavesPage.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useRef, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { Button, Form, Input, Modal, PageHeader, Table } from "antd";
+import { Button, Form, Input, Modal, PageHeader, Table, Tag } from "antd";
 
 import { libLink } from "@clusterio/lib";
 
@@ -105,9 +105,18 @@ export default function SlavesPage() {
 					sorter: (a, b) => strcmp(a["version"], b["version"]),
 				},
 				{
+					title: "Public address",
+					dataIndex: "public_address",
+					sorter: (a, b) => strcmp(a["public_address"], b["public_address"]),
+				},
+				{
 					title: "Connected",
 					key: "connected",
-					render: slave => slave["connected"] && "Yes",
+					render: slave => <Tag
+						color={slave["connected"] ? "#389e0d" : "#cf1322"}
+					>
+						{slave["connected"] ? "Connected" : "Disconnected"}
+					</Tag>,
 					sorter: (a, b) => a["connected"] - b["connected"],
 				},
 			]}


### PR DESCRIPTION
Implemented #381 partially because from what I see only the public_address was still missing.

Also added/changed the slave and instance status to use the Ant Design [Tag](https://ant.design/components/tag) component with some colors (I just picked some colors from the [colors list](https://ant.design/docs/spec/colors))

![image](https://user-images.githubusercontent.com/17990055/140238621-65b71d50-2c8e-4d3a-b8b6-e5687bda4c98.png)


![image](https://user-images.githubusercontent.com/17990055/140238601-acd85359-6afa-4a89-8d58-e314f80276b2.png)


![image](https://user-images.githubusercontent.com/17990055/140238569-6becb249-3d72-45e7-a89e-4b969acfdc0b.png)

It also still only gets the game_port from the config, need to figure out what's the best way to get it if the config value is empty.

Feedback is welcome 😄 