### PR TITLE
Start all, stop all and delete all instance buttons

### DIFF
--- a/packages/web_ui/src/components/InstancesPage.jsx
+++ b/packages/web_ui/src/components/InstancesPage.jsx
@@ -11,7 +11,6 @@ import { useInstanceList } from "../model/instance";
 import InstanceList from "./InstanceList";
 import { notifyErrorHandler } from "../util/notify";
 
-
 function CreateInstanceButton(props) {
 	let control = useContext(ControlContext);
 	let history = useHistory();
@@ -51,7 +50,7 @@ function CreateInstanceButton(props) {
 		>
 			<Form form={form}>
 				<Form.Item name="instanceName" label="Name">
-					<Input/>
+					<Input />
 				</Form.Item>
 			</Form>
 		</Modal>
@@ -59,6 +58,7 @@ function CreateInstanceButton(props) {
 }
 
 export default function InstancesPage() {
+	let control = useContext(ControlContext);
 	let account = useAccount();
 	let [instanceList] = useInstanceList();
 
@@ -66,7 +66,31 @@ export default function InstancesPage() {
 		<PageHeader
 			className="site-page-header"
 			title="Instances"
-			extra={account.hasPermission("core.instance.create") && <CreateInstanceButton />}
+			extra={<>
+				{account.hasPermission("core.instance.create") && <CreateInstanceButton />}
+				{account.hasPermission("core.instance.start")
+					&& <Button onClick={e => instanceList.forEach(instance => {
+						if (instance.status === "stopped") {
+							libLink.messages.startInstance.send(
+								control, { instance_id: instance.id, save: null }
+							).catch(notifyErrorHandler("Error starting instance"));
+						}
+					})
+					}>
+						Start all
+					</Button>}
+				{account.hasPermission("core.instance.stop")
+					&& <Button onClick={e => instanceList.forEach(instance => {
+						if (["starting", "running"].includes(instance.status)) {
+							libLink.messages.stopInstance.send(
+								control, { instance_id: instance.id }
+							).catch(notifyErrorHandler("Error stopping instance"));
+						}
+					})
+					}>
+						Stop all
+					</Button>}
+			</>}
 		/>
 
 		<InstanceList instances={instanceList} />


### PR DESCRIPTION
When playing around with my gridworld plugin I frequently found myself needing to spin my whole cluster up and down a lot, thought this might be useful for someone else as well.

![image](https://i.imgur.com/k2U4EXF.png)

![image](https://i.imgur.com/nW4cAMv.png)