### PR TITLE
Use strict parsing in installer

### DIFF
--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -527,7 +527,9 @@ async function main() {
 		})
 		.option("plugins", {
 			array: true, describe: "Plugins to install", type: "string",
-		});
+		})
+		.strict()
+	;
 
 	if (process.platform === "linux") {
 		args = args


### PR DESCRIPTION
Bail out if arguments that aren't understood are passed to the
installer script instead of silently ignoring them.