### PR TITLE
Add module export detection

### DIFF
--- a/packages/host/src/patch.ts
+++ b/packages/host/src/patch.ts
@@ -50,7 +50,7 @@ export class SaveModule {
 					if (relativePath == "module_exports.lua") {
 						this.files.set(
 							`modules/${this.info.name}.lua`,
-							Buffer.from(`return require("${savePath}")`, "utf-8")
+							Buffer.from(`return require("modules/${this.info.name}/module_exports")`, "utf-8")
 						);
 					}
 

--- a/packages/host/src/patch.ts
+++ b/packages/host/src/patch.ts
@@ -47,6 +47,12 @@ export class SaveModule {
 				if (entry.isFile()) {
 					let savePath = SaveModule.moduleFilePath(relativePath, this.info.name);
 					this.files.set(savePath, await fs.readFile(fsPath));
+					if (relativePath == "module_exports.lua") {
+						this.files.set(
+							`modules/${this.info.name}.lua`,
+							Buffer.from(`return require("${savePath}")`, "utf-8")
+						);
+					}
 
 				} else if (entry.isDirectory()) {
 					dirs.push([fsPath, relativePath]);

--- a/test/file/modules/test/module_exports.lua
+++ b/test/file/modules/test/module_exports.lua
@@ -1,0 +1,1 @@
+-- module_exports

--- a/test/host/patch.js
+++ b/test/host/patch.js
@@ -28,6 +28,29 @@ describe("host/patch", function() {
 				}
 			});
 		});
+
+		describe("loadFiles()", async function() {
+			const referenceFiles = new Map([
+				["modules/test/test.lua", "-- test\n"],
+				["modules/test/module_exports.lua", "-- module_exports\n"],
+				["locale/en/test.cfg", "module-test=A Test\n"],
+				["local/en/test-locale.cfg", "module-test-locale=Test Locale\n"],
+				["modules/test.lua", "return require(\"modules/test/module_exports\")"]
+			]);
+			const testModule = new SaveModule(new lib.ModuleInfo("test", "1.0.0"));
+			await testModule.loadFiles("test/file/modules/test");
+
+			it("Should read the contents of all files in a module", function() {
+				assert.equal(testModule.files.size, referenceFiles.size);
+				for (let [relativePath, contents] of referenceFiles) {
+					if (!testModule.files.has(relativePath)) {
+						assert.fail(`Module is missing file: ${relativePath}`);
+					} else {
+						assert.equal(testModule.files.get(relativePath), contents);
+					}
+				}
+			});
+		});
 	});
 
 	describe("generateLoader()", function() {

--- a/test/host/patch.js
+++ b/test/host/patch.js
@@ -29,24 +29,25 @@ describe("host/patch", function() {
 			});
 		});
 
-		describe("loadFiles()", async function() {
+		describe("loadFiles()", function() {
+			const testModule = new patch.SaveModule(new lib.ModuleInfo("test", "1.0.0"));
 			const referenceFiles = new Map([
 				["modules/test/test.lua", "-- test\n"],
 				["modules/test/module_exports.lua", "-- module_exports\n"],
 				["locale/en/test.cfg", "module-test=A Test\n"],
-				["local/en/test-locale.cfg", "module-test-locale=Test Locale\n"],
-				["modules/test.lua", "return require(\"modules/test/module_exports\")"]
+				["locale/en/test-locale.cfg", "module-test-locale=Test Locale\n"],
+				["modules/test.lua", "return require(\"modules/test/module_exports\")"],
 			]);
-			const testModule = new SaveModule(new lib.ModuleInfo("test", "1.0.0"));
-			await testModule.loadFiles("test/file/modules/test");
-
+			before(async function() {
+				await testModule.loadFiles("test/file/modules/test");
+			});
 			it("Should read the contents of all files in a module", function() {
 				assert.equal(testModule.files.size, referenceFiles.size);
 				for (let [relativePath, contents] of referenceFiles) {
 					if (!testModule.files.has(relativePath)) {
 						assert.fail(`Module is missing file: ${relativePath}`);
 					} else {
-						assert.equal(testModule.files.get(relativePath), contents);
+						assert.equal(testModule.files.get(relativePath).toString("utf-8"), contents);
 					}
 				}
 			});


### PR DESCRIPTION
Allows modules to include a `module_exports.lua` file in their root which will cause the file `save/modules/module_name.lua` to be generated pointing to the exports file.

The justification for this is to encourage code reuse between modules by explicitly stating their exports and making them easy to import in another module. If `myPlugin` in includes an export file, then other modules can include it through `require("modules/myPlugin")`.

The file name `module_exports.lua` was selected to not conflict with `api.lua` of the clustorio lib and to match the style of commonjs modules with `module.exports =`.