### PR TITLE
Shut up Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsonwebtoken": "^8.2.1",
     "jszip": "^3.2.2",
     "mocha": "^9.2.2",
-    "node-forge": "^0.10.0",
+    "node-forge": "^1.3.1",
     "nyc": "^15.1.0",
     "phin": "^3.5.1"
   }


### PR DESCRIPTION
If only the bot was clever enough to see that node-forge is only used
for a test that has no user input it might have had the foresight to
realize that crying wolf about completely irrelevant security issues
will only lead to legitimate issues being ignored in the future. But
alas, the AI overlords are not taking over any time soon.