### PR TITLE
Instance migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *debug.log*
+*.log
 
 # Runtime data
 pids

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "lerna": "^4.0.0",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0"
+  },
+  "dependencies": {
+    "@clusterio/plugin-edge_transports": "^0.0.2",
+    "@hornwitser/server_select": "^2.0.0-alpha.3"
   }
 }

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -884,7 +884,7 @@ messages.migrateInstanceCommand = new Request({
 		"status": {
 			type: "string",
 			enum: ["success", "failure"],
-		}
+		},
 	},
 });
 

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -872,6 +872,21 @@ messages.queryLog = new Request({
 	},
 });
 
+messages.migrateInstanceCommand = new Request({
+	type: "migrate_instance",
+	links: ["control-master"],
+	permission: "core.instance.migrate",
+	requestProperties: {
+		"instance_id": { type: "integer" },
+		"slave_id": { type: "integer" },
+	},
+	responseProperties: {
+		"status": {
+			type: "string",
+			enum: ["success", "failure"],
+		}
+	},
+});
 
 // Internal requests
 messages.updateInstances = new Request({

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -378,6 +378,11 @@ definePermission({
 	description: "Assign or reassign instances to a slave.",
 });
 definePermission({
+	name: "core.instance.migrate",
+	title: "Migrate instance",
+	description: "Migrate an instance to another slave. Uses stop, start, and assign internally.",
+});
+definePermission({
 	name: "core.instance.save.list",
 	title: "List saves on instance",
 	description: "List the saves currently on the instance.",

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -358,14 +358,6 @@ class ControlConnection extends BaseConnection {
 				instance_id: instance_id,
 			});
 		}
-		const restoreStatus = async originalStatus => {
-			if (originalStatus === "running") {
-				await libLink.messages.startInstance.send(originSlaveConnection, {
-					instance_id,
-					save: null,
-				});
-			}
-		}
 
 		// Get savefiles from origin slave
 		const saves = (await libLink.messages.listSaves.send(originSlaveConnection, {
@@ -427,9 +419,6 @@ class ControlConnection extends BaseConnection {
 				serialized_config: instance.config.serialize("slave"),
 			});
 
-			// Restart the instance if we stopped it
-			restoreStatus(originalStatus);
-
 			throw e;
 		}
 		try {
@@ -457,9 +446,6 @@ class ControlConnection extends BaseConnection {
 				instance_id,
 				serialized_config: instance.config.serialize("slave"),
 			});
-
-			// Restart the instance if we stopped it
-			restoreStatus(originalStatus);
 
 			throw e;
 		}

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -395,7 +395,7 @@ class ControlConnection extends BaseConnection {
 
 			return {
 				stream_id: stream.id,
-				filename
+				filename,
 			};
 		}));
 
@@ -411,7 +411,7 @@ class ControlConnection extends BaseConnection {
 				instance_id,
 				serialized_config: instance.config.serialize("slave"),
 			});
