### PR TITLE
Add gridworld and edge_transports to create

### DIFF
--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -24,10 +24,12 @@ const availablePlugins = [
 	{ name: "Research Sync", value: "@clusterio/plugin-research_sync" },
 	{ name: "Statistics Exporter", value: "@clusterio/plugin-statistics_exporter" },
 	{ name: "Subspace Storage", value: "@clusterio/plugin-subspace_storage" },
+	{ name: "Edge Transports", value: "@clusterio/plugin-edge_transports" },
 
 	// Comunity plugins
 	{ name: "Discord Bridge", value: "@hornwitser/discord_bridge" },
 	{ name: "Server Select", value: "@hornwitser/server_select" },
+	{ name: "Gridworld", value: "@danielv123/gridworld"},
 ];
 
 const factorioLocations = {


### PR DESCRIPTION
Edge transports has been around for some time, is there a reason why it wasn't included? Gridworld will likely still have a lot of development, but it is in a playable state now, especially since its basically just a configuration tool.