### PR TITLE
Installer fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Otherwise see below for OS specific instructions.
         wget -qO - https://deb.nodesource.com/setup_14.x | sudo -E bash -
         sudo apt install nodejs
 
-2.  Create a new directory and run the Clusterio installer:
+2.  Log in as the user you wish to install Clusterio as (do not use root), and then create a new directory and run the Clusterio installer:
 
         mkdir clusterio
         cd clusterio

--- a/README.md
+++ b/README.md
@@ -113,14 +113,7 @@ Otherwise see below for OS specific instructions.
 
     Make sure to note down the admin authentication token it provides at the end as you will need it later.
 
-3.  If you chose to use local factorio directory for the Factorio installation then download the headless build of Factorio and unpack it:
-
-        wget -O factorio.tar.xz https://www.factorio.com/get-download/latest/headless/linux64
-        tar -xf factorio.tar.xz
-
-    To specify a version of Factorio to download replace "latest" in the URL with a version number like "1.0.0".
-
-4.  Optionally copy the generated systemd service files in `systemd` folder to `/etc/systemd/system/`.
+3.  Optionally copy the generated systemd service files in `systemd` folder to `/etc/systemd/system/`.
 
 
 **Ubuntu with Docker**

--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -225,6 +225,17 @@ async function installClusterio(mode, plugins) {
 	}
 }
 
+async function groupIdToName(gid) {
+	try {
+		let exec = util.promisify(child_process.exec);
+		let { stdout } = await exec(`getent group ${gid}`);
+		return stdout.split(":")[0];
+	} catch (err) {
+		logger.warn(`getent group ${gid} failed: ${err.message}`);
+		return gid;
+	}
+}
+
 async function writeScripts(mode) {
 	if (["standalone", "master"].includes(mode)) {
 		if (process.platform === "win32") {
@@ -245,7 +256,7 @@ Description=Clusterio Master
 
 [Service]
 User=${os.userInfo().username}
-Group=nogroup
+Group=${await groupIdToName(os.userInfo().gid)}
 WorkingDirectory=${process.cwd()}
 KillMode=mixed
 KillSignal=SIGINT
@@ -276,7 +287,7 @@ Description=Clusterio Slave
 
 [Service]
 User=${os.userInfo().username}
-Group=nogroup
+Group=${await groupIdToName(os.userInfo().gid)}
 WorkingDirectory=${process.cwd()}
 KillMode=mixed
 KillSignal=SIGINT


### PR DESCRIPTION
I've noticed people installing and running Clusterio as root so I've added an error when you try to do that with the install. Should hopefully discourage people from doing it in the future. Who knows.

Also changes the group in the generated systemd file to work on more systems, specifically those without nogroup as a group.