-		} catch (e){
+		} catch (e) {
 			// Reassign instance to origin slave
 			instance.config.set("instance.assigned_slave", originSlaveId);
 			await libLink.messages.assignInstance.send(originSlaveConnection, {
@@ -425,7 +425,7 @@ class ControlConnection extends BaseConnection {
 			// Start transfer of files to slave
 			for (let preparedUpload of preparedUploads) {
 				const { stream_id, filename } = preparedUpload;
-				console.log(`Transferring ${preparedUpload.filename}`);
+				logger.info(`Transferring ${preparedUpload.filename}`);
 
 				// Make the other slave download the file
 				await libLink.messages.pullSave.send(destinationSlaveConnection, {

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -518,6 +518,9 @@ class ControlConnection extends BaseConnection {
 				serialized_config: instance.config.serialize("slave"),
 			});
 		}
+
+		// Trigger instance update
+		this._master.instanceUpdated(instance);
 	}
 
 	async setSaveListSubscriptionsRequestHandler(message) {

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -1484,6 +1484,7 @@ class Slave extends libLink.Link {
 		let writeStream;
 		while (true) {
 			try {
+				await fs.ensureDir(savesDir);
 				writeStream = fs.createWriteStream(path.join(savesDir, tempFilename), { flags: "wx" });
 				await events.once(writeStream, "open");
 				break;

--- a/packages/web_ui/src/components/InstanceViewPage.jsx
+++ b/packages/web_ui/src/components/InstanceViewPage.jsx
@@ -12,6 +12,7 @@ import InstanceConfigTree from "./InstanceConfigTree";
 import LogConsole from "./LogConsole";
 import InstanceRcon from "./InstanceRcon";
 import AssignInstanceModal from "./AssignInstanceModal";
+import MigrateInstanceModal from "./MigrateInstanceModal";
 import StartStopInstanceButton from "./StartStopInstanceButton";
 import LoadScenarioModal from "./LoadScenarioModal";
 import SavesList from "./SavesList";
@@ -127,6 +128,17 @@ export default function InstanceViewPage(props) {
 						disabled: !["unknown", "unassigned", "stopped"].includes(instance["status"]),
 					}}
 					buttonContent={assigned ? "Reassign" : "Assign"}
+				/>}
+				{account.hasPermission("core.instance.migrate") && <MigrateInstanceModal
+					id={instanceId}
+					slaveId={instance["assigned_slave"]}
+					buttonProps={{
+						size: "small",
+						style: { float: "Right" },
+						type: assigned ? "default" : "primary",
+						disabled: !["running", "stopped"].includes(instance["status"]) || !assigned,
+					}}
+					buttonContent={"Migrate"}
 				/>}
 			</Descriptions.Item>
 			<Descriptions.Item label="Status"><InstanceStatusTag status={instance["status"]} /></Descriptions.Item>

--- a/packages/web_ui/src/components/MigrateInstanceModal.jsx
+++ b/packages/web_ui/src/components/MigrateInstanceModal.jsx
@@ -1,0 +1,87 @@
+import React, { useContext, useState } from "react";
+import { Button, Form, Modal, Select, Typography } from "antd";
+
+import { libLink } from "@clusterio/lib";
+
+import ControlContext from "./ControlContext";
+import { notifyErrorHandler } from "../util/notify";
+import { useSlaveList } from "../model/slave";
+
+const { Paragraph } = Typography;
+
+export default function MigrateInstanceModal(props) {
+	let [visible, setVisible] = useState(false);
+	let [slaveList] = useSlaveList();
+	let [applying, setApplying] = useState(false);
+	let [form] = Form.useForm();
+	let control = useContext(ControlContext);
+
+	function open() {
+		setVisible(true);
+	}
+
+	function handleMigrate() {
+		let slaveId = form.getFieldValue("slave");
+		if (slaveId === undefined) {
+			setVisible(false);
+			return;
+		}
+
+		setApplying(true);
+		libLink.messages.migrateInstanceCommand.send(control, {
+			instance_id: props.id,
+			slave_id: slaveId,
+		}).then(() => {
+			setVisible(false);
+			if (props.onFinish) {
+				props.onFinish();
+			}
+		}).catch(
+			notifyErrorHandler("Error migrating instance")
+		).finally(
+			() => setApplying(false)
+		);
+	}
+
+	function handleCancel() {
+		setVisible(false);
+	}
+
+	return <>
+		<Button {...props.buttonProps} onClick={open}>
+			{props.buttonContent || "Migrate"}
+		</Button>
+		<Modal
+			title="Migrate Instance"
+			okText="Migrate"
+			visible={visible}
+			confirmLoading={applying}
+			onOk={handleMigrate}
+			onCancel={handleCancel}
+			destroyOnClose
+		>
+			<Paragraph style={{ maxWidth: "30em" }}>
+				Select a Slave to migrate this instance to. Migration
+				moves savefiles from one slave to another then reassigns it.
+				Configuration files are synchronized through the config system.
+				If the migration fails, the files will remain on the old slave
+				while partial data might be located on the destination slave.
+				You can recover by assigning the instance to the old slave.
+			</Paragraph>
+			<Form form={form} initialValues={{ slave: props.slaveId }}>
+				<Form.Item name="slave" label="Slave">
+					<Select>
+						{slaveList.map((slave) => <Select.Option
+							key={slave["id"]}
+							value={slave["id"]}
+							disabled={!slave["connected"]}
+						>
+							{slave["name"]}
+							{!slave["connected"] && " (offline)"}
+						</Select.Option>)}
+					</Select>
+				</Form.Item>
+			</Form>
+		</Modal>
+	</>;
+}

--- a/packages/web_ui/src/components/MigrateInstanceModal.jsx
+++ b/packages/web_ui/src/components/MigrateInstanceModal.jsx
@@ -64,21 +64,32 @@ export default function MigrateInstanceModal(props) {
 				Select a Slave to migrate this instance to. Migration
 				moves savefiles from one slave to another then reassigns it.
 				Configuration files are synchronized through the config system.
+				If the instance was running when the migration was initiated,
+				it will be stopped and restarted on the new slave.
+			</Paragraph>
+			<Paragraph style={{ maxWidth: "30em" }}>
 				If the migration fails, the files will remain on the old slave
 				while partial data might be located on the destination slave.
-				You can recover by assigning the instance to the old slave.
+				The automatic recovery process will attempt to recover the
+				instance by assigning it to the same slave it was on before.
+				If the automatic recovery fails, attempt a manual recovery
+				by assigning the instance to the original slave.
 			</Paragraph>
-			<Form form={form} initialValues={{ slave: props.slaveId }}>
+			<Form form={form} initialValues={{
+				slave: slaveList.filter(slave => slave["id"] !== props.slaveId)[0]?.["id"],
+			}}>
 				<Form.Item name="slave" label="Slave">
 					<Select>
-						{slaveList.map((slave) => <Select.Option
-							key={slave["id"]}
-							value={slave["id"]}
-							disabled={!slave["connected"]}
-						>
-							{slave["name"]}
-							{!slave["connected"] && " (offline)"}
-						</Select.Option>)}
+						{slaveList
+							.filter(slave => slave["id"] !== props.slaveId)
+							.map((slave) => <Select.Option
+								key={slave["id"]}
+								value={slave["id"]}
+								disabled={!slave["connected"]}
+							>
+								{slave["name"]}
+								{!slave["connected"] && " (offline)"}
+							</Select.Option>)}
 					</Select>
 				</Form.Item>
 			</Form>


### PR DESCRIPTION
Creating a draft PR to show progress on this issue. It is not ready for merge.

Instance migration moves an instance from one slave to another. The process should be entirely hands off. Errors are handled by reverting to the original state. If the server was running when the migration was initiated, leave it stopped in case of an error during the transfer.

This implementation uses existing methods to transfer savefiles, configs and instance state to reduce code duplication.

Current discussed feature list:

- [x] Migration of instances
- [x] Restore instance state on completed migration
- [x] Revert instance state on failed migration
- [x] Migration happens independant of UI
- [ ] Track migrations on the serverside and provide progress feedback/a list of running migrations
- [ ] Add a comprehensive test suite

Not discussed:

This PR does not implement a seperate "migrating" status for the instance. Instead it goes running -> stopping -> stopped -> reassign -> starting -> started. It can be argued that the "correct" status between stopped and starting would be "migrating", but I don't think its needed so I haven't added it to the todo list.

Here is an earlier version of migration in action: https://www.youtube.com/watch?v=mW1xa0rRrjA