### PR TITLE
Fix issue with research_sync plugin

### DIFF
--- a/plugins/research_sync/instance.ts
+++ b/plugins/research_sync/instance.ts
@@ -3,7 +3,7 @@ import {
 	ContributionEvent,
 	ProgressEvent,
 	FinishedEvent,
-	Technology,
+	TechnologySync,
 	SyncTechnologiesRequest,
 } from "./messages";
 
@@ -73,7 +73,7 @@ export class InstancePlugin extends lib.BaseInstancePlugin {
 		let techsToSend = [];
 		let instanceTechs = new Map();
 		for (let tech of JSON.parse(dumpJson)) {
-			techsToSend.push(new Technology(
+			techsToSend.push(new TechnologySync(
 				tech.name,
 				tech.level,
 				tech.progress || null,

--- a/plugins/research_sync/messages.ts
+++ b/plugins/research_sync/messages.ts
@@ -88,7 +88,7 @@ export class FinishedEvent {
 	}
 }
 
-export class Technology {
+export class TechnologySync {
 	constructor(
 		public name: string,
 		public level: number,
@@ -107,7 +107,7 @@ export class Technology {
 		return [this.name, this.level, this.progress, this.researched];
 	}
 
-	static fromJSON(json: Static<typeof Technology.jsonSchema>): Technology {
+	static fromJSON(json: Static<typeof TechnologySync.jsonSchema>): TechnologySync {
 		return new this(json[0], json[1], json[2], json[3]);
 	}
 }
@@ -120,18 +120,18 @@ export class SyncTechnologiesRequest {
 	static plugin = "research_sync" as const;
 
 	constructor(
-		public technologies: Technology[]
+		public technologies: TechnologySync[]
 	) {
 	}
 
-	static jsonSchema = Type.Array(Technology.jsonSchema);
+	static jsonSchema = Type.Array(TechnologySync.jsonSchema);
 	toJSON() {
 		return this.technologies;
 	}
 
 	static fromJSON(json: Static<typeof SyncTechnologiesRequest.jsonSchema>): SyncTechnologiesRequest {
-		return new this(json.map(e => Technology.fromJSON(e)));
+		return new this(json.map(e => TechnologySync.fromJSON(e)));
 	}
 
-	static Response = lib.jsonArray(Technology);
+	static Response = lib.jsonArray(TechnologySync);
 }


### PR DESCRIPTION
Fix type issues when loading technologies and broadcasting progress.
Locally tested;
Researches sync when adding a new instance.
Was able to research on one instance and see progress from another instance while searching a second or same research.
No more errors in logs.
