### PR TITLE
Save transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Packaged and uploaded to npm again, greatly simplifying distribution and installation of both Clusterio and plugins.
 - Added centralized logging for the cluster.
   All logs from both Clusterio and Factorio is stored in a shared log which can be inspected and queried.
-- Added remote save management with the ability to list, create, rename, copy, upload, download, delete and load saves for instances.
+- Added remote save management with the ability to list, create, rename, copy, upload, download, transfer, delete and load saves for instances.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Packaged and uploaded to npm again, greatly simplifying distribution and installation of both Clusterio and plugins.
 - Added centralized logging for the cluster.
   All logs from both Clusterio and Factorio is stored in a shared log which can be inspected and queried.
-- Added remote save management with the ability to list, create, upload, download, delete and load saves for instances.
+- Added remote save management with the ability to list, create, rename, copy, upload, download, delete and load saves for instances.
 
 ### Features
 

--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -660,6 +660,34 @@ instanceSaveCommands.add(new libCommand.Command({
 }));
 
 instanceSaveCommands.add(new libCommand.Command({
+	definition: [
+		"transfer <source-instance> <source-save> <target-instance> [target-save]",
+		"Transfer a save between instances",
+		(yargs) => {
+			yargs.positional("source-instance", { describe: "Instance to transfer save from", type: "string" });
+			yargs.positional("source-save", { describe: "Save to transfer.", type: "string" });
+			yargs.positional("target-instance", { describe: "Instance to transfer to", type: "string" });
+			yargs.positional("target-save", { describe: "Name to give transferred save.", type: "string" });
+			yargs.options({
+				"copy": { describe: "Copy instead of moving the save", type: "boolean", default: false },
+			});
+		},
+	],
+	handler: async function(args, control) {
+		let sourceInstanceId = await libCommand.resolveInstance(control, args.sourceInstance);
+		let targetInstanceId = await libCommand.resolveInstance(control, args.targetInstance);
+		let result = await libLink.messages.transferSave.send(control, {
+			instance_id: sourceInstanceId,
+			source_save: args.sourceSave,
+			target_instance_id: targetInstanceId,
+			target_save: args.targetSave || args.sourceSave,
+			copy: args.copy,
+		});
+		print(`Transferred as ${result.save} to ${args.targetInstance}.`);
+	},
+}));
+
+instanceSaveCommands.add(new libCommand.Command({
 	definition: ["download <instance> <save>", "Download a save from an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to download save from", type: "string" });
 		yargs.positional("save", { describe: "Save to download", type: "string" });

--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -577,6 +577,38 @@ instanceSaveCommands.add(new libCommand.Command({
 }));
 
 instanceSaveCommands.add(new libCommand.Command({
+	definition: ["rename <instance> <old-name> <new-name>", "Rename a save on an instance", (yargs) => {
+		yargs.positional("instance", { describe: "Instance to rename save on", type: "string" });
+		yargs.positional("old-name", { describe: "Old name of save.", type: "string" });
+		yargs.positional("new-name", { describe: "New name of save.", type: "string" });
+	}],
+	handler: async function(args, control) {
+		let instanceId = await libCommand.resolveInstance(control, args.instance);
+		await libLink.messages.renameSave.send(control, {
+			instance_id: instanceId,
+			old_name: args.oldName,
+			new_name: args.newName,
+		});
+	},
+}));
+
+instanceSaveCommands.add(new libCommand.Command({
+	definition: ["copy <instance> <source> <destination>", "Copy a save on an instance", (yargs) => {
+		yargs.positional("instance", { describe: "Instance to copy save on", type: "string" });
+		yargs.positional("source", { describe: "Save to copy.", type: "string" });
+		yargs.positional("destination", { describe: "Name of copy.", type: "string" });
+	}],
+	handler: async function(args, control) {
+		let instanceId = await libCommand.resolveInstance(control, args.instance);
+		await libLink.messages.copySave.send(control, {
+			instance_id: instanceId,
+			source: args.source,
+			destination: args.destination,
+		});
+	},
+}));
+
+instanceSaveCommands.add(new libCommand.Command({
 	definition: ["upload <instance> <filepath>", "Upload a save to an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to upload to", type: "string" });
 		yargs.positional("filepath", { describe: "Path to save to upload", type: "string" });

--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -533,8 +533,11 @@ async function loadMapSettings(args) {
 	};
 }
 
-instanceCommands.add(new libCommand.Command({
-	definition: ["list-saves <instance>", "list saves on an instance", (yargs) => {
+const instanceSaveCommands = new libCommand.CommandTree({
+	name: "save", alias: ["s"], description: "Instance save management",
+});
+instanceSaveCommands.add(new libCommand.Command({
+	definition: ["list <instance>", "list saves on an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to list saves on", type: "string" });
 	}],
 	handler: async function(args, control) {
@@ -548,8 +551,8 @@ instanceCommands.add(new libCommand.Command({
 	},
 }));
 
-instanceCommands.add(new libCommand.Command({
-	definition: ["create-save <instance> [name]", "Create a new save on an instance", (yargs) => {
+instanceSaveCommands.add(new libCommand.Command({
+	definition: ["create <instance> [name]", "Create a new save on an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to create on", type: "string" });
 		yargs.positional("name", { describe: "Name of save to create.", type: "string", default: "world.zip" });
 		yargs.options({
@@ -573,8 +576,8 @@ instanceCommands.add(new libCommand.Command({
 	},
 }));
 
-instanceCommands.add(new libCommand.Command({
-	definition: ["upload-save <instance> <filepath>", "Upload a save to an instance", (yargs) => {
+instanceSaveCommands.add(new libCommand.Command({
+	definition: ["upload <instance> <filepath>", "Upload a save to an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to upload to", type: "string" });
 		yargs.positional("filepath", { describe: "Path to save to upload", type: "string" });
 		yargs.options({
@@ -624,8 +627,8 @@ instanceCommands.add(new libCommand.Command({
 	},
 }));
 
-instanceCommands.add(new libCommand.Command({
-	definition: ["download-save <instance> <save>", "Download a save from an instance", (yargs) => {
+instanceSaveCommands.add(new libCommand.Command({
+	definition: ["download <instance> <save>", "Download a save from an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to download save from", type: "string" });
 		yargs.positional("save", { describe: "Save to download", type: "string" });
 	}],
@@ -669,8 +672,8 @@ instanceCommands.add(new libCommand.Command({
 	},
 }));
 
-instanceCommands.add(new libCommand.Command({
-	definition: ["delete-save <instance> <save>", "Delete a save from an instance", (yargs) => {
+instanceSaveCommands.add(new libCommand.Command({
+	definition: ["delete <instance> <save>", "Delete a save from an instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to delete save from", type: "string" });
 		yargs.positional("save", { describe: "Save to delete", type: "string" });
 	}],
@@ -682,6 +685,7 @@ instanceCommands.add(new libCommand.Command({
 		});
 	},
 }));
+instanceCommands.add(instanceSaveCommands);
 
 instanceCommands.add(new libCommand.Command({
 	definition: ["export-data <instance>", "Export item icons and locale from instance", (yargs) => {

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -595,6 +595,22 @@ messages.downloadSave = new Request({
 	},
 });
 
+messages.transferSave = new Request({
+	type: "transfer_save",
+	links: ["control-master", "master-slave"],
+	permission: "core.instance.save.transfer",
+	requestProperties: {
+		"instance_id": { type: "integer" },
+		"source_save": { type: "string" },
+		"target_instance_id": { type: "integer" },
+		"target_save": { type: "string" },
+		"copy": { type: "boolean" },
+	},
+	responseProperties: {
+		"save": { type: "string" },
+	},
+});
+
 messages.pullSave = new Request({
 	type: "pull_save",
 	links: ["master-slave"],

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -550,6 +550,28 @@ messages.createSave = new Request({
 	},
 });
 
+messages.renameSave = new Request({
+	type: "rename_save",
+	links: ["control-master", "master-slave"],
+	permission: "core.instance.save.rename",
+	forwardTo: "instance",
+	requestProperties: {
+		"old_name": { type: "string" },
+		"new_name": { type: "string" },
+	},
+});
+
+messages.copySave = new Request({
+	type: "copy_save",
+	links: ["control-master", "master-slave"],
+	permission: "core.instance.save.copy",
+	forwardTo: "instance",
+	requestProperties: {
+		"source": { type: "string" },
+		"destination": { type: "string" },
+	},
+});
+
 messages.deleteSave = new Request({
 	type: "delete_save",
 	links: ["control-master", "master-slave"],

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -379,7 +379,7 @@ definePermission({
 });
 definePermission({
 	name: "core.instance.save.list",
-	title: "List saves on instance",
+	title: "List saves",
 	description: "List the saves currently on the instance.",
 });
 definePermission({
@@ -389,22 +389,22 @@ definePermission({
 });
 definePermission({
 	name: "core.instance.save.create",
-	title: "Create new instance save",
+	title: "Create new save",
 	description: "Create new savegames on instances.",
 });
 definePermission({
 	name: "core.instance.save.delete",
-	title: "Delete instance save",
+	title: "Delete save",
 	description: "Delete savegames on instances.",
 });
 definePermission({
 	name: "core.instance.save.upload",
-	title: "Upload save to instance",
+	title: "Upload save",
 	description: "Upload savegames to instances.",
 });
 definePermission({
 	name: "core.instance.save.download",
-	title: "Download save from instance",
+	title: "Download save",
 	description: "Download savegames from instances.",
 });
 definePermission({

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -413,6 +413,11 @@ definePermission({
 	description: "Upload savegames to instances.",
 });
 definePermission({
+	name: "core.instance.save.transfer",
+	title: "Transfer save",
+	description: "Transfer savegames between instances.",
+});
+definePermission({
 	name: "core.instance.save.download",
 	title: "Download save",
 	description: "Download savegames from instances.",

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -393,6 +393,16 @@ definePermission({
 	description: "Create new savegames on instances.",
 });
 definePermission({
+	name: "core.instance.save.rename",
+	title: "Rename save",
+	description: "Rename savegames on instances.",
+});
+definePermission({
+	name: "core.instance.save.copy",
+	title: "Copy save",
+	description: "Create copies of savegames on instances.",
+});
+definePermission({
 	name: "core.instance.save.delete",
 	title: "Delete save",
 	description: "Delete savegames on instances.",

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -159,10 +159,7 @@ class ControlConnection extends BaseConnection {
 
 	async getInstanceRequestHandler(message) {
 		let id = message.data.id;
-		let instance = this._master.instances.get(id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${id} does not exist`);
-		}
+		let instance = this._master.getRequestInstance(id);
 
 		return {
 			id,
@@ -249,11 +246,7 @@ class ControlConnection extends BaseConnection {
 	}
 
 	async deleteInstanceRequestHandler(message, request) {
-		let instance = this._master.instances.get(message.data.instance_id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${message.data.instance_id} does not exist`);
-		}
-
+		let instance = this._master.getRequestInstance(message.data.instance_id);
 		if (instance.config.get("instance.assigned_slave") !== null) {
 			await this.forwardRequestToInstance(message, request);
 		}
@@ -266,11 +259,7 @@ class ControlConnection extends BaseConnection {
 	}
 
 	async getInstanceConfigRequestHandler(message) {
-		let instance = this._master.instances.get(message.data.instance_id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${message.data.instance_id} does not exist`);
-		}
-
+		let instance = this._master.getRequestInstance(message.data.instance_id);
 		return {
 			serialized_config: instance.config.serialize("control"),
 		};
@@ -290,11 +279,7 @@ class ControlConnection extends BaseConnection {
 	}
 
 	async setInstanceConfigFieldRequestHandler(message) {
-		let instance = this._master.instances.get(message.data.instance_id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${message.data.instance_id} does not exist`);
-		}
-
+		let instance = this._master.getRequestInstance(message.data.instance_id);
 		if (message.data.field === "instance.assigned_slave") {
 			throw new libErrors.RequestError("instance.assigned_slave must be set through the assign-slave interface");
 		}
@@ -309,11 +294,7 @@ class ControlConnection extends BaseConnection {
 	}
 
 	async setInstanceConfigPropRequestHandler(message) {
-		let instance = this._master.instances.get(message.data.instance_id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${message.data.instance_id} does not exist`);
-		}
-
+		let instance = this._master.getRequestInstance(message.data.instance_id);
 		let { field, prop, value } = message.data;
 		instance.config.setProp(field, prop, value, "control");
 		await this.updateInstanceConfig(instance);
@@ -321,10 +302,7 @@ class ControlConnection extends BaseConnection {
 
 	async assignInstanceCommandRequestHandler(message, request) {
 		let { slave_id, instance_id } = message.data;
-		let instance = this._master.instances.get(instance_id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${instance_id} does not exist`);
-		}
+		let instance = this._master.getRequestInstance(instance_id);
 
 		// Check if target slave is connected
 		let newSlaveConnection;

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -1,5 +1,6 @@
 "use strict";
 const jwt = require("jsonwebtoken");
+const events = require("events");
 
 const libConfig = require("@clusterio/lib/config");
 const libErrors = require("@clusterio/lib/errors");
@@ -371,6 +372,85 @@ class ControlConnection extends BaseConnection {
 
 		await ready;
 		return { stream_id: stream.id };
+	}
+
+	async transferSaveRequestHandler(message, request) {
+		let { source_save, target_save, copy, instance_id, target_instance_id } = message.data;
+		if (copy) {
+			this.user.checkPermission("core.instance.save.copy");
+		} else if (source_save !== target_save) {
+			this.user.checkPermission("core.instance.save.rename");
+		}
+
+		if (instance_id === target_instance_id) {
+			throw new libErrors.RequestError("Source and target instance may not be the same");
+		}
+		let sourceInstance = this._master.getRequestInstance(instance_id);
+		let targetInstance = this._master.getRequestInstance(target_instance_id);
+		let sourceSlaveId = sourceInstance.config.get("instance.assigned_slave");
+		let targetSlaveId = targetInstance.config.get("instance.assigned_slave");
+		if (sourceSlaveId === null) {
+			throw new libErrors.RequestError("Source instance is not assigned a slave");
+		}
+		if (targetSlaveId === null) {
+			throw new libErrors.RequestError("Target instance is not assigned a slave");
+		}
+
+		// Let slave handle request if source and target is on the same slave.
+		if (sourceSlaveId === targetSlaveId) {
+			return await this.forwardRequestToInstance(message, request);
+		}
+
+		// Check connectivity
+		let sourceSlaveConnection = this._master.wsServer.slaveConnections.get(sourceSlaveId);
+		if (!sourceSlaveConnection || sourceSlaveConnection.closing) {
+			throw new libErrors.RequestError("Source slave is not connected to the master server");
+		}
+
+		let targetSlaveConnection = this._master.wsServer.slaveConnections.get(targetSlaveId);
+		if (!targetSlaveConnection || targetSlaveConnection.closing) {
+			throw new libErrors.RequestError("Target slave is not connected to the master server");
+		}
+
+		// Create stream to proxy from target to source
+		let stream = await routes.createProxyStream(this._master.app);
+		stream.events.on("timeout", () => {
+			if (stream.source) {
+				stream.source.destroy();
+			}
+			stream.events.emit("error", new libErrors.RequestError("Timed out establishing transfer stream"));
+		});
+
+		// Ignore errors if not listening for them to avoid crash.
+		stream.events.on("error", () => { /* ignore */ });
+
+		// Establish push from source slave to stream, this is done first to
+		// ensure the file size is known prior to the target slave pull.
+		await Promise.all([
+			this._master.forwardRequestToInstance(libLink.messages.pushSave, {
+				instance_id,
+				stream_id: stream.id,
+				save: source_save,
+			}),
+			events.once(stream.events, "source"),
+		]);
+
+		// Establish pull from target slave to stream and wait for completion.
+		let result = await this._master.forwardRequestToInstance(libLink.messages.pullSave, {
+			instance_id: target_instance_id,
+			stream_id: stream.id,
+			filename: target_save,
+		});
+
+		// Delete source save if this is not a copy
+		if (!copy) {
+			await this._master.forwardRequestToInstance(libLink.messages.deleteSave, {
+				instance_id,
+				save: source_save,
+			});
+		}
+
+		return { save: result.save };
 	}
 
 	async setLogSubscriptionsRequestHandler(message) {

--- a/packages/master/src/Master.js
+++ b/packages/master/src/Master.js
@@ -424,6 +424,21 @@ class Master {
 		}
 	}
 
+	/**
+	 * Get instance by ID for a request
+	 *
+	 * @param {number} instanceId - ID of instance to get.
+	 * @returns {object} instance
+	 * @throws {module:lib/errors.RequestError} if the instance does not exist.
+	 */
+	getRequestInstance(instanceId) {
+		let instance = this.instances.get(instanceId);
+		if (!instance) {
+			throw new libErrors.RequestError(`Instance with ID ${instanceId} does not exist`);
+		}
+		return instance;
+	}
+
 	addInstanceHooks(instance) {
 		instance.config.on("fieldChanged", (group, field, prev) => {
 			if (group.name === "instance" && field === "name") {
@@ -608,11 +623,7 @@ class Master {
 	 * @returns {object} data returned from the request.
 	 */
 	async forwardRequestToInstance(request, data) {
-		let instance = this.instances.get(data.instance_id);
-		if (!instance) {
-			throw new libErrors.RequestError(`Instance with ID ${data.instance_id} does not exist`);
-		}
-
+		let instance = this.getRequestInstance(data.instance_id);
 		let slaveId = instance.config.get("instance.assigned_slave");
 		if (slaveId === null) {
 			throw new libErrors.RequestError("Instance is not assigned to a slave");

--- a/packages/slave/slave.js
+++ b/packages/slave/slave.js
@@ -1449,6 +1449,46 @@ class Slave extends libLink.Link {
 		await request.send(instanceConnection, message.data);
 	}
 
+	async renameSaveRequestHandler(message) {
+		let { instance_id, old_name, new_name } = message.data;
+		checkRequestSaveName(old_name);
+		checkRequestSaveName(new_name);
+		let instanceInfo = this.getRequestInstanceInfo(instance_id);
+		try {
+			await fs.move(
+				path.join(instanceInfo.path, "saves", old_name),
+				path.join(instanceInfo.path, "saves", new_name),
+				{ overwrite: false },
+			);
+		} catch (err) {
+			if (err.code === "ENOENT") {
+				throw new libErrors.RequestError(`${old_name} does not exist`);
+			}
+			throw err;
+		}
+		await this.sendSaveListUpdate(instance_id, path.join(instanceInfo.path, "saves"));
+	}
+
+	async copySaveRequestHandler(message) {
+		let { instance_id, source, destination } = message.data;
+		checkRequestSaveName(source);
+		checkRequestSaveName(destination);
+		let instanceInfo = this.getRequestInstanceInfo(instance_id);
+		try {
+			await fs.copy(
+				path.join(instanceInfo.path, "saves", source),
+				path.join(instanceInfo.path, "saves", destination),
+				{ overwrite: false, errorOnExist: true },
+			);
+		} catch (err) {
+			if (err.code === "ENOENT") {
+				throw new libErrors.RequestError(`${old_name} does not exist`);
+			}
+			throw err;
+		}
+		await this.sendSaveListUpdate(instance_id, path.join(instanceInfo.path, "saves"));
+	}
+
 	async sendSaveListUpdate(instance_id, savesDir) {
 		let instanceConnection = this.instanceConnections.get(instance_id);
 		let saveList;

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -250,11 +250,11 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 
-		describe("instance create-save", function() {
+		describe("instance save create", function() {
 			it("creates a save", async function() {
 				slowTest(this);
 				getControl().saveListUpdates = [];
-				await execCtl("instance create-save test");
+				await execCtl("instance save create test");
 				await checkInstanceStatus(44, "stopped");
 			});
 		});
@@ -266,10 +266,10 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 
-		describe("instance list-saves", function() {
+		describe("instance save list", function() {
 			it("lists the created save", async function() {
 				slowTest(this);
-				let result = await execCtl("instance list-saves test");
+				let result = await execCtl("instance save list test");
 				assert(/world\.zip/.test(result.stdout), "world.zip not present in list save output");
 			});
 		});
@@ -530,10 +530,10 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 
-		describe("instance upload-save", function() {
+		describe("instance save upload", function() {
 			it("should upload a zip file", async function() {
 				await fs.outputFile(path.join("temp", "test", "upload.zip"), "a test");
-				await execCtl("instance upload-save 44 upload.zip");
+				await execCtl("instance save upload 44 upload.zip");
 				assert(
 					await fs.pathExists(path.join("temp", "test", "instances", "test", "saves", "upload.zip")),
 					"file not uploaded to saves directory"
@@ -541,42 +541,42 @@ describe("Integration of Clusterio", function() {
 			});
 			it("should reject non-zip files", async function() {
 				await fs.outputFile(path.join("temp", "test", "invalid"), "a test");
-				await assert.rejects(execCtl("instance upload-save 44 invalid"));
+				await assert.rejects(execCtl("instance save upload 44 invalid"));
 			});
 			it("should reject path traversal attacks", async function() {
 				await fs.outputFile(path.join("temp", "test", "upload.zip"), "a test");
-				await assert.rejects(execCtl("instance upload-save 44 upload.zip --name ../traversal.zip"));
+				await assert.rejects(execCtl("instance save upload 44 upload.zip --name ../traversal.zip"));
 			});
 		});
 
-		describe("instance download-save", function() {
+		describe("instance save download", function() {
 			it("should download a save", async function() {
 				await fs.remove(path.join("temp", "test", "upload.zip"));
-				await execCtl("instance download-save 44 upload.zip");
+				await execCtl("instance save download 44 upload.zip");
 				assert(await fs.pathExists(path.join("temp", "test", "upload.zip")));
 			});
 			it("should error if save does not exist", async function() {
-				await assert.rejects(execCtl("instance download-save 44 invalid"));
+				await assert.rejects(execCtl("instance save download 44 invalid"));
 			});
 			it("should error on path traversal attacks", async function() {
-				await assert.rejects(execCtl("instance download-save 44 ../factorio-current.log"));
+				await assert.rejects(execCtl("instance save download 44 ../factorio-current.log"));
 			});
 		});
 
-		describe("instance delete-save", function() {
+		describe("instance save delete", function() {
 			it("should delete a save", async function() {
-				await execCtl("instance delete-save 44 upload.zip");
+				await execCtl("instance save delete 44 upload.zip");
 				assert(
 					!await fs.pathExists(path.join("temp", "test", "instances", "test", "saves", "upload.zip")),
 					"file not deleted"
 				);
 			});
 			it("should error if save does not exist", async function() {
-				await assert.rejects(execCtl("instance delete-save 44 upload.zip"));
+				await assert.rejects(execCtl("instance save delete 44 upload.zip"));
 			});
 			it("should error on path traversal attacks", async function() {
 				await fs.outputFile(path.join("temp", "test", "upload.zip"), "a test");
-				await assert.rejects(execCtl("instance delete-save 44 ../../upload.zip"));
+				await assert.rejects(execCtl("instance save delete 44 ../../upload.zip"));
 			});
 		});
 

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -563,6 +563,41 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 
+		describe("instance save copy", function() {
+			it("copy a save file", async function() {
+				await execCtl("instance save copy 44 upload.zip copy.zip");
+				assert(await fs.pathExists(path.join("temp", "test", "instances", "test", "saves", "copy.zip")));
+			});
+			it("should error if destination exist", async function() {
+				await assert.rejects(execCtl("instance save copy 44 upload.zip copy.zip"));
+			});
+			it("should error if source does not exist", async function() {
+				await assert.rejects(execCtl("instance save copy 44 not-here.zip invalid.zip"));
+			});
+			it("should reject path traversal attacks", async function() {
+				await assert.rejects(execCtl("instance save copy 44 upload.zip ../traversal.zip"));
+				await assert.rejects(execCtl("instance save copy 44 ../saves/upload.zip traversal.zip "));
+			});
+		});
+
+		describe("instance save rename", function() {
+			it("rename a save file", async function() {
+				await execCtl("instance save rename 44 copy.zip rename.zip");
+				assert(!await fs.pathExists(path.join("temp", "test", "instances", "test", "saves", "copy.zip")));
+				assert(await fs.pathExists(path.join("temp", "test", "instances", "test", "saves", "rename.zip")));
+			});
+			it("should error if new name exist", async function() {
+				await assert.rejects(execCtl("instance save rename 44 upload.zip rename.zip"));
+			});
+			it("should error if old name does not exist", async function() {
+				await assert.rejects(execCtl("instance save rename 44 not-here.zip invalid.zip"));
+			});
+			it("should reject path traversal attacks", async function() {
+				await assert.rejects(execCtl("instance save rename 44 upload.zip ../traversal.zip"));
+				await assert.rejects(execCtl("instance save rename 44 ../saves/upload.zip traversal.zip "));
+			});
+		});
+
 		describe("instance save delete", function() {
 			it("should delete a save", async function() {
 				await execCtl("instance save delete 44 upload.zip");

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -109,7 +109,8 @@ let slaveConfigPath = path.join("temp", "test", "config-slave.json");
 let controlConfigPath = path.join("temp", "test", "config-control.json");
 
 async function exec(command, options = {}) {
-	console.log(command);
+	// Uncomment to show commands run in tests
+	// console.log(command);
 	options = { cwd: path.join("temp", "test"), ...options };
 	return await util.promisify(child_process.exec)(command, options);
 }


### PR DESCRIPTION
Implement rename, copy, and cross instance/slave save transfer. Copy, rename and local transfer is implemented via simple file operations while the cross slave transfers use the proxy stream system. For organization sake the save related commands are grouped under `ctl instance save` now.