### PR TITLE
Per player statistics

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,10 +6,7 @@ module.exports = {
 	"env": {
 		"node": true,
 		"commonjs": true,
-		"es6": true,
-	},
-	"parserOptions": {
-		"ecmaVersion": 11,
+		"es2022": true,
 	},
 
 	"overrides": [

--- a/docs/managing-a-cluster.md
+++ b/docs/managing-a-cluster.md
@@ -50,6 +50,16 @@ Terminates the running Factorio server without giving it a chance to save or cle
 
 Note: This may cause loss of data.
 
+### Extract players from instance
+
+    ctl> instance extract-players <name>
+
+Creates a user account in the cluster for each player that has been online on the currently running save of the instance and sets the play time of that account on this instance to the online time recorded in the save.
+
+Useful when importing a save to a cluster.
+Note that the online time in a save is recorded differntly from how Clusterio records online time.
+Most notably Clusterio records wall clock time while the save time is recorded in ticks and this extraction of player time assumes the game runs at 60 ticks a second.
+
 
 ### Config management
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@clusterio/lib": "workspace:*",
     "@clusterio/master": "workspace:*",
     "@clusterio/slave": "workspace:*",
-    "eslint": "^7.25.0",
+    "eslint": "^8.18.0",
     "eslint-plugin-node": "^11.1.0",
     "express": "^4.16.2",
     "form-data": "^4.0.0",

--- a/packages/ctl/ctl.js
+++ b/packages/ctl/ctl.js
@@ -89,6 +89,8 @@ class Control extends libLink.Link {
 
 	async saveListUpdateEventHandler() { }
 
+	async userUpdateEventHandler() { }
+
 	async setLogSubscriptions({
 		all = false,
 		master = false,

--- a/packages/ctl/src/commands.js
+++ b/packages/ctl/src/commands.js
@@ -941,9 +941,59 @@ roleCommands.add(new libCommand.Command({
 
 const userCommands = new libCommand.CommandTree({ name: "user", alias: ["u"], description: "User management" });
 userCommands.add(new libCommand.Command({
-	definition: [["list", "l"], "List user in the cluster"],
+	definition: ["show <name>", "Show details for one user", (yargs) => {
+		yargs.positional("name", { decribe: "Name of user to show", type: "string" });
+		yargs.options({
+			"instance-stats": { describe: "include per-instance stats", nargs: 0, type: "boolean", default: false },
+		});
+	}],
+	handler: async function(args, control) {
+		let response = await libLink.messages.getUser.send(control, { name: args.name });
+		delete response["seq"];
+		Object.assign(response, response["player_stats"]);
+		delete response["player_stats"];
+		let instanceStats = response["instance_stats"];
+		delete response["instance_stats"];
+		print(asTable(Object.entries(response).map(([property, value]) => ({ property, value }))));
+
+		if (args.instanceStats) {
+			let instances = (await libLink.messages.listInstances.send(control)).list;
+			function instanceName(id) {
+				let instance = instances.find(i => i.id === id);
+				if (instance) {
+					return instance.name;
+				}
+				return "<deleted>";
+			}
+			for (let [id, playerInstanceStats] of instanceStats) {
+				print();
+				print(`Instance ${instanceName(id)} (${id}):`);
+				print(asTable(Object.entries(playerInstanceStats).map(([property, value]) => ({ property, value }))));
+			}
+		}
+	},
+}));
+
+userCommands.add(new libCommand.Command({
+	definition: [["list", "l"], "List user in the cluster", (yargs) => {
+		yargs.options({
+			"stats": { describe: "include user stats", nargs: 0, type: "boolean", default: false },
+			"attributes": { describe: "include admin/whitelisted/banned", nargs: 0, type: "boolean", default: false },
+		});
+	}],
 	handler: async function(args, control) {
 		let response = await libLink.messages.listUsers.send(control);
+		for (let user of response.list) {
+			if (args.stats) {
+				Object.assign(user, user["player_stats"]);
+			}
+			delete user["player_stats"];
+			if (!args.attributes) {
+				delete user["is_admin"];
+				delete user["is_whitelisted"];
+				delete user["is_banned"];
+			}
+		}
 		print(asTable(response.list));
 	},
 }));

--- a/packages/ctl/src/commands.js
+++ b/packages/ctl/src/commands.js
@@ -749,6 +749,19 @@ instanceCommands.add(new libCommand.Command({
 }));
 
 instanceCommands.add(new libCommand.Command({
+	definition: ["extract-players <instance>", "Extract players from running save into the cluster.", (yargs) => {
+		yargs.positional("instance", { describe: "Instance to extract players and play time from", type: "string" });
+	}],
+	handler: async function(args, control) {
+		let instanceId = await libCommand.resolveInstance(control, args.instance);
+		await control.setLogSubscriptions({ instance_ids: [instanceId] });
+		await libLink.messages.extractPlayers.send(control, {
+			instance_id: instanceId,
+		});
+	},
+}));
+
+instanceCommands.add(new libCommand.Command({
 	definition: ["start <instance>", "Start instance", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to start", type: "string" });
 		yargs.options({

--- a/packages/lib/PlayerStats.js
+++ b/packages/lib/PlayerStats.js
@@ -1,0 +1,84 @@
+"use strict";
+
+/**
+ * Stastics collected about a player.
+ * @alias module:lib/PlayerStats
+ */
+class PlayerStats {
+	/**
+	 * Count of the number of times this player has been seen joining this server.
+	 * @type {number}
+	 */
+	joinCount = 0;
+
+	/**
+	 * Time in ms this player has been seen online on this instance.
+	 * @type {number}
+	 */
+	onlineTimeMs = 0;
+
+	/**
+	 * Timestamp the player was last seen joining.
+	 * @type {Date=}
+	 */
+	lastJoinAt;
+
+	/**
+	 * Timestamp the player was last seen leaving.
+	 * @type {Date=}
+	 */
+	lastLeaveAt;
+
+	/**
+	 * Reason the player was last seen leaving with.
+	 * @type {string=}
+	 */
+	lastLeaveReason;
+
+	static jsonSchema = {
+		type: "object",
+		properties: {
+			"join_count": { type: "integer" },
+			"online_time_ms": { type: "number" },
+			"last_join_at": { type: "number" },
+			"last_leave_at": { type: "number" },
+			"last_leave_reason": { type: "string" },
+		},
+	};
+
+	constructor(json = {}) {
+		if (json["join_count"]) {
+			this.joinCount = json["join_count"];
+		}
+		if (json["online_time_ms"]) {
+			this.onlineTimeMs = json["online_time_ms"];
+		}
+		if (json["last_join_at"]) {
+			this.lastJoinAt = new Date(json["last_join_at"]);
+		}
+		if (json["last_leave_at"]) {
+			this.lastLeaveAt = new Date(json["last_leave_at"]);
+			this.lastLeaveReason = json["last_leave_reason"] || "quit";
+		}
+	}
+
+	toJSON() {
+		let json = {};
+		if (this.joinCount) {
+			json["join_count"] = this.joinCount;
+		}
+		if (this.onlineTimeMs) {
+			json["online_time_ms"] = this.onlineTimeMs;
+		}
+		if (this.lastJoinAt) {
+			json["last_join_at"] = this.lastJoinAt.getTime();
+		}
+		if (this.lastLeaveAt) {
+			json["last_leave_at"] = this.lastLeaveAt.getTime();
+			json["last_leave_reason"] = this.lastLeaveReason;
+		}
+		return json;
+	}
+}
+
+module.exports = PlayerStats;

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -3,6 +3,7 @@
 const libSchema = require("../schema");
 const libErrors = require("../errors");
 const { logger } = require("../logging");
+const PlayerStats = require("../PlayerStats");
 
 class MissingLinkHandlerError extends Error {
 	constructor(type, source, target) {
@@ -795,6 +796,14 @@ const userProperties = {
 	"is_whitelisted": { type: "boolean" },
 	"instances": { type: "array", items: { type: "integer" }},
 	"is_deleted": { type: "boolean" },
+	"player_stats": PlayerStats.jsonSchema,
+	"instance_stats": {
+		type: "array",
+		items: {
+			type: "array",
+			items: [{ type: "integer" }, PlayerStats.jsonSchema],
+		},
+	},
 };
 
 messages.getUser = new Request({
@@ -1325,6 +1334,7 @@ messages.playerEvent = new Event({
 		"type": { type: "string", enum: ["join", "leave"] },
 		"name": { type: "string" },
 		"reason": { type: "string" },
+		"stats": PlayerStats.jsonSchema,
 	},
 });
 

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -1284,10 +1284,12 @@ messages.playerEvent = new Event({
 	type: "player_event",
 	links: ["instance-slave", "slave-master"],
 	forwardTo: "master",
+	eventRequired: ["instance_id", "type", "name"],
 	eventProperties: {
 		"instance_id": { type: "integer" },
 		"type": { type: "string", enum: ["join", "leave"] },
 		"name": { type: "string" },
+		"reason": { type: "string" },
 	},
 });
 

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -668,6 +668,13 @@ messages.exportData = new Request({
 	forwardTo: "instance",
 });
 
+messages.extractPlayers = new Request({
+	type: "extract_players",
+	links: ["control-master", "master-slave", "slave-instance"],
+	permission: "core.instance.extract_players",
+	forwardTo: "instance",
+});
+
 messages.stopInstance = new Request({
 	type: "stop_instance",
 	links: ["control-master", "master-slave", "slave-instance"],
@@ -1331,7 +1338,7 @@ messages.playerEvent = new Event({
 	eventRequired: ["instance_id", "type", "name"],
 	eventProperties: {
 		"instance_id": { type: "integer" },
-		"type": { type: "string", enum: ["join", "leave"] },
+		"type": { type: "string", enum: ["join", "leave", "import"] },
 		"name": { type: "string" },
 		"reason": { type: "string" },
 		"stats": PlayerStats.jsonSchema,

--- a/packages/lib/link/messages.js
+++ b/packages/lib/link/messages.js
@@ -786,6 +786,28 @@ messages.deleteRole = new Request({
 	},
 });
 
+const userRequired = ["name", "roles", "instances"];
+const userProperties = {
+	"name": { type: "string" },
+	"roles": { type: "array", items: { type: "integer" }},
+	"is_admin": { type: "boolean" },
+	"is_banned": { type: "boolean" },
+	"is_whitelisted": { type: "boolean" },
+	"instances": { type: "array", items: { type: "integer" }},
+	"is_deleted": { type: "boolean" },
+};
+
+messages.getUser = new Request({
+	type: "get_user",
+	links: ["control-master"],
+	permission: "core.user.get",
+	requestProperties: {
+		"name": { type: "string" },
+	},
+	responseRequired: userRequired,
+	responseProperties: userProperties,
+});
+
 messages.listUsers = new Request({
 	type: "list_users",
 	links: ["control-master"],
@@ -795,16 +817,22 @@ messages.listUsers = new Request({
 			type: "array",
 			items: {
 				additionalProperties: false,
-				required: ["name", "roles", "instances"],
-				properties: {
-					"name": { type: "string" },
-					"roles": { type: "array", items: { type: "integer" }},
-					"is_admin": { type: "boolean" },
-					"is_banned": { type: "boolean" },
-					"is_whitelisted": { type: "boolean" },
-					"instances": { type: "array", items: { type: "integer" }},
-				},
+				required: userRequired,
+				properties: userProperties,
 			},
+		},
+	},
+});
+
+messages.setUserSubscriptions = new Request({
+	type: "set_user_subscriptions",
+	links: ["control-master"],
+	permission: "core.user.subscribe",
+	requestProperties: {
+		"all": { type: "boolean" },
+		"names": {
+			type: "array",
+			items: { type: "string" },
 		},
 	},
 });
@@ -1216,6 +1244,13 @@ messages.saveListUpdate = new Event({
 		"instance_id": { type: "integer" },
 		"list": saveList,
 	},
+});
+
+messages.userUpdate = new Event({
+	type: "user_update",
+	links: ["master-control"],
+	eventRequired: userRequired,
+	eventProperties: userProperties,
 });
 
 messages.masterConnectionEvent = new Event({

--- a/packages/lib/plugin.js
+++ b/packages/lib/plugin.js
@@ -206,7 +206,7 @@ class BaseInstancePlugin {
 	 * Invoked when a player either joins or leaves the instance.
 	 *
 	 * @param {Object} event - Information about the event.
-	 * @param {string} event.type - Either "join" or "leave".
+	 * @param {string} event.type - Either "join", "leave" or "import".
 	 * @param {string} event.name - Name of the player that joined/left.
 	 * @param {string=} event.reason -
 	 *     Only present for type "leave". Reason for player leaving the
@@ -502,7 +502,7 @@ class BaseMasterPlugin {
 	 *
 	 * @param {Object} instance - the instance it occured on.
 	 * @param {Object} event - Information about the event.
-	 * @param {string} event.type - Either "join" or "leave".
+	 * @param {string} event.type - Either "join", "leave" or "import".
 	 * @param {string} event.name - Name of the player that joined/left.
 	 * @param {string=} event.reason -
 	 *     Only present for type "leave". Reason for player leaving the

--- a/packages/lib/plugin.js
+++ b/packages/lib/plugin.js
@@ -208,6 +208,9 @@ class BaseInstancePlugin {
 	 * @param {Object} event - Information about the event.
 	 * @param {string} event.type - Either "join" or "leave".
 	 * @param {string} event.name - Name of the player that joined/left.
+	 * @param {string=} event.reason -
+	 *     Only present for type "leave". Reason for player leaving the
+	 *     game, one of the possible reasons in defines.disconnect_reason.
 	 */
 	async onPlayerEvent(event) { }
 
@@ -500,6 +503,9 @@ class BaseMasterPlugin {
 	 * @param {Object} event - Information about the event.
 	 * @param {string} event.type - Either "join" or "leave".
 	 * @param {string} event.name - Name of the player that joined/left.
+	 * @param {string=} event.reason -
+	 *     Only present for type "leave". Reason for player leaving the
+	 *     game, one of the possible reasons in defines.disconnect_reason.
 	 */
 	async onPlayerEvent(instance, event) { }
 

--- a/packages/lib/plugin.js
+++ b/packages/lib/plugin.js
@@ -210,7 +210,8 @@ class BaseInstancePlugin {
 	 * @param {string} event.name - Name of the player that joined/left.
 	 * @param {string=} event.reason -
 	 *     Only present for type "leave". Reason for player leaving the
-	 *     game, one of the possible reasons in defines.disconnect_reason.
+	 *     game, one of the possible reasons in defines.disconnect_reason
+	 *     or "server_quit" if the server exits while the player is online.
 	 */
 	async onPlayerEvent(event) { }
 
@@ -505,7 +506,8 @@ class BaseMasterPlugin {
 	 * @param {string} event.name - Name of the player that joined/left.
 	 * @param {string=} event.reason -
 	 *     Only present for type "leave". Reason for player leaving the
-	 *     game, one of the possible reasons in defines.disconnect_reason.
+	 *     game, one of the possible reasons in defines.disconnect_reason
+	 *     or "server_quit" if the server exits while the player is online.
 	 */
 	async onPlayerEvent(instance, event) { }
 

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -476,6 +476,11 @@ definePermission({
 	description: "Export the the locale and icons from an instance and upload it to the master.",
 });
 definePermission({
+	name: "core.instance.extract_players",
+	title: "Extract player stats from running save",
+	description: "Run extraction to create a user for each player in the save and set the play time from the save.",
+});
+definePermission({
 	name: "core.instance.start",
 	title: "Start instance",
 	description: "Start instances.",

--- a/packages/lib/users.js
+++ b/packages/lib/users.js
@@ -195,6 +195,12 @@ class User {
 				}
 			}
 		}
+
+		/**
+		 * True if this user object has been removed from the cluster.
+		 * @type {boolean}
+		 */
+		this.isDeleted = false;
 	}
 
 	serialize() {
@@ -488,9 +494,19 @@ definePermission({
 });
 
 definePermission({
+	name: "core.user.get",
+	title: "Get user",
+	description: "Get the details of a user in the cluster.",
+});
+definePermission({
 	name: "core.user.list",
 	title: "List users",
 	description: "Get the full list of users in the cluster.",
+});
+definePermission({
+	name: "core.user.subscribe",
+	title: "Subscribe to user updates",
+	description: "Subscribe to be notified on updates on the details and status of users.",
 });
 definePermission({
 	name: "core.user.create",

--- a/packages/master/src/ControlConnection.js
+++ b/packages/master/src/ControlConnection.js
@@ -578,6 +578,8 @@ class ControlConnection extends BaseConnection {
 			is_banned: user.isBanned,
 			is_whitelisted: user.isWhitelisted,
 			instances: [...user.instances],
+			player_stats: user.playerStats,
+			instance_stats: [...user.instanceStats],
 		};
 	}
 
@@ -591,6 +593,7 @@ class ControlConnection extends BaseConnection {
 				is_banned: user.isBanned,
 				is_whitelisted: user.isWhitelisted,
 				instances: [...user.instances],
+				player_stats: user.playerStats,
 			});
 		}
 		return { list };
@@ -612,6 +615,8 @@ class ControlConnection extends BaseConnection {
 				is_banned: user.isBanned,
 				is_whitelisted: user.isWhitelisted,
 				instances: [...user.instances],
+				player_stats: user.playerStats,
+				instance_stats: [...user.instanceStats],
 				is_deleted: user.isDeleted,
 			});
 		}

--- a/packages/master/src/Master.js
+++ b/packages/master/src/Master.js
@@ -503,6 +503,16 @@ class Master {
 		}
 	}
 
+	userUpdated(user) {
+		for (let controlConnection of this.wsServer.controlConnections) {
+			if (controlConnection.connector.closing) {
+				continue;
+			}
+
+			controlConnection.userUpdated(user);
+		}
+	}
+
 	/**
 	 * Notify connected control clients under the given user that the
 	 * permissions for this user may have changed.

--- a/packages/master/src/SlaveConnection.js
+++ b/packages/master/src/SlaveConnection.js
@@ -186,6 +186,7 @@ class SlaveConnection extends BaseConnection {
 		} else if (type === "leave") {
 			user.notifyLeave(instance_id);
 		}
+		this._master.userUpdated(user);
 
 		let instance = this._master.instances.get(instance_id);
 		await libPlugin.invokeHook(this._master.plugins, "onPlayerEvent", instance, message.data);

--- a/packages/master/src/SlaveConnection.js
+++ b/packages/master/src/SlaveConnection.js
@@ -3,6 +3,7 @@ const libConfig = require("@clusterio/lib/config");
 const libLink = require("@clusterio/lib/link");
 const { logger } = require("@clusterio/lib/logging");
 const libPlugin = require("@clusterio/lib/plugin");
+const PlayerStats = require("@clusterio/lib/PlayerStats");
 
 const BaseConnection = require("./BaseConnection");
 
@@ -175,7 +176,7 @@ class SlaveConnection extends BaseConnection {
 	}
 
 	async playerEventEventHandler(message) {
-		let { instance_id, name, type } = message.data;
+		let { instance_id, name, type, stats } = message.data;
 		let user = this._master.userManager.users.get(name);
 		if (!user) {
 			user = this._master.userManager.createUser(name);
@@ -186,8 +187,11 @@ class SlaveConnection extends BaseConnection {
 		} else if (type === "leave") {
 			user.notifyLeave(instance_id);
 		}
+		user.instanceStats.set(instance_id, new PlayerStats(stats));
+		user.recalculatePlayerStats();
 		this._master.userUpdated(user);
 
+		delete message.data.stats;
 		let instance = this._master.instances.get(instance_id);
 		await libPlugin.invokeHook(this._master.plugins, "onPlayerEvent", instance, message.data);
 	}

--- a/packages/slave/modules/clusterio/impl.lua
+++ b/packages/slave/modules/clusterio/impl.lua
@@ -28,9 +28,18 @@ impl.events[defines.events.on_player_joined_game] = function(event)
 	api.send_json("player_event", { type = "join", name = player.name })
 end
 
+local disconnect_reason_name = {}
+for name, i in pairs(defines.disconnect_reason) do
+	disconnect_reason_name[i] = name
+end
+
 impl.events[defines.events.on_player_left_game] = function(event)
 	local player = game.players[event.player_index]
-	api.send_json("player_event", { type = "leave", name = player.name })
+	api.send_json("player_event", {
+		type = "leave",
+		name = player.name,
+		reason = disconnect_reason_name[event.reason],
+	})
 end
 
 -- Internal API

--- a/packages/slave/src/Instance.js
+++ b/packages/slave/src/Instance.js
@@ -342,6 +342,7 @@ class Instance extends libLink.Link {
 			instance_id: this.id,
 			type: "join",
 			name,
+			stats: stats.toJSON(),
 		};
 		libLink.messages.playerEvent.send(this, event);
 		libPlugin.invokeHook(this.plugins, "onPlayerEvent", event);
@@ -363,6 +364,7 @@ class Instance extends libLink.Link {
 			type: "leave",
 			name,
 			reason,
+			stats: stats.toJSON(),
 		};
 		libLink.messages.playerEvent.send(this, event);
 		libPlugin.invokeHook(this.plugins, "onPlayerEvent", event);
@@ -483,7 +485,7 @@ class Instance extends libLink.Link {
 			pluginInstance.onExit();
 		}
 
-		for (let player of left) {
+		for (let player of this.playersOnline) {
 			this._recordPlayerLeave(player, "server_quit");
 		}
 		this._saveStats().catch(err => this.logger.error(`Error saving stats:\n${err.stack}`));

--- a/packages/slave/src/Instance.js
+++ b/packages/slave/src/Instance.js
@@ -483,6 +483,9 @@ class Instance extends libLink.Link {
 			pluginInstance.onExit();
 		}
 
+		for (let player of left) {
+			this._recordPlayerLeave(player, "server_quit");
+		}
 		this._saveStats().catch(err => this.logger.error(`Error saving stats:\n${err.stack}`));
 	}
 

--- a/packages/web_ui/src/components/InstanceViewPage.jsx
+++ b/packages/web_ui/src/components/InstanceViewPage.jsx
@@ -100,6 +100,13 @@ export default function InstanceViewPage(props) {
 			label: "Export data",
 		});
 	}
+	if (account.hasPermission("core.instance.extract_players")) {
+		instanceButtonMenuItems.push({
+			disabled: instance["status"] !== "running",
+			key: "extract",
+			label: "Extract players from save",
+		});
+	}
 	if (account.hasPermission("core.instance.kill")) {
 		instanceButtonMenuItems.push({
 			disabled: ["unknown", "unassigned", "stopped"].includes(instance["status"]),
@@ -132,6 +139,11 @@ export default function InstanceViewPage(props) {
 					setExportingData(false);
 				});
 
+			} else if (key === "extract") {
+				libLink.messages.extractPlayers.send(
+					control, { instance_id: instanceId }
+				).catch(notifyErrorHandler("Error extracting player data"));
+
 			} else if (key === "kill") {
 				libLink.messages.killInstance.send(
 					control, { instance_id: instanceId }
@@ -162,6 +174,7 @@ export default function InstanceViewPage(props) {
 		{account.hasPermission("core.instance.load_scenario") && <LoadScenarioModal instance={instance} />}
 		{account.hasAnyPermission(
 			"core.instance.export_data",
+			"core.instance.extract_players",
 			"core.instance.kill",
 			"core.instance.delete",
 		) && <Dropdown placement="bottomRight" trigger={["click"]} overlay={instanceButtonsMenu}>

--- a/packages/web_ui/src/components/UserViewPage.jsx
+++ b/packages/web_ui/src/components/UserViewPage.jsx
@@ -10,30 +10,8 @@ import ControlContext from "./ControlContext";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
 import { notifyErrorHandler } from "../util/notify";
+import { useUser } from "../model/user";
 
-
-function useUser(name) {
-	let control = useContext(ControlContext);
-	let [user, setUser] = useState({ loading: true });
-
-	function updateUser() {
-		// XXX optimize by requesting only the user in question
-		libLink.messages.listUsers.send(control).then(result => {
-			let match = result.list.find(u => u.name === name);
-			if (!match) {
-				setUser({ missing: true });
-			} else {
-				setUser({ ...match, present: true });
-			}
-		});
-	}
-
-	useEffect(() => {
-		updateUser();
-	}, [name]);
-
-	return [user, updateUser];
-}
 
 export default function UserViewPage() {
 	let params = useParams();

--- a/packages/web_ui/src/components/UsersPage.jsx
+++ b/packages/web_ui/src/components/UsersPage.jsx
@@ -9,6 +9,7 @@ import ControlContext from "./ControlContext";
 import { notifyErrorHandler } from "../util/notify";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
+import { useUserList } from "../model/user";
 
 const strcmp = new Intl.Collator(undefined, { numerice: "true", sensitivity: "base" }).compare;
 
@@ -57,14 +58,11 @@ export default function UsersPage() {
 	let account = useAccount();
 	let control = useContext(ControlContext);
 	let history = useHistory();
+	let [userList] = useUserList();
 
-	let [users, setUsers] = useState([]);
 	let [roles, setRoles] = useState(new Map());
 
 	useEffect(() => {
-		libLink.messages.listUsers.send(control).then(result => {
-			setUsers(result["list"]);
-		}).catch(notifyErrorHandler("Error fetching user list"));
 		libLink.messages.listRoles.send(control).then(result => {
 			setRoles(new Map(result["list"].map(role => [role["id"], role])));
 		}).catch(() => {
@@ -113,7 +111,7 @@ export default function UsersPage() {
 					responsive: ["lg"],
 				},
 			]}
-			dataSource={users}
+			dataSource={userList}
 			pagination={false}
 			rowKey={user => user["name"]}
 			onRow={(user, rowIndex) => ({

--- a/packages/web_ui/src/model/user.jsx
+++ b/packages/web_ui/src/model/user.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useContext, useState } from "react";
+import ControlContext from "../components/ControlContext";
+
+import { libLink, libLogging } from "@clusterio/lib";
+const { logger } = libLogging;
+
+
+export function useUser(name) {
+	let control = useContext(ControlContext);
+	let [user, setUser] = useState({ loading: true });
+
+	function updateUser() {
+		libLink.messages.getUser.send(control, { name }).then(result => {
+			setUser({ ...result, present: true });
+		}).catch(err => {
+			logger.error(`Failed to get user: ${err}`);
+			setUser({ missing: true });
+		});
+
+	}
+
+	useEffect(() => {
+		if (typeof name !== "string") {
+			setUser({ missing: true });
+			return undefined;
+		}
+		updateUser();
+
+		function updateHandler(newUser) {
+			setUser({ ...newUser, present: true });
+		}
+
+		control.onUserUpdate(name, updateHandler);
+		return () => {
+			control.offUserUpdate(name, updateHandler);
+		};
+	}, [name]);
+
+	return [user, updateUser];
+}
+
+export function useUserList() {
+	let control = useContext(ControlContext);
+	let [userList, setUserList] = useState([]);
+
+	function updateUserList() {
+		libLink.messages.listUsers.send(control).then(result => {
+			setUserList(result.list);
+		}).catch(err => {
+			logger.error(`Failed to list users:\n${err}`);
+		});
+	}
+
+	useEffect(() => {
+		updateUserList();
+
+		function updateHandler(newUser) {
+			setUserList(oldList => {
+				let newList = oldList.concat();
+				let index = newList.findIndex(u => u.name === newUser.name);
+				if (!newUser.is_deleted) {
+					if (index !== -1) {
+						newList[index] = newUser;
+					} else {
+						newList.push(newUser);
+					}
+				} else if (index !== -1) {
+					newList.splice(index, 1);
+				}
+				return newList;
+			});
+		}
+
+		control.onUserUpdate(null, updateHandler);
+		return () => {
+			control.offUserUpdate(null, updateHandler);
+		};
+	}, []);
+
+	return [userList];
+}

--- a/packages/web_ui/src/util/time_format.jsx
+++ b/packages/web_ui/src/util/time_format.jsx
@@ -1,0 +1,33 @@
+const formatSecond = new Intl.NumberFormat(undefined, { style: "unit", unit: "second", unitDisplay: "narrow" }).format;
+const formatMinute = new Intl.NumberFormat(undefined, { style: "unit", unit: "minute", unitDisplay: "narrow" }).format;
+const formatHour = new Intl.NumberFormat(undefined, { style: "unit", unit: "hour", unitDisplay: "narrow" }).format;
+const formatDay = new Intl.NumberFormat(undefined, { style: "unit", unit: "day", unitDisplay: "narrow" }).format;
+
+/**
+ * Formats a duration of time in milliseconds to something human readable.
+ * @param {number} ms - Duration to formatDuration
+ * @param {object=} options - Options to control the formatting.
+ * @returns {string} human readable representation of the duration.
+ */
+export function formatDuration(ms, options = {}) {
+	let result = "";
+	if (ms < 0) {
+		result += "-";
+		ms = -ms;
+	}
+
+	if (ms > 86400e3) {
+		result += formatDay(Math.floor(ms / 86400e3));
+		ms %= 86400e3;
+	}
+	if (ms > 3600e3) {
+		result += formatHour(Math.floor(ms / 3600e3));
+		ms %= 3600e3;
+	}
+	if (ms > 60e3) {
+		result += formatMinute(Math.floor(ms / 60e3));
+		ms %= 60e3;
+	}
+	result += formatSecond(Math.round(ms / 1e3));
+	return result;
+}

--- a/packages/web_ui/webpack.common.js
+++ b/packages/web_ui/webpack.common.js
@@ -98,9 +98,10 @@ module.exports = (env = {}) => ({
 			// Required for winston
 			"util": require.resolve("util/"),
 			"os": require.resolve("os-browserify/browser"),
+			"buffer": require.resolve("buffer/"),
 
 			// Required for zlib
-			"assert": require.resolve("assert"),
+			"assert": require.resolve("assert/"),
 			"stream": require.resolve("stream-browserify"),
 
 			"events": require.resolve("events/"),

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -483,6 +483,7 @@ describe("Integration of Clusterio", function() {
 			let lists = ["admin", "whitelisted", "banned"];
 			it("should add and remove the given user to the list", async function() {
 				slowTest(this);
+				getControl().userUpdates = [];
 				await libLink.messages.createUser.send(getControl(), { name: "list_test" });
 				let user = (await getUsers()).get("list_test");
 				for (let list of lists) {
@@ -499,6 +500,7 @@ describe("Integration of Clusterio", function() {
 				for (let list of lists) {
 					assert.equal(user[`is_${list}`], false, `unexpected ${list} status`);
 				}
+				assert.equal(getControl().userUpdates.length, 7);
 			});
 			it("should not create the user if not instructed to", async function() {
 				slowTest(this);
@@ -512,11 +514,13 @@ describe("Integration of Clusterio", function() {
 			});
 			it("should create the user if instructed to", async function() {
 				slowTest(this);
+				getControl().userUpdates = [];
 				for (let list of lists) {
 					await execCtl(`user set-${list} --create test_create_${list}`);
 					let user = (await getUsers()).get(`test_create_${list}`);
 					assert.equal(user && user[`is_${list}`], true, `user not created and added to ${list}`);
 				}
+				assert.equal(getControl().userUpdates.length, 3);
 			});
 		});
 
@@ -868,28 +872,36 @@ describe("Integration of Clusterio", function() {
 
 		describe("user create", function() {
 			it("should create the given user", async function() {
+				getControl().userUpdates = [];
 				await execCtl("user create temp");
 				let result = await libLink.messages.listUsers.send(getControl());
 				let tempUser = result.list.find(user => user.name === "temp");
 				assert(tempUser, "user was not created");
+				assert.equal(getControl().userUpdates.length, 1);
+				assert.equal(getControl().userUpdates[0].name, "temp");
 			});
 		});
 
 		describe("user set-roles", function() {
 			it("should set the roles on the user", async function() {
+				getControl().userUpdates = [];
 				await execCtl('user set-roles temp "Cluster Admin"');
 				let result = await libLink.messages.listUsers.send(getControl());
 				let tempUser = result.list.find(user => user.name === "temp");
 				assert.deepEqual(tempUser.roles, [0]);
+				assert.equal(getControl().userUpdates.length, 1);
 			});
 		});
 
 		describe("user delete", function() {
 			it("should delete the user", async function() {
+				getControl().userUpdates = [];
 				await execCtl("user delete temp");
 				let result = await libLink.messages.listUsers.send(getControl());
 				let tempUser = result.list.find(user => user.name === "temp");
 				assert(!tempUser, "user was note deleted");
+				assert.equal(getControl().userUpdates.length, 1);
+				assert.equal(getControl().userUpdates[0].is_deleted, true);
 			});
 		});
 	});

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -524,6 +524,13 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 
+		describe("instance extract-players", function() {
+			it("runs", async function() {
+				slowTest(this);
+				await execCtl("instance extract-players test");
+			});
+		});
+
 		describe("instance stop", function() {
 			it("stops the instance", async function() {
 				slowTest(this);

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -28,6 +28,7 @@ class TestControl extends libLink.Link {
 		this.slaveUpdates = [];
 		this.instanceUpdates = [];
 		this.saveListUpdates = [];
+		this.userUpdates = [];
 
 		this.connector.on("connect", () => {
 			libLink.messages.setSlaveSubscriptions.send(
@@ -39,6 +40,9 @@ class TestControl extends libLink.Link {
 			libLink.messages.setSaveListSubscriptions.send(
 				this, { all: true, instance_ids: [] }
 			).catch(err => logger.error(`Error setting save list subscriptions:\n${err.stack}`));
+			libLink.messages.setUserSubscriptions.send(
+				this, { all: true, names: [] }
+			).catch(err => logger.error(`Error setting user subscriptions:\n${err.stack}`));
 		});
 	}
 
@@ -61,6 +65,10 @@ class TestControl extends libLink.Link {
 
 	async saveListUpdateEventHandler(message) {
 		this.saveListUpdates.push(message.data);
+	}
+
+	async userUpdateEventHandler(message) {
+		this.userUpdates.push(message.data);
 	}
 
 	async logMessageEventHandler() { }

--- a/test/slave/Instance.js
+++ b/test/slave/Instance.js
@@ -54,18 +54,28 @@ describe("class Instance", function() {
 
 		it("should send player_event", function() {
 			instance._recordPlayerJoin("player");
+			let stats = instance.playerStats.get("player");
 			assert.deepEqual(
 				connector.sentMessages[0],
 				{
 					seq: 1,
 					type: "player_event_event",
-					data: { type: "join", instance_id: instance.id, name: "player" },
+					data: {
+						type: "join",
+						instance_id: instance.id,
+						name: "player",
+						stats: {
+							join_count: 1,
+							last_join_at: stats.lastJoinAt.getTime(),
+						},
+					},
 				},
 			);
 		});
 
-		it("should be idempotent", function() {
+		it("should be idempotent", async function() {
 			instance._recordPlayerJoin("player");
+			await wait(10);
 			instance._recordPlayerJoin("player");
 			assert(instance.playersOnline.has("player"), "player was not added");
 			assert.equal(connector.sentMessages.length, 1);
@@ -73,8 +83,9 @@ describe("class Instance", function() {
 	});
 
 	describe("._recordPlayerLeave()", function() {
-		it("should remove player to playersOnline", function() {
+		it("should remove player to playersOnline", async function() {
 			instance._recordPlayerJoin("player");
+			await wait(10);
 			instance._recordPlayerLeave("player");
 			assert(!instance.playersOnline.has("player"), "player was not removed");
 		});
@@ -87,22 +98,38 @@ describe("class Instance", function() {
 			assert(instance.playerStats.get("player").onlineTimeMs > 0, "no onlineTimeMs recorded");
 		});
 
-		it("should send player_event", function() {
+		it("should send player_event", async function() {
 			instance._recordPlayerJoin("player");
+			await wait(10);
 			instance._recordPlayerLeave("player", "quit");
+			let stats = instance.playerStats.get("player");
 			assert.deepEqual(
 				connector.sentMessages[1],
 				{
 					seq: 2,
 					type: "player_event_event",
-					data: { type: "leave", instance_id: instance.id, name: "player", reason: "quit" },
+					data: {
+						type: "leave",
+						instance_id: instance.id,
+						name: "player",
+						reason: "quit",
+						stats: {
+							join_count: 1,
+							online_time_ms: stats.onlineTimeMs,
+							last_join_at: stats.lastJoinAt.getTime(),
+							last_leave_at: stats.lastLeaveAt.getTime(),
+							last_leave_reason: "quit",
+						},
+					},
 				},
 			);
 		});
 
-		it("should be idempotent", function() {
+		it("should be idempotent", async function() {
 			instance._recordPlayerJoin("player");
+			await wait(10);
 			instance._recordPlayerLeave("player", "quit");
+			await wait(10);
 			instance._recordPlayerLeave("player", "quit");
 			assert(!instance.playersOnline.has("player"), "player was not removed");
 			assert.equal(connector.sentMessages.length, 2);
@@ -129,12 +156,21 @@ describe("class Instance", function() {
 			);
 			instance._recordPlayerJoin("player");
 			await instance._checkOnlinePlayers();
+			let stats = instance.playerStats.get("foo");
 			assert.deepEqual(
 				connector.sentMessages[1],
 				{
 					seq: 2,
 					type: "player_event_event",
-					data: { type: "join", instance_id: instance.id, name: "foo" },
+					data: {
+						type: "join",
+						instance_id: instance.id,
+						name: "foo",
+						stats: {
+							join_count: 1,
+							last_join_at: stats.lastJoinAt.getTime(),
+						},
+					},
 				},
 			);
 		});
@@ -142,13 +178,27 @@ describe("class Instance", function() {
 		it("should remove extra players", async function() {
 			instance.server.rconCommandResults.set("/players online", "Online Players (0):\n");
 			instance._recordPlayerJoin("player");
+			await wait(10);
 			await instance._checkOnlinePlayers();
+			let stats = instance.playerStats.get("player");
 			assert.deepEqual(
 				connector.sentMessages[1],
 				{
 					seq: 2,
 					type: "player_event_event",
-					data: { type: "leave", instance_id: instance.id, name: "player", reason: "quit" },
+					data: {
+						type: "leave",
+						instance_id: instance.id,
+						name: "player",
+						reason: "quit",
+						stats: {
+							join_count: 1,
+							online_time_ms: stats.onlineTimeMs,
+							last_join_at: stats.lastJoinAt.getTime(),
+							last_leave_at: stats.lastLeaveAt.getTime(),
+							last_leave_reason: "quit",
+						},
+					},
 				},
 			);
 		});

--- a/test/slave/Instance.js
+++ b/test/slave/Instance.js
@@ -89,21 +89,21 @@ describe("class Instance", function() {
 
 		it("should send player_event", function() {
 			instance._recordPlayerJoin("player");
-			instance._recordPlayerLeave("player");
+			instance._recordPlayerLeave("player", "quit");
 			assert.deepEqual(
 				connector.sentMessages[1],
 				{
 					seq: 2,
 					type: "player_event_event",
-					data: { type: "leave", instance_id: instance.id, name: "player" },
+					data: { type: "leave", instance_id: instance.id, name: "player", reason: "quit" },
 				},
 			);
 		});
 
 		it("should be idempotent", function() {
 			instance._recordPlayerJoin("player");
-			instance._recordPlayerLeave("player");
-			instance._recordPlayerLeave("player");
+			instance._recordPlayerLeave("player", "quit");
+			instance._recordPlayerLeave("player", "quit");
 			assert(!instance.playersOnline.has("player"), "player was not removed");
 			assert.equal(connector.sentMessages.length, 2);
 		});
@@ -148,7 +148,7 @@ describe("class Instance", function() {
 				{
 					seq: 2,
 					type: "player_event_event",
-					data: { type: "leave", instance_id: instance.id, name: "player" },
+					data: { type: "leave", instance_id: instance.id, name: "player", reason: "quit" },
 				},
 			);
 		});


### PR DESCRIPTION
Add per player stat tracking on instances that is sent to the master server whenever it updates. Currently implements online time, join count, last join timestamp, last leave timestamp and last leave reason. And a command to import online time data from the running save.

Implements live updates for the user list to make the stats update in real time in the web interface.