### PR TITLE
Fix sendRcon not waiting for startup if called too early

### DIFF
--- a/packages/lib/factorio/server.js
+++ b/packages/lib/factorio/server.js
@@ -968,7 +968,7 @@ class FactorioServer extends events.EventEmitter {
 	 * @returns {string} response from server.
 	 */
 	async sendRcon(message, expectEmpty) {
-		this._check(["running", "stopping"]);
+		this._check(["running", "stopping", "init"]);
 		if (!this._rconReady) {
 			await events.once(this, "rcon-ready");
 		}


### PR DESCRIPTION
If sendRcon was called before the instance had entered the startup state it would throw an error as demonstrated in #429

resolves #429 although I am not sure if this could introduce edgecases in other places where "init" is used in combination with .sendRcon().
