### PR TITLE
Player online autosave pool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,6 +271,19 @@ If null a random secure password is generated and used each time the instance st
 Defaults to null.
 
 
+### player_online_autosave_slots
+
+Keeps a separate pool for autosaves where at least on player has been online since the previous autosave was done.
+This requires regular autosaving to be enabled and will rename autosaves to `_autosave_poN.zip` (where N is a slot number) whenever a player has been online for that save.
+The slot numbers start at 1, are incremented by 1 after each autosave that is renamed and reset back to 1 whenever this value is exceeded.
+Note that this value should be set to a higher value than the value of `autosave_slots` in `factorio.settings`.
+Useful for preventing the loss of all progress when nobody is around on always online servers with auto pause disabled.
+
+If 0 no autosave renaming takes place.
+
+Defaults to 5.
+
+
 ### factorio.enable_save_patching
 
 Whether to use save patching or not.

--- a/packages/lib/config/definitions.js
+++ b/packages/lib/config/definitions.js
@@ -266,6 +266,14 @@ FactorioGroup.define({
 	optional: true,
 });
 FactorioGroup.define({
+	name: "player_online_autosave_slots",
+	description:
+		"Rename autosaves where players have been online since the previous autosave into a separate autosave " +
+		"pool with this many slots. Requires autosaves to be enabled to work. Set to 0 to disable.",
+	type: "number",
+	initial_value: 5,
+});
+FactorioGroup.define({
 	name: "enable_save_patching",
 	description: "Patch saves with Lua code. Required for Clusterio integrations, lua modules, and most plugins.",
 	type: "boolean",

--- a/packages/slave/modules/clusterio/impl.lua
+++ b/packages/slave/modules/clusterio/impl.lua
@@ -46,7 +46,7 @@ end
 
 
 -- This is not part of the add_remote_interface callback to ensure it is
--- available when the clusterio_lib mod is loaded.	The reason this is
+-- available when the clusterio_lib mod is loaded.  The reason this is
 -- neccessary is that on_init for newly added mods happen before on_load
 -- for existing mods, and the add_remote_interface callback is done in
 -- on_load.  See https://forums.factorio.com/viewtopic.php?f=25&t=81552 for

--- a/packages/slave/src/Instance.js
+++ b/packages/slave/src/Instance.js
@@ -302,7 +302,7 @@ class Instance extends libLink.Link {
 	async sendSaveListUpdate() {
 		libLink.messages.saveListUpdate.send(this, {
 			instance_id: this.id,
-			list: await Instance.listSaves(this.server.writePath("saves"), this._loadedSave),
+			list: await Instance.listSaves(this.path("saves"), this._loadedSave),
 		});
 	}
 
@@ -828,7 +828,7 @@ class Instance extends libLink.Link {
 
 	async listSavesRequestHandler(message) {
 		return {
-			list: await Instance.listSaves(this.server.writePath("saves"), this._loadedSave),
+			list: await Instance.listSaves(this.path("saves"), this._loadedSave),
 		};
 	}
 

--- a/packages/web_ui/src/components/LoadScenarioModal.jsx
+++ b/packages/web_ui/src/components/LoadScenarioModal.jsx
@@ -60,7 +60,7 @@ export default function LoadScenarioModal(props) {
 		}).then(() => {
 			setVisible(false);
 		}).catch(
-			notifyErrorHandler("Error creating save")
+			notifyErrorHandler("Error loading scenario")
 		).finally(() => {
 			setLoadingScenario(false);
 		});

--- a/test/lib/factorio/lines.js
+++ b/test/lib/factorio/lines.js
@@ -103,6 +103,36 @@ let testLines = new Map([
 		},
 	],
 	[
+		"2019-01-20 15:46:34 [KICK] User was kicked by <server>. Reason: unspecified.",
+		{
+			format: "date",
+			time: "2019-01-20 15:46:34",
+			type: "action",
+			action: "KICK",
+			message: "User was kicked by <server>. Reason: unspecified.",
+		},
+	],
+	[
+		"2019-01-20 15:47:50 [BAN] User was banned by <server>. Reason: unspecified.",
+		{
+			format: "date",
+			time: "2019-01-20 15:47:50",
+			type: "action",
+			action: "BAN",
+			message: "User was banned by <server>. Reason: unspecified.",
+		},
+	],
+	[
+		"2019-01-20 15:48:28 [UNBANNED] User was unbanned by <server>.",
+		{
+			format: "date",
+			time: "2019-01-20 15:48:28",
+			type: "action",
+			action: "UNBANNED",
+			message: "User was unbanned by <server>.",
+		},
+	],
+	[
 		"Error while running event level::on_nth_tick(1)",
 		{
 			format: "none",

--- a/test/mock.js
+++ b/test/mock.js
@@ -242,6 +242,7 @@ module.exports = {
 	MockLogger,
 	MockSocket,
 	MockConnector,
+	MockServer,
 	MockInstance,
 	MockSlave,
 	MockControl,

--- a/test/slave.js
+++ b/test/slave.js
@@ -13,31 +13,6 @@ describe("Slave testing", function() {
 		libConfig.InstanceConfig.finalize();
 	});
 
-	describe("class Instance", function() {
-		let instance;
-		before(async function() {
-			let instanceConfig = new libConfig.InstanceConfig("slave");
-			await instanceConfig.init();
-			instanceConfig.set("instance.name", "foo");
-			instance = new Instance({}, new libLink.VirtualConnector(), "dir", "factorioDir", instanceConfig);
-		});
-
-		describe(".name", function() {
-			it("should give the name of the instance", function() {
-				assert.equal(instance.name, "foo");
-			});
-		});
-
-		describe(".path()", function() {
-			it("should give the path when called without arguments", function() {
-				assert.equal(instance.path(), "dir");
-			});
-			it("should join path with arguments", function() {
-				assert.equal(instance.path("bar"), path.join("dir", "bar"));
-			});
-		});
-	});
-
 	describe("checkFilename()", function() {
 		it("should allow a basic name", function() {
 			Slave._checkFilename("file");

--- a/test/slave/Instance.js
+++ b/test/slave/Instance.js
@@ -1,0 +1,156 @@
+"use strict";
+const assert = require("assert").strict;
+const path = require("path");
+
+const libConfig = require("@clusterio/lib/config");
+const { wait } = require("@clusterio/lib/helpers");
+const Instance = require("@clusterio/slave/src/Instance");
+const { MockConnector, MockServer } = require("../mock");
+
+
+describe("class Instance", function() {
+	before(function() {
+		libConfig.InstanceConfig.finalize();
+	});
+
+	let instance;
+	let connector;
+	beforeEach(async function() {
+		let instanceConfig = new libConfig.InstanceConfig("slave");
+		await instanceConfig.init();
+		instanceConfig.set("instance.name", "foo");
+		connector = new MockConnector();
+		instance = new Instance({}, connector, "dir", "factorioDir", instanceConfig);
+		instance.server = new MockServer();
+	});
+
+	describe(".name", function() {
+		it("should give the name of the instance", function() {
+			assert.equal(instance.name, "foo");
+		});
+	});
+
+	describe(".path()", function() {
+		it("should give the path when called without arguments", function() {
+			assert.equal(instance.path(), "dir");
+		});
+		it("should join path with arguments", function() {
+			assert.equal(instance.path("bar"), path.join("dir", "bar"));
+		});
+	});
+
+	describe("._recordPlayerJoin()", function() {
+		it("should add player to playersOnline", function() {
+			instance._recordPlayerJoin("player");
+			assert(instance.playersOnline.has("player"), "player was not added");
+		});
+
+		it("should create playerStats entry", function() {
+			assert(!instance.playerStats.has("player"));
+			instance._recordPlayerJoin("player");
+			assert(instance.playerStats.has("player"), "player was not added to stats");
+		});
+
+
+		it("should send player_event", function() {
+			instance._recordPlayerJoin("player");
+			assert.deepEqual(
+				connector.sentMessages[0],
+				{
+					seq: 1,
+					type: "player_event_event",
+					data: { type: "join", instance_id: instance.id, name: "player" },
+				},
+			);
+		});
+
+		it("should be idempotent", function() {
+			instance._recordPlayerJoin("player");
+			instance._recordPlayerJoin("player");
+			assert(instance.playersOnline.has("player"), "player was not added");
+			assert.equal(connector.sentMessages.length, 1);
+		});
+	});
+
+	describe("._recordPlayerLeave()", function() {
+		it("should remove player to playersOnline", function() {
+			instance._recordPlayerJoin("player");
+			instance._recordPlayerLeave("player");
+			assert(!instance.playersOnline.has("player"), "player was not removed");
+		});
+
+		it("should update playerStats", async function() {
+			instance._recordPlayerJoin("player");
+			await wait(10);
+			instance._recordPlayerLeave("player");
+			assert(instance.playerStats.has("player"), "playerStats record missing");
+			assert(instance.playerStats.get("player").onlineTimeMs > 0, "no onlineTimeMs recorded");
+		});
+
+		it("should send player_event", function() {
+			instance._recordPlayerJoin("player");
+			instance._recordPlayerLeave("player");
+			assert.deepEqual(
+				connector.sentMessages[1],
+				{
+					seq: 2,
+					type: "player_event_event",
+					data: { type: "leave", instance_id: instance.id, name: "player" },
+				},
+			);
+		});
+
+		it("should be idempotent", function() {
+			instance._recordPlayerJoin("player");
+			instance._recordPlayerLeave("player");
+			instance._recordPlayerLeave("player");
+			assert(!instance.playersOnline.has("player"), "player was not removed");
+			assert.equal(connector.sentMessages.length, 2);
+		});
+	});
+
+	describe("._checkOnlinePlayers()", function() {
+		it("should do nothing on empty server", async function() {
+			await instance._checkOnlinePlayers();
+			assert.equal(instance.server.rconCommands.length, 0, "commands were sent");
+			assert.equal(connector.sentMessages.length, 0, "messages were sent");
+		});
+
+		it("should do nothing on correct online presence", async function() {
+			instance.server.rconCommandResults.set("/players online", "Online Players (1):\n  player (online)\n");
+			instance.playersOnline.add("player");
+			await instance._checkOnlinePlayers();
+			assert.equal(connector.sentMessages.length, 0, "messages were sent");
+		});
+
+		it("should add missing players", async function() {
+			instance.server.rconCommandResults.set(
+				"/players online", "Online Players (2):\n  player (online)\n  foo (online)\n"
+			);
+			instance._recordPlayerJoin("player");
+			await instance._checkOnlinePlayers();
+			assert.deepEqual(
+				connector.sentMessages[1],
+				{
+					seq: 2,
+					type: "player_event_event",
+					data: { type: "join", instance_id: instance.id, name: "foo" },
+				},
+			);
+		});
+
+		it("should remove extra players", async function() {
+			instance.server.rconCommandResults.set("/players online", "Online Players (0):\n");
+			instance._recordPlayerJoin("player");
+			await instance._checkOnlinePlayers();
+			assert.deepEqual(
+				connector.sentMessages[1],
+				{
+					seq: 2,
+					type: "player_event_event",
+					data: { type: "leave", instance_id: instance.id, name: "player" },
+				},
+			);
+		});
+	});
+});


### PR DESCRIPTION
Adds a separate autosave pool for autosaves that have had players online since the last autosave. This also required some better tracking of player online status so that it would also work with save patching disabled, this is also paving the way for some per-player stats tracking in the future.