### PR TITLE
Refactor/subscriptions - Create a generalized event subscription class

### DIFF
--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -1,4 +1,5 @@
 import type WsServerConnector from "./WsServerConnector";
+import type { HostInfo } from "./HostConnection";
 
 import events from "events";
 import fs from "fs-extra";

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -241,12 +241,12 @@ export default class Controller {
 		}
 
 		// Handle subscriptions for all internal properties
-		this.subscriptions.handle<lib.HostUpdateEvent>(lib.HostUpdateEvent, event => event.update.id);
-		this.subscriptions.handle<lib.InstanceDetailsUpdateEvent>(lib.InstanceDetailsUpdateEvent, event => event.details.id);
-		this.subscriptions.handle<lib.InstanceSaveListUpdateEvent>(lib.InstanceSaveListUpdateEvent, event => event.instanceId);
-		this.subscriptions.handle<lib.ModPackUpdateEvent>(lib.ModPackUpdateEvent, event => event.modPack.id!);
-		this.subscriptions.handle<lib.ModUpdateEvent>(lib.ModUpdateEvent);
-		this.subscriptions.handle<lib.UserUpdateEvent>(lib.UserUpdateEvent, event => event.user.name);
+		this.subscriptions.handle(lib.HostUpdateEvent);
+		this.subscriptions.handle(lib.InstanceDetailsUpdateEvent);
+		this.subscriptions.handle(lib.InstanceSaveListUpdateEvent);
+		this.subscriptions.handle(lib.ModPackUpdateEvent);
+		this.subscriptions.handle(lib.ModUpdateEvent);
+		this.subscriptions.handle(lib.UserUpdateEvent);
 
 		// Load plugins
 		await this.loadPlugins();

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -74,6 +74,9 @@ export default class Controller {
 	wsServer: WsServer;
 	debugEvents: events.EventEmitter = new events.EventEmitter();
 	private _events: events.EventEmitter = new events.EventEmitter();
+
+	/** Event subscription controller */
+	subscriptions: lib.SubscriptionController;
 	
 	// Possible states are new, starting, running, stopping, stopped
 	private _state: string = "new";
@@ -106,6 +109,7 @@ export default class Controller {
 
 		this.wsServer = new WsServer(this);
 		this.userManager = new UserManager(this.config);
+		this.subscriptions = new lib.SubscriptionController(this);
 	}
 
 	async start(args: ControllerArgs) {
@@ -235,6 +239,14 @@ export default class Controller {
 			}
 			this.app.locals.mainBundle = manifest["main.js"] || "no_web_build";
 		}
+
+		// Handle subscriptions for all internal properties
+		this.subscriptions.handle<lib.HostUpdateEvent>(lib.HostUpdateEvent, undefined, event => event.update.id);
+		this.subscriptions.handle<lib.InstanceDetailsUpdateEvent>(lib.InstanceDetailsUpdateEvent, undefined, event => event.details.id);
+		this.subscriptions.handle<lib.InstanceSaveListUpdateEvent>(lib.InstanceSaveListUpdateEvent, undefined, event => event.instanceId);
+		this.subscriptions.handle<lib.ModPackUpdateEvent>(lib.ModPackUpdateEvent, undefined, event => event.modPack.id!);
+		this.subscriptions.handle<lib.ModUpdateEvent>(lib.ModUpdateEvent);
+		this.subscriptions.handle<lib.UserUpdateEvent>(lib.UserUpdateEvent, undefined, event => event.user.name);
 
 		// Load plugins
 		await this.loadPlugins();
@@ -575,13 +587,7 @@ export default class Controller {
 			host.public_address === null ? undefined : host.public_address,
 		);
 
-		for (let controlConnection of this.wsServer.controlConnections.values()) {
-			if (controlConnection.connector.closing) {
-				continue;
-			}
-
-			controlConnection.hostUpdated(host, update);
-		}
+		this.subscriptions.broadcast(new lib.HostUpdateEvent(update));
 	}
 
 	/**
@@ -761,56 +767,56 @@ export default class Controller {
 	}
 
 	instanceUpdated(instance: InstanceInfo) {
-		for (let controlConnection of this.wsServer.controlConnections.values()) {
-			if (controlConnection.connector.closing) {
-				continue;
-			}
-
-			controlConnection.instanceUpdated(instance);
+		let assigned_host: number|null|undefined = instance.config.get("instance.assigned_host");
+		if (assigned_host === null) {
+			assigned_host = undefined;
 		}
+
+		let game_port: number|null|undefined = instance.game_port
+		if (game_port === null) {
+			game_port = undefined;
+		}
+
+		this.subscriptions.broadcast(new lib.InstanceDetailsUpdateEvent(
+			new lib.InstanceDetails(
+				instance.config.get("instance.name"),
+				instance.id,
+				assigned_host,
+				game_port,
+				instance.status,
+			)
+		));
 	}
 
 	saveListUpdate(instanceId: number, saves: lib.SaveDetails[]) {
-		for (let controlConnection of this.wsServer.controlConnections.values()) {
-			if (controlConnection.connector.closing) {
-				continue;
-			}
-
-			controlConnection.saveListUpdate(instanceId, saves);
-		}
+		this.subscriptions.broadcast(new lib.InstanceSaveListUpdateEvent(instanceId, saves));
 	}
 
 	modPackUpdated(modPack: lib.ModPack) {
-		for (let controlConnection of this.wsServer.controlConnections.values()) {
-			if (controlConnection.connector.closing) {
-				continue;
-			}
-			controlConnection.modPackUpdated(modPack);
-		}
-
+		this.subscriptions.broadcast(new lib.ModPackUpdateEvent(modPack));
 		lib.invokeHook(this.plugins, "onModPackUpdated", modPack);
 	}
 
 	modUpdated(mod: lib.ModInfo) {
-		for (let controlConnection of this.wsServer.controlConnections.values()) {
-			if (controlConnection.connector.closing) {
-				continue;
-			}
-
-			controlConnection.modUpdated(mod);
-		}
-
+		this.subscriptions.broadcast(new lib.ModUpdateEvent(mod));
 		lib.invokeHook(this.plugins, "onModUpdated", mod);
 	}
 
 	userUpdated(user: lib.User) {
-		for (let controlConnection of this.wsServer.controlConnections.values()) {
-			if (controlConnection.connector.closing) {
-				continue;
-			}
-
-			controlConnection.userUpdated(user);
-		}
+		this.subscriptions.broadcast(new lib.UserUpdateEvent(
+			new lib.RawUser(
+				user.name,
+				[...user.roles].map(role => role.id),
+				[...user.instances],
+				user.isAdmin,
+				user.isBanned,
+				user.isWhitelisted,
+				user.banReason,
+				user.isDeleted,
+				user.playerStats,
+				user.instanceStats,
+			)
+		));
 	}
 
 	/**

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -241,12 +241,12 @@ export default class Controller {
 		}
 
 		// Handle subscriptions for all internal properties
-		this.subscriptions.handle<lib.HostUpdateEvent>(lib.HostUpdateEvent, undefined, event => event.update.id);
-		this.subscriptions.handle<lib.InstanceDetailsUpdateEvent>(lib.InstanceDetailsUpdateEvent, undefined, event => event.details.id);
-		this.subscriptions.handle<lib.InstanceSaveListUpdateEvent>(lib.InstanceSaveListUpdateEvent, undefined, event => event.instanceId);
-		this.subscriptions.handle<lib.ModPackUpdateEvent>(lib.ModPackUpdateEvent, undefined, event => event.modPack.id!);
+		this.subscriptions.handle<lib.HostUpdateEvent>(lib.HostUpdateEvent, event => event.update.id);
+		this.subscriptions.handle<lib.InstanceDetailsUpdateEvent>(lib.InstanceDetailsUpdateEvent, event => event.details.id);
+		this.subscriptions.handle<lib.InstanceSaveListUpdateEvent>(lib.InstanceSaveListUpdateEvent, event => event.instanceId);
+		this.subscriptions.handle<lib.ModPackUpdateEvent>(lib.ModPackUpdateEvent, event => event.modPack.id!);
 		this.subscriptions.handle<lib.ModUpdateEvent>(lib.ModUpdateEvent);
-		this.subscriptions.handle<lib.UserUpdateEvent>(lib.UserUpdateEvent, undefined, event => event.user.name);
+		this.subscriptions.handle<lib.UserUpdateEvent>(lib.UserUpdateEvent, event => event.user.name);
 
 		// Load plugins
 		await this.loadPlugins();

--- a/packages/lib/browser.js
+++ b/packages/lib/browser.js
@@ -9,6 +9,7 @@ export * from "./dist/src/logging";
 export * from "./dist/src/plugin";
 export * from "./dist/src/schema";
 export * from "./dist/src/users";
+export * from "./dist/src/subscriptions";
 
 export { default as ExponentialBackoff } from "./dist/src/ExponentialBackoff";
 export { default as PlayerStats } from "./dist/src/PlayerStats";

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -25,6 +25,7 @@ export * from "./src/shared_commands";
 export * from "./src/stream";
 export * from "./src/users";
 export * from "./src/zip_ops";
+export * from "./src/subscriptions"
 
 export { default as ExponentialBackoff } from "./src/ExponentialBackoff";
 export { default as PlayerStats } from "./src/PlayerStats";

--- a/packages/lib/src/data/messages_host.ts
+++ b/packages/lib/src/data/messages_host.ts
@@ -53,6 +53,10 @@ export class HostUpdateEvent {
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(HostDetails.fromJSON(json.update));
 	}
+
+	get subscriptionChannel() {
+		return this.update.id;
+	}
 }
 
 export class HostMetricsRequest {

--- a/packages/lib/src/data/messages_host.ts
+++ b/packages/lib/src/data/messages_host.ts
@@ -35,34 +35,12 @@ export class HostListRequest {
 	static Response = jsonArray(HostDetails);
 }
 
-export class HostSetSubscriptionsRequest {
-	declare ["constructor"]: typeof HostSetSubscriptionsRequest;
-	static type = "request" as const;
-	static src = "control" as const;
-	static dst = "controller" as const;
-	static permission = "core.host.subscribe" as const;
-
-	constructor(
-		public all: boolean,
-		public hostIds: number[],
-	) { }
-
-	static jsonSchema = Type.Object({
-		"all": Type.Boolean(),
-		"hostIds": Type.Array(Type.Integer()),
-	});
-
-	static fromJSON(json: Static<typeof this.jsonSchema>) {
-		return new this(json.all, json.hostIds);
-	}
-}
-
-
 export class HostUpdateEvent {
 	declare ["constructor"]: typeof HostUpdateEvent;
 	static type = "event" as const;
 	static src = "controller" as const;
 	static dst = "control" as const;
+	static permission = "core.host.subscribe" as const;
 
 	constructor(
 		public update: HostDetails,

--- a/packages/lib/src/data/messages_instance.ts
+++ b/packages/lib/src/data/messages_instance.ts
@@ -87,6 +87,10 @@ export class InstanceDetailsUpdateEvent {
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(InstanceDetails.fromJSON(json));
 	}
+
+	get subscriptionChannel() {
+		return this.details.id;
+	}
 };
 
 export class InstanceCreateRequest {
@@ -297,6 +301,10 @@ export class InstanceSaveListUpdateEvent {
 
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(json.instanceId, json.saves.map(i => SaveDetails.fromJSON(i)));
+	}
+
+	get subscriptionChannel() {
+		return this.instanceId;
 	}
 }
 

--- a/packages/lib/src/data/messages_instance.ts
+++ b/packages/lib/src/data/messages_instance.ts
@@ -67,33 +67,12 @@ export class InstanceDetailsListRequest {
 	static Response = jsonArray(InstanceDetails);
 };
 
-export class InstanceDetailsSetSubscriptionsRequest {
-	declare ["constructor"]: typeof InstanceDetailsSetSubscriptionsRequest;
-	static type = "request" as const;
-	static src = "control" as const;
-	static dst = "controller" as const;
-	static permission = "core.instance.subscribe" as const;
-
-	constructor(
-		public all: boolean = false,
-		public instanceIds: number[] = [],
-	) { }
-
-	static jsonSchema = Type.Object({
-		"all": Type.Boolean(),
-		"instanceIds": Type.Array(Type.Integer()),
-	});
-
-	static fromJSON(json: Static<typeof this.jsonSchema>) {
-		return new this(json.all, json.instanceIds);
-	}
-};
-
 export class InstanceDetailsUpdateEvent {
 	declare ["constructor"]: typeof InstanceDetailsUpdateEvent;
 	static type = "event" as const;
 	static src = "controller" as const;
 	static dst = "control" as const;
+	static permission = "core.instance.subscribe" as const;
 
 	constructor(
 		public details: InstanceDetails,
@@ -299,33 +278,12 @@ export class InstanceListSavesRequest {
 	static Response = jsonArray(SaveDetails);
 }
 
-export class InstanceSetSaveListSubscriptionsRequest {
-	declare ["constructor"]: typeof InstanceSetSaveListSubscriptionsRequest;
-	static type = "request" as const;
-	static src = "control" as const;
-	static dst = "controller" as const;
-	static permission = "core.instance.save.list_subscribe" as const;
-
-	constructor(
-		public all: boolean = false,
-		public instanceIds: number[] = [],
-	) { }
-
-	static jsonSchema = Type.Object({
-		"all": Type.Boolean(),
-		"instanceIds": Type.Array(Type.Integer()),
-	});
-
-	static fromJSON(json: Static<typeof this.jsonSchema>) {
-		return new this(json.all, json.instanceIds);
-	}
-};
-
 export class InstanceSaveListUpdateEvent {
 	declare ["constructor"]: typeof InstanceSaveListUpdateEvent;
 	static type = "event" as const;
 	static src = ["instance", "host", "controller"] as const;
 	static dst = ["controller", "control"] as const;
+	static permission = "core.instance.save.list_subscribe" as const;
 
 	constructor(
 		public instanceId: number,

--- a/packages/lib/src/data/messages_mod.ts
+++ b/packages/lib/src/data/messages_mod.ts
@@ -104,28 +104,6 @@ export class ModPackDeleteRequest {
 	}
 }
 
-export class ModPackSetSubscriptionsRequest {
-	declare ["constructor"]: typeof ModPackSetSubscriptionsRequest;
-	static type = "request" as const;
-	static src = "control" as const;
-	static dst = "controller" as const;
-	static permission = "core.mod_pack.subscribe" as const;
-
-	constructor(
-		public all: boolean,
-		public modPackIds: number[],
-	) { }
-
-	static jsonSchema = Type.Object({
-		"all": Type.Boolean(),
-		"modPackIds": Type.Array(Type.Integer()),
-	});
-
-	static fromJSON(json: Static<typeof this.jsonSchema>) {
-		return new this(json.all, json.modPackIds);
-	}
-}
-
 export class ModGetRequest {
 	declare ["constructor"]: typeof ModGetRequest;
 	static type = "request" as const;
@@ -217,28 +195,6 @@ export class ModSearchRequest {
 	};
 }
 
-export class ModSetSubscriptionsRequest {
-	declare ["constructor"]: typeof ModSetSubscriptionsRequest;
-	static type = "request" as const;
-	static src = "control" as const;
-	static dst = "controller" as const;
-	static permission = "core.mod.subscribe" as const;
-
-	constructor(
-		public all: boolean,
-		public modNames: string[],
-	) { }
-
-	static jsonSchema = Type.Object({
-		"all": Type.Boolean(),
-		"modNames": Type.Array(Type.String()),
-	});
-
-	static fromJSON(json: Static<typeof this.jsonSchema>) {
-		return new this(json.all, json.modNames);
-	}
-}
-
 export class ModDownloadRequest {
 	declare ["constructor"]: typeof ModDownloadRequest;
 	static type = "request" as const;
@@ -290,6 +246,7 @@ export class ModPackUpdateEvent {
 	static type = "event" as const;
 	static src = "controller" as const;
 	static dst = "control" as const;
+	static permission = "core.mod_pack.subscribe" as const;
 
 	constructor(
 		public modPack: ModPack,
@@ -309,6 +266,7 @@ export class ModUpdateEvent {
 	static type = "event" as const;
 	static src = "controller" as const;
 	static dst = "control" as const;
+	static permission = "core.mod.subscribe" as const;
 
 	constructor(
 		public mod: ModInfo,

--- a/packages/lib/src/data/messages_mod.ts
+++ b/packages/lib/src/data/messages_mod.ts
@@ -259,6 +259,10 @@ export class ModPackUpdateEvent {
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(ModPack.fromJSON(json.modPack));
 	}
+
+	get subscriptionChannel() {
+		return this.modPack.id;
+	}
 }
 
 export class ModUpdateEvent {
@@ -278,5 +282,9 @@ export class ModUpdateEvent {
 
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(ModInfo.fromJSON(json.mod));
+	}
+
+	get subscriptionChannel() {
+		return this.mod.name;
 	}
 }

--- a/packages/lib/src/data/messages_user.ts
+++ b/packages/lib/src/data/messages_user.ts
@@ -251,28 +251,6 @@ export class UserListRequest {
 	static Response = jsonArray(RawUser);
 }
 
-export class UserSetSubscriptionsRequest {
-	declare ["constructor"]: typeof UserSetSubscriptionsRequest;
-	static type = "request" as const;
-	static src = "control" as const;
-	static dst = "controller" as const;
-	static permission = "core.user.subscribe" as const;
-
-	constructor(
-		public all: boolean,
-		public names: string[],
-	) { }
-
-	static jsonSchema = Type.Object({
-		"all": Type.Boolean(),
-		"names": Type.Array(Type.String()),
-	});
-
-	static fromJSON(json: Static<typeof this.jsonSchema>) {
-		return new this(json.all, json.names);
-	}
-}
-
 export class UserCreateRequest {
 	declare ["constructor"]: typeof UserCreateRequest;
 	static type = "request" as const;
@@ -460,6 +438,7 @@ export class UserUpdateEvent {
 	static type = "event" as const;
 	static src = "controller" as const;
 	static dst = "control" as const;
+	static permission = "core.user.subscribe" as const;
 
 	constructor(
 		public user: RawUser,

--- a/packages/lib/src/data/messages_user.ts
+++ b/packages/lib/src/data/messages_user.ts
@@ -451,4 +451,8 @@ export class UserUpdateEvent {
 	static fromJSON(json: Static<typeof this.jsonSchema>) {
 		return new this(RawUser.fromJSON(json.user));
 	}
+
+	get subscriptionChannel() {
+		return this.user.name;
+	}
 }

--- a/packages/lib/src/link/messages.ts
+++ b/packages/lib/src/link/messages.ts
@@ -5,6 +5,7 @@ import * as host from "../data/messages_host";
 import * as instance from "../data/messages_instance";
 import * as mod from "../data/messages_mod";
 import * as user from "../data/messages_user";
+import * as subscriptions from "../subscriptions"
 import type { RequestClass, EventClass } from "./link";
 
 /**
@@ -27,8 +28,9 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	controller.DebugDumpWsRequest,
 	controller.DebugWsMessageEvent,
 
+	subscriptions.SubscriptionRequest,
+
 	host.HostListRequest,
-	host.HostSetSubscriptionsRequest,
 	host.HostUpdateEvent,
 	host.HostMetricsRequest,
 	host.ControllerConnectionEvent,
@@ -37,7 +39,6 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 
 	instance.InstanceDetailsGetRequest,
 	instance.InstanceDetailsListRequest,
-	instance.InstanceDetailsSetSubscriptionsRequest,
 	instance.InstanceDetailsUpdateEvent,
 	instance.InstanceCreateRequest,
 	instance.InstanceConfigGetRequest,
@@ -47,7 +48,6 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	instance.InstanceMetricsRequest,
 	instance.InstanceStartRequest,
 	instance.InstanceListSavesRequest,
-	instance.InstanceSetSaveListSubscriptionsRequest,
 	instance.InstanceSaveListUpdateEvent,
 	instance.InstanceCreateSaveRequest,
 	instance.InstanceRenameSaveRequest,
@@ -82,11 +82,9 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	mod.ModPackCreateRequest,
 	mod.ModPackUpdateRequest,
 	mod.ModPackDeleteRequest,
-	mod.ModPackSetSubscriptionsRequest,
 	mod.ModGetRequest,
 	mod.ModListRequest,
 	mod.ModSearchRequest,
-	mod.ModSetSubscriptionsRequest,
 	mod.ModDownloadRequest,
 	mod.ModDeleteRequest,
 	mod.ModPackUpdateEvent,
@@ -100,7 +98,6 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	user.RoleDeleteRequest,
 	user.UserGetRequest,
 	user.UserListRequest,
-	user.UserSetSubscriptionsRequest,
 	user.UserCreateRequest,
 	user.UserRevokeTokenRequest,
 	user.UserUpdateRolesRequest,

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -1,0 +1,273 @@
+import { Type, Static } from "@sinclair/typebox";
+import { Link, Event, EventClass, RequestHandler, WebSocketClientConnector } from "./link";
+import { Address, MessageRequest } from "./data";
+import { User } from "./users";
+
+export type SubscriptionChannelCategoriser<T> = (event: Event<T>) => string | number;
+export type SubscriptionRequestHandler<T> = RequestHandler<SubscriptionRequest, Event<T> | null>;
+export type EventSubscriberCallback<T> = (event: Event<T>) => Promise<void>;
+
+/**
+ * Response received by the subscriber after a request
+ * It can contain an eventReplay value if the event sender implements a subscription handler
+ */
+export class SubscriptionResponse {
+    constructor(
+        public readonly eventReplay: Event<unknown> | null = null,
+    ) {
+        if (eventReplay && !Link._eventsByClass.has(eventReplay.constructor)) {
+            throw new Error(`Unregistered Event class ${eventReplay.constructor.name}`);
+        }
+    }
+
+    static jsonSchema = Type.Union([
+        Type.Tuple([
+            Type.String(),
+            Type.Unknown(),
+        ]),
+        Type.Null()
+    ])
+
+    toJSON() {
+        if (this.eventReplay) {
+            const entry = Link._eventsByClass.get(this.eventReplay.constructor)!; 
+            return [entry.name, this.eventReplay];
+        } else {
+            return null;
+        }
+    }
+
+    static fromJSON(json: Static<typeof SubscriptionResponse.jsonSchema>): SubscriptionResponse {
+        if (json) {
+            const entry = Link._eventsByName.get(json[0]);
+            if (!entry) {
+                throw new Error(`Unregistered Event class ${json[0]}`);
+            } else {
+                return new SubscriptionResponse(entry.eventFromJSON(json[1]));
+            }
+        } else {
+            return new SubscriptionResponse();
+        }
+    }
+}
+
+/**
+ * A subscription request sent by a subscriber, this updates what events the subscriber will be sent
+ * allChannels: false, channels: [] will unsubscribe the subscriber from being sent any events
+ */
+export class SubscriptionRequest {
+    declare ["constructor"]: typeof SubscriptionRequest;
+	static type = "request" as const;
+	static src =  ["control", "instance"] as const;
+	static dst = "controller" as const;
+	static plugin = "exp_commands" as const;
+    static Response = SubscriptionResponse;
+	static permission(user: User, message: MessageRequest) {
+        if (typeof message.data === "object" && message.data !== null) {
+            const data = message.data as Static<typeof SubscriptionRequest.jsonSchema>;
+            const entry = Link._eventsByName.get(data[0]);
+            if (entry && entry.Event.permission) {
+                if (typeof entry.Event.permission === "string") {
+                    user.checkPermission(entry.Event.permission);
+                } else {
+                    entry.Event.permission(user, message);
+                }
+            }
+        }
+    }
+    
+    constructor(
+        public eventName: string,
+        public allChannels: boolean,
+        public channels: Array<string | number> = [],
+        public lastRequestTime: number = 0,
+    ) {
+    }
+
+    static jsonSchema = Type.Tuple([
+        Type.String(),
+        Type.Boolean(),
+        Type.Array(Type.Union([Type.String(), Type.Number()])),
+        Type.Number(),
+    ])
+
+    toJSON() {
+        return [this.eventName, this.allChannels, this.channels, this.lastRequestTime];
+    }
+
+    static fromJSON(json: Static<typeof SubscriptionRequest.jsonSchema>): SubscriptionRequest {
+        return new this(...json);
+    }
+}
+
+/**
+ * A class component to handle incoming subscription requests and offers a method to broadcast to subscribers
+ * After creation, no other handler can be registered for SubscriptionRequest
+ */
+export class SubscriptionController {
+    _events = new Map<string, {
+        subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
+        channelCategoriser?: SubscriptionChannelCategoriser<unknown>,
+        subscriptions: Map<Link, { all: boolean, channels: Array<string | number> }>,
+    }>();
+
+    constructor(
+        private controller: any, // Controller | Link
+    ) {
+        this.controller.handle(SubscriptionRequest, this._handleEvent.bind(this));
+    }
+
+	handle<T>(Event: EventClass<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>, channelCategoriser?: SubscriptionChannelCategoriser<T>): void;
+    handle(
+        Event: EventClass<unknown>,
+		subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
+		channelCategoriser?: SubscriptionChannelCategoriser<unknown>,
+    ) {
+        const entry = Link._eventsByClass.get(Event);
+		if (!entry) {
+			throw new Error(`Unregistered Event class ${Event.name}`);
+		}
+		if (this._events.has(entry.name)) {
+			throw new Error(`Event ${entry.name} is already registered`);
+		}
+        this._events.set(entry.name, {
+            subscriptionUpdate: subscriptionUpdate,
+            channelCategoriser: channelCategoriser,
+            subscriptions: new Map(),
+        });
+    }
+
+    broadcast<T>(event: Event<T>): void;
+    broadcast(event: Event<unknown>) {
+        const entry = Link._eventsByClass.get(event.constructor);
+        if (!entry) {
+			throw new Error(`Unregistered Event class ${Event.name}`);
+		}
+        const eventData = this._events.get(entry.name);
+        if (!eventData) {
+            throw new Error(`Event ${entry.name} is not a registered as subscribable`);
+		}
+        const channel = eventData.channelCategoriser ? eventData.channelCategoriser(event) : null;
+        for (let [link, subscription] of eventData.subscriptions.entries()) {
+            if (subscription.all || (channel && subscription.channels.includes(channel))) {
+                link.send(event);
+            }
+		}
+    }
+
+    async _handleEvent(event: SubscriptionRequest, src: Address, dst: Address) {
+        if (!Link._eventsByName.has(event.eventName)) {
+            throw new Error(`Event ${event.eventName} is not a registered event`);
+		}
+        const eventData = this._events.get(event.eventName);
+        if (!eventData) {
+            throw new Error(`Event ${event.eventName} is not a registered as subscribable`);
+		}
+        const eventReplay = eventData.subscriptionUpdate ? await eventData.subscriptionUpdate(event, src, dst) : null;
+        const link: Link = this.controller.wsServer.controlConnections.get(src.id);
+        if (event.allChannels === false && event.channels.length === 0) {
+            eventData.subscriptions.delete(link);
+            return new SubscriptionResponse(eventReplay);
+        } else {
+            eventData.subscriptions.set(link, { all: event.allChannels, channels: event.channels });
+            return new SubscriptionResponse(eventReplay);
+        }
+    }
+}
+
+/**
+ * A class component to handle incoming subscription requests and offers a method to broadcast to subscribers
+ * After creation, no other handler can be registered for SubscriptionRequest
+ */
+export class EventSubscriber<T> {
+    _callbacks = new Array<EventSubscriberCallback<T>>()
+    _channelCallbacks = new Map<string | number, Array<EventSubscriberCallback<T>>>()
+    lastResponse?: Event<T> = undefined;
+    lastResponseTime = 0;
+
+    constructor(
+        private event: EventClass<T>,
+        private channelCategoriser?: SubscriptionChannelCategoriser<T>,
+        private control?: Link
+    ) {
+        const entry = Link._eventsByClass.get(this.event);
+		if (!entry) {
+			throw new Error(`Unregistered Event class ${this.event.name}`);
+		}
+        if (this.control) {
+            this.control.handle(this.event, this._handle.bind(this));
+        }
+    }
+
+    async _handle(response: Event<T>) {
+        this.lastResponse = response;
+        this.lastResponseTime = Date.now();
+        for (let callback of this._callbacks) {
+			callback(response);
+		}
+    }
+
+    connectControl(control: Link) {
+        if (this.control === control) return;
+        this.control = control;
+        this.control.handle(this.event, this._handle.bind(this));
+    }
+
+    subscribeAll(handler: EventSubscriberCallback<T>) {
+        this._callbacks.push(handler);
+		this._updateSubscription();
+    }
+
+    subscribe(channel: string | number, handler: EventSubscriberCallback<T>) {
+        if (!this._channelCallbacks.get(channel)) {
+            this._channelCallbacks.set(channel, []);
+        }
+        this._channelCallbacks.get(channel)!.push(handler);
+		this._updateSubscription();
+    }
+
+    unsubscribeAll(handler: EventSubscriberCallback<T>) {
+        let index = this._callbacks.lastIndexOf(handler);
+		if (index === -1) {
+			throw new Error("handler is not registered");
+		}
+
+		this._callbacks.splice(index, 1);
+		this._updateSubscription();
+    }
+
+    unsubscribe(channel: string | number, handler: EventSubscriberCallback<T>) {
+        const channelCallbacks = this._channelCallbacks.get(channel);
+        if (!channelCallbacks) {
+            throw new Error("handler is not registered");
+        }
+
+        let index = channelCallbacks.lastIndexOf(handler);
+		if (index === -1) {
+			throw new Error("handler is not registered");
+		}
+
+        if (channelCallbacks.length === 1) {
+            this._channelCallbacks.delete(channel);
+        } else {
+            channelCallbacks.splice(index, 1);
+        }
+		this._updateSubscription();
+    }
+
+    async _updateSubscription() {
+        if (!this.control || !(this.control.connector as WebSocketClientConnector).connected) return;
+        const entry = Link._eventsByClass.get(this.event)!;
+
+        const response = await this.control.send(new SubscriptionRequest(
+            entry.name,
+            this._callbacks.length > 0,
+            [...this._channelCallbacks.keys()],
+            this.lastResponseTime
+        ));
+
+        if (response.eventReplay) {
+            this._handle(response.eventReplay);
+        }
+    }
+}

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -213,7 +213,7 @@ export class EventSubscriber<T, V=T> {
 
     constructor(
         private event: EventClass<T> | ChannelEventClass<T>,
-        private prehandler?: (event: Event<T>) => V,
+        private prehandler?: (event: T) => V,
         control?: Link
     ) {
         const entry = Link._eventsByClass.get(this.event);
@@ -231,7 +231,7 @@ export class EventSubscriber<T, V=T> {
     async _handle(response: Event<T> | ChannelEvent<T>) {
         this.lastResponse = response;
         this.lastResponseTime = Date.now();
-        const value = this.prehandler ? this.prehandler(response) : response as any;
+        const value = this.prehandler ? this.prehandler(response as T) : response as any;
         for (let callback of this._callbacks) {
             callback(value);
         }

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -131,11 +131,7 @@ export class SubscriptionController {
 	 * Allow clients to subscribe to an event by telling the subscription controller to accept them
 	 * Has an optional subscription update handler which is called when any client updates their subscription
 	 */
-	handle<T>(Event: EventClass<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>,): void;
-	handle(
-		Event: EventClass<unknown>,
-		subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
-	) {
+	handle<T>(Event: EventClass<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>) {
 		const entry = Link._eventsByClass.get(Event);
 		if (!entry) {
 			throw new Error(`Unregistered Event class ${Event.name}`);
@@ -152,8 +148,7 @@ export class SubscriptionController {
 	/**
 	 * Broadcast an event to all subscribers of that event, will be filtered by channel if a ChannelEvent is provided
 	 */
-	broadcast<T>(event: Event<T> | ChannelEvent<T>): void;
-	broadcast(event: Event<unknown> | ChannelEvent<unknown>) {
+	broadcast<T>(event: Event<T> | ChannelEvent<T>) {
 		const entry = Link._eventsByClass.get(event.constructor);
 		if (!entry) {
 			throw new Error(`Unregistered Event class ${event.constructor.name}`);

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -7,11 +7,11 @@ export type SubscriptionRequestHandler<T> = RequestHandler<SubscriptionRequest, 
 export type EventSubscriberCallback<T> = (value: T) => void;
 
 export type ChannelEvent<T> = Event<T> & {
-    get subscriptionChannel(): number | string;
+	get subscriptionChannel(): number | string;
 }
 
 export type ChannelEventClass<T> = EventClass<T> & {
-    new(...args: any): ChannelEvent<T>
+	new(...args: any): ChannelEvent<T>
 }
 
 /**
@@ -20,43 +20,43 @@ export type ChannelEventClass<T> = EventClass<T> & {
  * This replay will be send to the handlers as if an update had just occurred
  */
 export class SubscriptionResponse {
-    constructor(
-        public readonly eventReplay: Event<unknown> | null = null,
-    ) {
-        if (eventReplay && !Link._eventsByClass.has(eventReplay.constructor)) {
-            throw new Error(`Unregistered Event class ${eventReplay.constructor.name}`);
-        }
-    }
+	constructor(
+		public readonly eventReplay: Event<unknown> | null = null,
+	) {
+		if (eventReplay && !Link._eventsByClass.has(eventReplay.constructor)) {
+			throw new Error(`Unregistered Event class ${eventReplay.constructor.name}`);
+		}
+	}
 
-    static jsonSchema = Type.Union([
-        Type.Tuple([
-            Type.String(),
-            Type.Unknown(),
-        ]),
-        Type.Null()
-    ])
+	static jsonSchema = Type.Union([
+		Type.Tuple([
+			Type.String(),
+			Type.Unknown(),
+		]),
+		Type.Null()
+	])
 
-    toJSON() {
-        if (this.eventReplay) {
-            const entry = Link._eventsByClass.get(this.eventReplay.constructor)!; 
-            return [entry.name, this.eventReplay];
-        } else {
-            return null;
-        }
-    }
+	toJSON() {
+		if (this.eventReplay) {
+			const entry = Link._eventsByClass.get(this.eventReplay.constructor)!;
+			return [entry.name, this.eventReplay];
+		} else {
+			return null;
+		}
+	}
 
-    static fromJSON(json: Static<typeof SubscriptionResponse.jsonSchema>): SubscriptionResponse {
-        if (json) {
-            const entry = Link._eventsByName.get(json[0]);
-            if (!entry) {
-                throw new Error(`Unregistered Event class ${json[0]}`);
-            } else {
-                return new SubscriptionResponse(entry.eventFromJSON(json[1]));
-            }
-        } else {
-            return new SubscriptionResponse();
-        }
-    }
+	static fromJSON(json: Static<typeof SubscriptionResponse.jsonSchema>): SubscriptionResponse {
+		if (json) {
+			const entry = Link._eventsByName.get(json[0]);
+			if (!entry) {
+				throw new Error(`Unregistered Event class ${json[0]}`);
+			} else {
+				return new SubscriptionResponse(entry.eventFromJSON(json[1]));
+			}
+		} else {
+			return new SubscriptionResponse();
+		}
+	}
 }
 
 /**
@@ -65,50 +65,50 @@ export class SubscriptionResponse {
  * allChannels: false, channels: [] will unsubscribe the subscriber from all notifications
  */
 export class SubscriptionRequest {
-    declare ["constructor"]: typeof SubscriptionRequest;
+	declare ["constructor"]: typeof SubscriptionRequest;
 	static type = "request" as const;
 	static src =  ["control", "instance"] as const;
 	static dst = "controller" as const;
-    static Response = SubscriptionResponse;
+	static Response = SubscriptionResponse;
 	static permission(user: User, message: MessageRequest) {
-        if (typeof message.data === "object" && message.data !== null) {
-            const data = message.data as Static<typeof SubscriptionRequest.jsonSchema>;
-            const entry = Link._eventsByName.get(data[0]);
-            if (entry && entry.Event.permission) {
-                if (typeof entry.Event.permission === "string") {
-                    user.checkPermission(entry.Event.permission);
-                } else {
-                    entry.Event.permission(user, message);
-                }
-            }
-        }
-    }
-    
-    constructor(
-        public eventName: string,
-        public allChannels: boolean,
-        public channels: Array<string | number> = [],
-        public lastRequestTime: number = 0,
-    ) {
-        if (!Link._eventsByName.has(eventName)) {
-            throw new Error(`Unregistered Event class ${eventName}`);
-        }
-    }
+		if (typeof message.data === "object" && message.data !== null) {
+			const data = message.data as Static<typeof SubscriptionRequest.jsonSchema>;
+			const entry = Link._eventsByName.get(data[0]);
+			if (entry && entry.Event.permission) {
+				if (typeof entry.Event.permission === "string") {
+					user.checkPermission(entry.Event.permission);
+				} else {
+					entry.Event.permission(user, message);
+				}
+			}
+		}
+	}
 
-    static jsonSchema = Type.Tuple([
-        Type.String(),
-        Type.Boolean(),
-        Type.Array(Type.Union([Type.String(), Type.Number()])),
-        Type.Number(),
-    ])
+	constructor(
+		public eventName: string,
+		public allChannels: boolean,
+		public channels: Array<string | number> = [],
+		public lastRequestTime: number = 0,
+	) {
+		if (!Link._eventsByName.has(eventName)) {
+			throw new Error(`Unregistered Event class ${eventName}`);
+		}
+	}
 
-    toJSON() {
-        return [this.eventName, this.allChannels, this.channels, this.lastRequestTime];
-    }
+	static jsonSchema = Type.Tuple([
+		Type.String(),
+		Type.Boolean(),
+		Type.Array(Type.Union([Type.String(), Type.Number()])),
+		Type.Number(),
+	])
 
-    static fromJSON(json: Static<typeof SubscriptionRequest.jsonSchema>): SubscriptionRequest {
-        return new this(...json);
-    }
+	toJSON() {
+		return [this.eventName, this.allChannels, this.channels, this.lastRequestTime];
+	}
+
+	static fromJSON(json: Static<typeof SubscriptionRequest.jsonSchema>): SubscriptionRequest {
+		return new this(...json);
+	}
 }
 
 /**
@@ -116,91 +116,91 @@ export class SubscriptionRequest {
  * After creation, no other handler can be registered for SubscriptionRequest on the controller
  */
 export class SubscriptionController {
-    _events = new Map<string, {
-        subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
-        subscriptions: Map<Link, { all: boolean, channels: Array<string | number>, onceClose: () => void }>,
-    }>();
-
-    constructor(
-        private controller: any, // Controller | Link
-    ) {
-        this.controller.handle(SubscriptionRequest, this._handleRequest.bind(this));
-    }
-
-    /**
-     * Allow clients to subscribe to an event by telling the subscription controller to accept them
-     * Has an optional subscription update handler which is called when any client updates their subscription
-     */
-	handle<T>(Event: EventClass<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>,): void;
-    handle(
-        Event: EventClass<unknown>,
+	_events = new Map<string, {
 		subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
-    ) {
-        const entry = Link._eventsByClass.get(Event);
+		subscriptions: Map<Link, { all: boolean, channels: Array<string | number>, onceClose: () => void }>,
+	}>();
+
+	constructor(
+		private controller: any, // Controller | Link
+	) {
+		this.controller.handle(SubscriptionRequest, this._handleRequest.bind(this));
+	}
+
+	/**
+	 * Allow clients to subscribe to an event by telling the subscription controller to accept them
+	 * Has an optional subscription update handler which is called when any client updates their subscription
+	 */
+	handle<T>(Event: EventClass<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>,): void;
+	handle(
+		Event: EventClass<unknown>,
+		subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
+	) {
+		const entry = Link._eventsByClass.get(Event);
 		if (!entry) {
 			throw new Error(`Unregistered Event class ${Event.name}`);
 		}
 		if (this._events.has(entry.name)) {
 			throw new Error(`Event ${entry.name} is already registered`);
 		}
-        this._events.set(entry.name, {
-            subscriptionUpdate: subscriptionUpdate,
-            subscriptions: new Map(),
-        });
-    }
+		this._events.set(entry.name, {
+			subscriptionUpdate: subscriptionUpdate,
+			subscriptions: new Map(),
+		});
+	}
 
-    /**
-     * Broadcast an event to all subscribers of that event, will be filtered by channel if a ChannelEvent is provided
-     */
-    broadcast<T>(event: Event<T> | ChannelEvent<T>): void;
-    broadcast(event: Event<unknown> | ChannelEvent<unknown>) {
-        const entry = Link._eventsByClass.get(event.constructor);
-        if (!entry) {
+	/**
+	 * Broadcast an event to all subscribers of that event, will be filtered by channel if a ChannelEvent is provided
+	 */
+	broadcast<T>(event: Event<T> | ChannelEvent<T>): void;
+	broadcast(event: Event<unknown> | ChannelEvent<unknown>) {
+		const entry = Link._eventsByClass.get(event.constructor);
+		if (!entry) {
 			throw new Error(`Unregistered Event class ${event.constructor.name}`);
 		}
-        const eventData = this._events.get(entry.name);
-        if (!eventData) {
-            throw new Error(`Event ${entry.name} is not a registered as subscribable`);
+		const eventData = this._events.get(entry.name);
+		if (!eventData) {
+			throw new Error(`Event ${entry.name} is not a registered as subscribable`);
 		}
-        const channel = "subscriptionChannel" in event ? event.subscriptionChannel : null;
-        for (let [link, subscription] of eventData.subscriptions) {
-            if ((link.connector as WebSocketBaseConnector).closing) {
-                eventData.subscriptions.delete(link);
-            } else if ((subscription.all || (channel && subscription.channels.includes(channel)))) {
-                link.send(event);
-            }
+		const channel = "subscriptionChannel" in event ? event.subscriptionChannel : null;
+		for (let [link, subscription] of eventData.subscriptions) {
+			if ((link.connector as WebSocketBaseConnector).closing) {
+				eventData.subscriptions.delete(link);
+			} else if ((subscription.all || (channel && subscription.channels.includes(channel)))) {
+				link.send(event);
+			}
 		}
-    }
+	}
 
-    /**
-     * Handle incoming event subscription requests
-     */
-    async _handleRequest(event: SubscriptionRequest, src: Address, dst: Address) {
-        if (!Link._eventsByName.has(event.eventName)) {
-            throw new Error(`Event ${event.eventName} is not a registered event`);
+	/**
+	 * Handle incoming event subscription requests
+	 */
+	async _handleRequest(event: SubscriptionRequest, src: Address, dst: Address) {
+		if (!Link._eventsByName.has(event.eventName)) {
+			throw new Error(`Event ${event.eventName} is not a registered event`);
 		}
-        const eventData = this._events.get(event.eventName);
-        if (!eventData) {
-            throw new Error(`Event ${event.eventName} is not a registered as subscribable`);
+		const eventData = this._events.get(event.eventName);
+		if (!eventData) {
+			throw new Error(`Event ${event.eventName} is not a registered as subscribable`);
 		}
-        const eventReplay = eventData.subscriptionUpdate ? await eventData.subscriptionUpdate(event, src, dst) : null;
-        const link: Link = this.controller.wsServer.controlConnections.get(src.id);
-        if (event.allChannels === false && event.channels.length === 0) {
-            let onceClose = eventData.subscriptions.get(link)?.onceClose;
-            if (onceClose) {
-                link.connector.off("close", onceClose);
-                eventData.subscriptions.delete(link);
-            }
-        } else {
-            let onceClose = eventData.subscriptions.get(link)?.onceClose;
-            if (!onceClose) {
-                onceClose = () => eventData.subscriptions.delete(link);
-                link.connector.once("close", onceClose);
-            }
-            eventData.subscriptions.set(link, { all: event.allChannels, channels: event.channels, onceClose: onceClose });
-        }
-        return new SubscriptionResponse(eventReplay);
-    }
+		const eventReplay = eventData.subscriptionUpdate ? await eventData.subscriptionUpdate(event, src, dst) : null;
+		const link: Link = this.controller.wsServer.controlConnections.get(src.id);
+		if (event.allChannels === false && event.channels.length === 0) {
+			let onceClose = eventData.subscriptions.get(link)?.onceClose;
+			if (onceClose) {
+				link.connector.off("close", onceClose);
+				eventData.subscriptions.delete(link);
+			}
+		} else {
+			let onceClose = eventData.subscriptions.get(link)?.onceClose;
+			if (!onceClose) {
+				onceClose = () => eventData.subscriptions.delete(link);
+				link.connector.once("close", onceClose);
+			}
+			eventData.subscriptions.set(link, { all: event.allChannels, channels: event.channels, onceClose: onceClose });
+		}
+		return new SubscriptionResponse(eventReplay);
+	}
 }
 
 /**
@@ -209,129 +209,129 @@ export class SubscriptionController {
  * Multiple handlers can be subscribed at the same time, on the same or different channels
  */
 export class EventSubscriber<T, V=T> {
-    _callbacks = new Array<EventSubscriberCallback<V>>()
-    _channelCallbacks = new Map<string | number, Array<EventSubscriberCallback<V>>>()
-    lastResponse: Event<T> | null = null;
-    lastResponseTime = 0;
-    control?: Link
+	_callbacks = new Array<EventSubscriberCallback<V>>()
+	_channelCallbacks = new Map<string | number, Array<EventSubscriberCallback<V>>>()
+	lastResponse: Event<T> | null = null;
+	lastResponseTime = 0;
+	control?: Link
 
-    constructor(
-        private event: EventClass<T> | ChannelEventClass<T>,
-        private prehandler?: (event: T) => V,
-        control?: Link
-    ) {
-        const entry = Link._eventsByClass.get(this.event);
+	constructor(
+		private event: EventClass<T> | ChannelEventClass<T>,
+		private prehandler?: (event: T) => V,
+		control?: Link
+	) {
+		const entry = Link._eventsByClass.get(this.event);
 		if (!entry) {
 			throw new Error(`Unregistered Event class ${this.event.name}`);
 		}
-        if (control) {
-            this.connectControl(control);
-        }
-    }
+		if (control) {
+			this.connectControl(control);
+		}
+	}
 
-    /**
-     * Handle incoming events and distribute it to the correct callbacks
-     */
-    async _handle(response: Event<T> | ChannelEvent<T>) {
-        this.lastResponse = response;
-        this.lastResponseTime = Date.now();
-        const value = this.prehandler ? this.prehandler(response as T) : response as any;
-        for (let callback of this._callbacks) {
-            callback(value);
-        }
-        const channel = "subscriptionChannel" in response ? response.subscriptionChannel : null;
-        if (channel) {
-            const callbacks = this._channelCallbacks.get(channel);
-            if (callbacks) {
-                for (let callback of callbacks) {
-                    callback(value);
-                }
-            }
-        }
-    }
+	/**
+	 * Handle incoming events and distribute it to the correct callbacks
+	 */
+	async _handle(response: Event<T> | ChannelEvent<T>) {
+		this.lastResponse = response;
+		this.lastResponseTime = Date.now();
+		const value = this.prehandler ? this.prehandler(response as T) : response as any;
+		for (let callback of this._callbacks) {
+			callback(value);
+		}
+		const channel = "subscriptionChannel" in response ? response.subscriptionChannel : null;
+		if (channel) {
+			const callbacks = this._channelCallbacks.get(channel);
+			if (callbacks) {
+				for (let callback of callbacks) {
+					callback(value);
+				}
+			}
+		}
+	}
 
-    /**
-     * If a control link was not connected at creation, it can be connected here (normally during onControllerConnectionEvent)
-     */
-    async connectControl(control: Link) {
-        if (this.control === control) return;
-        this.control = control;
-        this.control.handle(this.event, this._handle.bind(this));
-        await this._updateSubscription();
-    }
-
-    /**
-     * Subscribe to receive all event notifications
-     */
-    async subscribe(handler: EventSubscriberCallback<V>) {
-        this._callbacks.push(handler);
+	/**
+	 * If a control link was not connected at creation, it can be connected here (normally during onControllerConnectionEvent)
+	 */
+	async connectControl(control: Link) {
+		if (this.control === control) return;
+		this.control = control;
+		this.control.handle(this.event, this._handle.bind(this));
 		await this._updateSubscription();
-    }
+	}
 
-    /**
-     * Subscribe to receive event notifications for the given channel
-     */
-    async subscribeToChannel(channel: string | number, handler: EventSubscriberCallback<V>) {
-        if (!this._channelCallbacks.get(channel)) {
-            this._channelCallbacks.set(channel, []);
-        }
-        this._channelCallbacks.get(channel)!.push(handler);
+	/**
+	 * Subscribe to receive all event notifications
+	 */
+	async subscribe(handler: EventSubscriberCallback<V>) {
+		this._callbacks.push(handler);
 		await this._updateSubscription();
-    }
+	}
 
-    /**
-     * Unsubscribe from receiving all event notifications, does not effect the subscriptions of other handlers
-     * Will throw an error if your handler is not subscribed to all channels, does not accept anonymous functions
-     */
-    async unsubscribe(handler: EventSubscriberCallback<V>) {
-        let index = this._callbacks.lastIndexOf(handler);
+	/**
+	 * Subscribe to receive event notifications for the given channel
+	 */
+	async subscribeToChannel(channel: string | number, handler: EventSubscriberCallback<V>) {
+		if (!this._channelCallbacks.get(channel)) {
+			this._channelCallbacks.set(channel, []);
+		}
+		this._channelCallbacks.get(channel)!.push(handler);
+		await this._updateSubscription();
+	}
+
+	/**
+	 * Unsubscribe from receiving all event notifications, does not effect the subscriptions of other handlers
+	 * Will throw an error if your handler is not subscribed to all channels, does not accept anonymous functions
+	 */
+	async unsubscribe(handler: EventSubscriberCallback<V>) {
+		let index = this._callbacks.lastIndexOf(handler);
 		if (index === -1) {
 			throw new Error("handler is not registered");
 		}
 
 		this._callbacks.splice(index, 1);
 		await this._updateSubscription();
-    }
+	}
 
-    /**
-     * Unsubscribe from receiving event notifications for a given channel, does not effect the subscriptions of other handlers
-     * Will throw an error if your handler is not subscribed to the channel, does not accept anonymous functions
-     */
-    async unsubscribeFromChannel(channel: string | number, handler: EventSubscriberCallback<V>) {
-        const channelCallbacks = this._channelCallbacks.get(channel);
-        if (!channelCallbacks) {
-            throw new Error("handler is not registered");
-        }
+	/**
+	 * Unsubscribe from receiving event notifications for a given channel, does not effect the subscriptions of other handlers
+	 * Will throw an error if your handler is not subscribed to the channel, does not accept anonymous functions
+	 */
+	async unsubscribeFromChannel(channel: string | number, handler: EventSubscriberCallback<V>) {
+		const channelCallbacks = this._channelCallbacks.get(channel);
+		if (!channelCallbacks) {
+			throw new Error("handler is not registered");
+		}
 
-        let index = channelCallbacks.lastIndexOf(handler);
+		let index = channelCallbacks.lastIndexOf(handler);
 		if (index === -1) {
 			throw new Error("handler is not registered");
 		}
 
-        if (channelCallbacks.length === 1) {
-            this._channelCallbacks.delete(channel);
-        } else {
-            channelCallbacks.splice(index, 1);
-        }
+		if (channelCallbacks.length === 1) {
+			this._channelCallbacks.delete(channel);
+		} else {
+			channelCallbacks.splice(index, 1);
+		}
 		await this._updateSubscription();
-    }
+	}
 
-    /**
-     * Update the subscription with the controller based on current handler counts
-     */
-    async _updateSubscription() {
-        if (!this.control || !(this.control.connector as WebSocketClientConnector).connected) return;
-        const entry = Link._eventsByClass.get(this.event)!;
+	/**
+	 * Update the subscription with the controller based on current handler counts
+	 */
+	async _updateSubscription() {
+		if (!this.control || !(this.control.connector as WebSocketClientConnector).connected) return;
+		const entry = Link._eventsByClass.get(this.event)!;
 
-        const response = await this.control.send(new SubscriptionRequest(
-            entry.name,
-            this._callbacks.length > 0,
-            [...this._channelCallbacks.keys()],
-            this.lastResponseTime
-        ));
+		const response = await this.control.send(new SubscriptionRequest(
+			entry.name,
+			this._callbacks.length > 0,
+			[...this._channelCallbacks.keys()],
+			this.lastResponseTime
+		));
 
-        if (response.eventReplay) {
-            await this._handle(response.eventReplay);
-        }
-    }
+		if (response.eventReplay) {
+			await this._handle(response.eventReplay);
+		}
+	}
 }

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -121,11 +121,11 @@ export class SubscriptionController {
      * Allow clients to subscribe to an event by telling the subscription controller to accept them
      * Has an optional subscription update handler which is called when any client updates their subscription
      */
-	handle<T>(Event: EventClass<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>, channelCategoriser?: SubscriptionChannelCategoriser<T>): void;
+	handle<T>(Event: EventClass<T>, channelCategoriser?: SubscriptionChannelCategoriser<T>, subscriptionUpdate?: SubscriptionRequestHandler<T>,): void;
     handle(
         Event: EventClass<unknown>,
-		subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
 		channelCategoriser?: SubscriptionChannelCategoriser<unknown>,
+		subscriptionUpdate?: SubscriptionRequestHandler<unknown>,
     ) {
         const entry = Link._eventsByClass.get(Event);
 		if (!entry) {

--- a/packages/web_ui/src/model/host.ts
+++ b/packages/web_ui/src/model/host.ts
@@ -38,9 +38,9 @@ export function useHost(id: number): [ HostState, () => void ] {
 			setHost({ ...newHost, loading:false, missing:false, present:true });
 		}
 
-		control.onHostUpdate(id, updateHandler);
+		control.hostUpdate.subscribeToChannel(id, updateHandler);
 		return () => {
-			control.offHostUpdate(id, updateHandler);
+			control.hostUpdate.unsubscribeFromChannel(id, updateHandler);
 		};
 	}, [id]);
 
@@ -74,9 +74,9 @@ export function useHostList() {
 			});
 		}
 
-		control.onHostUpdate(null, updateHandler);
+		control.hostUpdate.subscribe(updateHandler);
 		return () => {
-			control.offHostUpdate(null, updateHandler);
+			control.hostUpdate.unsubscribe(updateHandler);
 		};
 	}, []);
 

--- a/packages/web_ui/src/model/instance.ts
+++ b/packages/web_ui/src/model/instance.ts
@@ -35,9 +35,9 @@ export function useInstance(id: number): [InstanceState, ()=>void] {
 			setInstance({ ...newInstance, present: true });
 		}
 
-		control.onInstanceUpdate(id, updateHandler);
+		control.instanceUpdate.subscribeToChannel(id, updateHandler);
 		return () => {
-			control.offInstanceUpdate(id, updateHandler);
+			control.instanceUpdate.unsubscribeFromChannel(id, updateHandler);
 		};
 	}, [id]);
 
@@ -76,9 +76,9 @@ export function useInstanceList() {
 			});
 		}
 
-		control.onInstanceUpdate(null, updateHandler);
+		control.instanceUpdate.subscribe(updateHandler);
 		return () => {
-			control.offInstanceUpdate(null, updateHandler);
+			control.instanceUpdate.unsubscribe(updateHandler);
 		};
 	}, []);
 

--- a/packages/web_ui/src/model/mod_pack.ts
+++ b/packages/web_ui/src/model/mod_pack.ts
@@ -33,9 +33,9 @@ export function useModPack(id: number) {
 		}
 		updateModPack();
 
-		control.onModPackUpdate(id, setModPack);
+		control.modPackUpdate.subscribeToChannel(id, setModPack);
 		return () => {
-			control.offModPackUpdate(id, setModPack);
+			control.modPackUpdate.unsubscribeFromChannel(id, setModPack);
 		};
 	}, [id]);
 
@@ -74,9 +74,9 @@ export function useModPackList() {
 			});
 		}
 
-		control.onModPackUpdate(null, updateHandler);
+		control.modPackUpdate.subscribe(updateHandler);
 		return () => {
-			control.offModPackUpdate(null, updateHandler);
+			control.modPackUpdate.unsubscribe(updateHandler);
 		};
 	}, []);
 

--- a/packages/web_ui/src/model/mods.ts
+++ b/packages/web_ui/src/model/mods.ts
@@ -38,9 +38,9 @@ export function useModList() {
 			});
 		}
 
-		control.onModUpdate(null, updateHandler);
+		control.modUpdate.subscribe(updateHandler);
 		return () => {
-			control.offModUpdate(null, updateHandler);
+			control.modUpdate.unsubscribe(updateHandler);
 		};
 	}, []);
 

--- a/packages/web_ui/src/model/saves.ts
+++ b/packages/web_ui/src/model/saves.ts
@@ -29,9 +29,9 @@ export function useSaves(instanceId?: number): lib.SaveDetails[] {
 			setSaves(data.saves);
 		}
 
-		control.onSaveListUpdate(instanceId!, updateHandler);
+		control.saveListUpdate.subscribeToChannel(instanceId!, updateHandler);
 		return () => {
-			control.offSaveListUpdate(instanceId!, updateHandler);
+			control.saveListUpdate.unsubscribeFromChannel(instanceId!, updateHandler);
 		};
 	}, [instanceId]);
 

--- a/packages/web_ui/src/model/user.tsx
+++ b/packages/web_ui/src/model/user.tsx
@@ -82,9 +82,9 @@ export function useUser(name: string): [RawUserState, () => void] {
 			setUser({ ...newUser, present: true });
 		}
 
-		control.onUserUpdate(name, updateHandler);
+		control.userUpdate.subscribeToChannel(name, updateHandler);
 		return () => {
-			control.offUserUpdate(name, updateHandler);
+			control.userUpdate.unsubscribeFromChannel(name, updateHandler);
 		};
 	}, [name]);
 
@@ -123,9 +123,9 @@ export function useUserList() {
 			});
 		}
 
-		control.onUserUpdate(null, updateHandler);
+		control.userUpdate.subscribe(updateHandler);
 		return () => {
-			control.offUserUpdate(null, updateHandler);
+			control.userUpdate.unsubscribe(updateHandler);
 		};
 	}, []);
 

--- a/packages/web_ui/src/util/websocket.ts
+++ b/packages/web_ui/src/util/websocket.ts
@@ -59,9 +59,9 @@ export class Control extends lib.Link {
 	hostUpdate = new lib.EventSubscriber<lib.HostUpdateEvent, lib.HostDetails>(lib.HostUpdateEvent, event => event.update);
 	instanceUpdate = new lib.EventSubscriber<lib.InstanceDetailsUpdateEvent, lib.InstanceDetails>(lib.InstanceDetailsUpdateEvent, event => event.details);
 	saveListUpdate = new lib.EventSubscriber<lib.InstanceSaveListUpdateEvent>(lib.InstanceSaveListUpdateEvent);
-	modPackUpdate = new lib.EventSubscriber<lib.ModPackUpdateEvent, lib.ModPack>(lib.InstanceSaveListUpdateEvent, event => event.modPack);
-	modUpdate = new lib.EventSubscriber<lib.ModUpdateEvent, lib.ModInfo>(lib.InstanceSaveListUpdateEvent, event => event.mod);
-	userUpdate = new lib.EventSubscriber<lib.UserUpdateEvent, lib.RawUser>(lib.InstanceSaveListUpdateEvent, event => event.user);
+	modPackUpdate = new lib.EventSubscriber<lib.ModPackUpdateEvent, lib.ModPack>(lib.ModPackUpdateEvent, event => event.modPack);
+	modUpdate = new lib.EventSubscriber<lib.ModUpdateEvent, lib.ModInfo>(lib.ModUpdateEvent, event => event.mod);
+	userUpdate = new lib.EventSubscriber<lib.UserUpdateEvent, lib.RawUser>(lib.UserUpdateEvent, event => event.user);
 
 	declare connector: ControlConnector;
 

--- a/packages/web_ui/src/util/websocket.ts
+++ b/packages/web_ui/src/util/websocket.ts
@@ -50,14 +50,18 @@ export class Control extends lib.Link {
 	accountName: string | null = null;
 	/** Roles of the account this control link is connected as. */
 	accountRoles: lib.AccountRole[] | null = null;
+
+	/** Updates not handled by the subscription service */
 	accountUpdateHandlers: Function[] = [];
-	hostUpdateHandlers: Map<number|null, hostHandler[]> = new Map();
-	instanceUpdateHandlers: Map<number|null, instanceHandler[]> = new Map();
-	saveListUpdateHandlers: Map<number|null, saveListHandler[]> = new Map();
-	modPackUpdateHandlers: Map<number|null, modPackHandler[]> = new Map();
-	modUpdateHandlers: Map<string|null, modInfoHandler[]> = new Map();
-	userUpdateHandlers: Map<string|null, userHandler[]> = new Map();
 	logHandlers: Map<lib.LogFilter, logHandler[]> = new Map();
+
+	/** Updates handled by the subscription service */
+	hostUpdate = new lib.EventSubscriber<lib.HostUpdateEvent, lib.HostDetails>(lib.HostUpdateEvent, event => event.update);
+	instanceUpdate = new lib.EventSubscriber<lib.InstanceDetailsUpdateEvent, lib.InstanceDetails>(lib.InstanceDetailsUpdateEvent, event => event.details);
+	saveListUpdate = new lib.EventSubscriber<lib.InstanceSaveListUpdateEvent>(lib.InstanceSaveListUpdateEvent);
+	modPackUpdate = new lib.EventSubscriber<lib.ModPackUpdateEvent, lib.ModPack>(lib.InstanceSaveListUpdateEvent, event => event.modPack);
+	modUpdate = new lib.EventSubscriber<lib.ModUpdateEvent, lib.ModInfo>(lib.InstanceSaveListUpdateEvent, event => event.mod);
+	userUpdate = new lib.EventSubscriber<lib.UserUpdateEvent, lib.RawUser>(lib.InstanceSaveListUpdateEvent, event => event.user);
 
 	declare connector: ControlConnector;
 
@@ -75,22 +79,22 @@ export class Control extends lib.Link {
 			this.accountName = data.account.name;
 			this.accountRoles = data.account.roles;
 			this.emitAccountUpdate();
-			this.updateHostSubscriptions().catch(err => logger.error(
+			this.hostUpdate.connectControl(this).catch(err => logger.error(
 				`Unexpected error updating host subscriptions:\n${err.stack}`
-			));
-			this.updateInstanceSubscriptions().catch(err => logger.error(
+			));;
+			this.instanceUpdate.connectControl(this).catch(err => logger.error(
 				`Unexpected error updating instance subscriptions:\n${err.stack}`
 			));
-			this.updateSaveListSubscriptions().catch(err => logger.error(
+			this.saveListUpdate.connectControl(this).catch(err => logger.error(
 				`Unexpected error updating save list subscriptions:\n${err.stack}`
 			));
-			this.updateModPackSubscriptions().catch(err => logger.error(
+			this.modPackUpdate.connectControl(this).catch(err => logger.error(
 				`Unexpected error updating mod pack subscriptions:\n${err.stack}`
 			));
-			this.updateModSubscriptions().catch(err => logger.error(
+			this.modUpdate.connectControl(this).catch(err => logger.error(
 				`Unexpected error updating mod subscriptions:\n${err.stack}`
 			));
-			this.updateUserSubscriptions().catch(err => logger.error(
+			this.userUpdate.connectControl(this).catch(err => logger.error(
 				`Unexpected error updating user subscriptions:\n${err.stack}`
 			));
 			this.updateLogSubscriptions().catch(err => logger.error(
@@ -113,12 +117,6 @@ export class Control extends lib.Link {
 		}
 
 		this.handle(lib.AccountUpdateEvent, this.handleAccountUpdateEvent.bind(this));
-		this.handle(lib.HostUpdateEvent, this.handleHostUpdateEvent.bind(this));
-		this.handle(lib.InstanceDetailsUpdateEvent, this.handleInstanceDetailsUpdateEvent.bind(this));
-		this.handle(lib.InstanceSaveListUpdateEvent, this.handleInstanceSaveListUpdateEvent.bind(this));
-		this.handle(lib.ModPackUpdateEvent, this.handleModPackUpdateEvent.bind(this));
-		this.handle(lib.ModUpdateEvent, this.handleModUpdateEvent.bind(this));
-		this.handle(lib.UserUpdateEvent, this.handleUserUpdateEvent.bind(this));
 		this.handle(lib.LogMessageEvent, this.handleLogMessageEvent.bind(this));
 		this.handle(lib.DebugWsMessageEvent, this.handleDebugWsMessageEvent.bind(this));
 	}
@@ -147,349 +145,6 @@ export class Control extends lib.Link {
 			throw new Error("Given handler is not registered for account update");
 		}
 		this.accountUpdateHandlers.splice(index, 1);
-	}
-
-	async handleHostUpdateEvent(event: lib.HostUpdateEvent) {
-		let handlers: Function[] = ([] as Function[]).concat(
-			this.hostUpdateHandlers.get(null) || [],
-			this.hostUpdateHandlers.get(event.update.id) || [],
-		);
-		for (let handler of handlers) {
-			handler(event.update);
-		}
-	}
-
-	async onHostUpdate(id: number|null, handler: hostHandler) {
-		if (id !== null && !Number.isInteger(id)) {
-			throw new Error("Invalid host id");
-		}
-
-		let handlers = this.hostUpdateHandlers.get(id);
-		if (!handlers) {
-			handlers = [];
-			this.hostUpdateHandlers.set(id, handlers);
-		}
-
-		handlers.push(handler);
-
-		if (handlers.length === 1) {
-			await this.updateHostSubscriptions();
-		}
-	}
-
-	async offHostUpdate(id: number|null, handler: hostHandler) {
-		let handlers = this.hostUpdateHandlers.get(id);
-		if (!handlers || !handlers.length) {
-			throw new Error(`No handlers for host ${id} exists`);
-		}
-
-		let index = handlers.lastIndexOf(handler);
-		if (index === -1) {
-			throw new Error(`Given handler is not registered for host ${id}`);
-		}
-
-		handlers.splice(index, 1);
-		if (!handlers.length) {
-			this.hostUpdateHandlers.delete(id);
-			await this.updateHostSubscriptions();
-		}
-	}
-
-	async updateHostSubscriptions() {
-		if (!this.connector.connected) {
-			return;
-		}
-
-		await this.send(new lib.HostSetSubscriptionsRequest(
-			this.hostUpdateHandlers.has(null),
-			[...this.hostUpdateHandlers.keys()].filter(e => e !== null) as number[],
-		));
-	}
-
-	async handleInstanceDetailsUpdateEvent(event: lib.InstanceDetailsUpdateEvent) {
-		let handlers = ([] as Function[]).concat(
-			this.instanceUpdateHandlers.get(null) || [],
-			this.instanceUpdateHandlers.get(event.details.id) || [],
-		);
-		for (let handler of handlers) {
-			handler(event.details);
-		}
-	};
-
-	async onInstanceUpdate(id: number|null, handler: instanceHandler) {
-		if (id !== null && !Number.isInteger(id)) {
-			throw new Error("Invalid instance id");
-		}
-
-		let handlers = this.instanceUpdateHandlers.get(id);
-		if (!handlers) {
-			handlers = [];
-			this.instanceUpdateHandlers.set(id, handlers);
-		}
-
-		handlers.push(handler);
-
-		if (handlers.length === 1) {
-			await this.updateInstanceSubscriptions();
-		}
-	}
-
-	async offInstanceUpdate(id: number|null, handler: instanceHandler) {
-		let handlers = this.instanceUpdateHandlers.get(id);
-		if (!handlers || !handlers.length) {
-			throw new Error(`No handlers for instance ${id} exist`);
-		}
-
-		let index = handlers.lastIndexOf(handler);
-		if (index === -1) {
-			throw new Error(`Given handler is not registered for instance ${id}`);
-		}
-
-		handlers.splice(index, 1);
-		if (!handlers.length) {
-			this.instanceUpdateHandlers.delete(id);
-			await this.updateInstanceSubscriptions();
-		}
-	}
-
-	async updateInstanceSubscriptions() {
-		if (!this.connector.connected) {
-			return;
-		}
-
-		await this.send(new lib.InstanceDetailsSetSubscriptionsRequest(
-			this.instanceUpdateHandlers.has(null),
-			[...this.instanceUpdateHandlers.keys()].filter(e => e !== null) as number[],
-		));
-	}
-
-	async handleInstanceSaveListUpdateEvent(event: lib.InstanceSaveListUpdateEvent) {
-		let handlers = this.saveListUpdateHandlers.get(event.instanceId);
-		for (let handler of handlers || []) {
-			handler(event);
-		}
-	};
-
-	async onSaveListUpdate(id: number, handler: saveListHandler) {
-		if (!Number.isInteger(id)) {
-			throw new Error("Invalid instance id");
-		}
-
-		let handlers = this.saveListUpdateHandlers.get(id);
-		if (!handlers) {
-			handlers = [];
-			this.saveListUpdateHandlers.set(id, handlers);
-		}
-
-		handlers.push(handler);
-
-		if (handlers.length === 1) {
-			await this.updateSaveListSubscriptions();
-		}
-	}
-
-	async offSaveListUpdate(id: number, handler: saveListHandler) {
-		let handlers = this.saveListUpdateHandlers.get(id);
-		if (!handlers) {
-			throw new Error(`No handlers for instance ${id} exists`);
-		}
-
-		let index = handlers.lastIndexOf(handler);
-		if (index === -1) {
-			throw new Error(`Given handler is not registered for instance ${id}`);
-		}
-
-		handlers.splice(index, 1);
-		if (!handlers.length) {
-			this.saveListUpdateHandlers.delete(id);
-			await this.updateSaveListSubscriptions();
-		}
-	}
-
-	async updateSaveListSubscriptions() {
-		if (!this.connector.connected) {
-			return;
-		}
-
-		await this.send(new lib.InstanceSetSaveListSubscriptionsRequest(
-			false,
-			[...this.saveListUpdateHandlers.keys()].filter(e => e !== null) as number[],
-		));
-	}
-
-	async handleModPackUpdateEvent(event: lib.ModPackUpdateEvent) {
-		let modPack = event.modPack;
-
-		let handlers = ([] as modPackHandler[]).concat(
-			this.modPackUpdateHandlers.get(null) || [],
-			this.modPackUpdateHandlers.get(modPack.id??null) || [],
-		);
-		for (let handler of handlers) {
-			handler(modPack);
-		}
-	}
-
-	async onModPackUpdate(id: number|null, handler: modPackHandler) {
-		if (id !== null && typeof id !== "number") {
-			throw new Error("Invalid mod pack id");
-		}
-
-		let handlers = this.modPackUpdateHandlers.get(id);
-		if (!handlers) {
-			handlers = [];
-			this.modPackUpdateHandlers.set(id, handlers);
-		}
-
-		handlers.push(handler);
-
-		if (handlers.length === 1) {
-			await this.updateModPackSubscriptions();
-		}
-	}
-
-	async offModPackUpdate(id: number|null, handler: modPackHandler) {
-		let handlers = this.modPackUpdateHandlers.get(id);
-		if (!handlers || !handlers.length) {
-			throw new Error(`No handlers for mod pack ${id} exist`);
-		}
-
-		let index = handlers.lastIndexOf(handler);
-		if (index === -1) {
-			throw new Error(`Given handler is not registered for mod pack ${id}`);
-		}
-
-		handlers.splice(index, 1);
-		if (!handlers.length) {
-			this.modPackUpdateHandlers.delete(id);
-			await this.updateModPackSubscriptions();
-		}
-	}
-
-	async updateModPackSubscriptions() {
-		if (!this.connector.connected) {
-			return;
-		}
-
-		await this.send(new lib.ModPackSetSubscriptionsRequest(
-			this.modPackUpdateHandlers.has(null),
-			[...this.modPackUpdateHandlers.keys()]
-				.filter(k => k !== null && k !== undefined) as number[],
-		));
-	}
-
-	async handleModUpdateEvent(event: lib.ModUpdateEvent) {
-		let mod = event.mod;
-		let handlers = ([] as modInfoHandler[]).concat(
-			this.modUpdateHandlers.get(null) || [],
-			this.modUpdateHandlers.get(mod.name) || []
-		);
-		for (let handler of handlers) {
-			handler(mod);
-		}
-	}
-
-	async onModUpdate(name: string|null, handler: modInfoHandler) {
-		if (name !== null && typeof name !== "string") {
-			throw new Error("Invalid mod name");
-		}
-
-		let handlers = this.modUpdateHandlers.get(name);
-		if (!handlers) {
-			handlers = [];
-			this.modUpdateHandlers.set(name, handlers);
-		}
-
-		handlers.push(handler);
-
-		if (handlers.length === 1) {
-			await this.updateModSubscriptions();
-		}
-	}
-
-	async offModUpdate(name: string|null, handler: modInfoHandler) {
-		let handlers = this.modUpdateHandlers.get(name);
-		if (!handlers || !handlers.length) {
-			throw new Error(`No handlers for mod ${name} exist`);
-		}
-
-		let index = handlers.lastIndexOf(handler);
-		if (index === -1) {
-			throw new Error(`Given handler is not registered for mod ${name}`);
-		}
-
-		handlers.splice(index, 1);
-		if (!handlers.length) {
-			this.modUpdateHandlers.delete(name);
-			await this.updateModSubscriptions();
-		}
-	}
-
-	async updateModSubscriptions() {
-		if (!this.connector.connected) {
-			return;
-		}
-
-		await this.send(new lib.ModSetSubscriptionsRequest(
-			this.modUpdateHandlers.has(null),
-			[...this.modUpdateHandlers.keys()].filter(k => k !== null) as string[],
-		));
-	}
-
-	async handleUserUpdateEvent(event: lib.UserUpdateEvent) {
-		let handlers = ([] as userHandler[]).concat(
-			this.userUpdateHandlers.get(null) || [],
-			this.userUpdateHandlers.get(event.user.name) || [],
-		);
-		for (let handler of handlers) {
-			handler(event.user);
-		}
-	};
-
-	async onUserUpdate(name: string|null, handler: userHandler) {
-		if (name !== null && typeof name !== "string") {
-			throw new Error("Invalid user name");
-		}
-
-		let handlers = this.userUpdateHandlers.get(name);
-		if (!handlers) {
-			handlers = [];
-			this.userUpdateHandlers.set(name, handlers);
-		}
-
-		handlers.push(handler);
-
-		if (handlers.length === 1) {
-			await this.updateUserSubscriptions();
-		}
-	}
-
-	async offUserUpdate(name: string|null, handler: userHandler) {
-		let handlers = this.userUpdateHandlers.get(name);
-		if (!handlers || !handlers.length) {
-			throw new Error(`No handlers for user ${name} exist`);
-		}
-
-		let index = handlers.lastIndexOf(handler);
-		if (index === -1) {
-			throw new Error(`Given handler is not registered for user ${name}`);
-		}
-
-		handlers.splice(index, 1);
-		if (!handlers.length) {
-			this.userUpdateHandlers.delete(name);
-			await this.updateUserSubscriptions();
-		}
-	}
-
-	async updateUserSubscriptions() {
-		if (!this.connector.connected) {
-			return;
-		}
-
-		await this.send(new lib.UserSetSubscriptionsRequest(
-			this.userUpdateHandlers.has(null),
-			[...this.userUpdateHandlers.keys()].filter(e => e !== null) as string[],
-		));
 	}
 
 	async handleLogMessageEvent(event: lib.LogMessageEvent) {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -34,19 +34,22 @@ class TestControl extends lib.Link {
 				return;
 			}
 			this.send(
-				new lib.HostSetSubscriptionsRequest(true, [])
+				new lib.SubscriptionRequest(lib.HostUpdateEvent.name, true)
 			).catch(err => logger.error(`Error setting host subscriptions:\n${err.stack}`));
 			this.send(
-				new lib.InstanceDetailsSetSubscriptionsRequest(true, [])
+				new lib.SubscriptionRequest(lib.InstanceDetailsUpdateEvent.name, true)
 			).catch(err => logger.error(`Error setting instance subscriptions:\n${err.stack}`));
 			this.send(
-				new lib.InstanceSetSaveListSubscriptionsRequest(true, [])
+				new lib.SubscriptionRequest(lib.InstanceSaveListUpdateEvent.name, true)
 			).catch(err => logger.error(`Error setting save list subscriptions:\n${err.stack}`));
 			this.send(
-				new lib.ModSetSubscriptionsRequest(true, [])
+				new lib.SubscriptionRequest(lib.ModUpdateEvent.name, true)
 			).catch(err => logger.error(`Error setting mod subscriptions:\n${err.stack}`));
 			this.send(
-				new lib.UserSetSubscriptionsRequest(true, [])
+				new lib.SubscriptionRequest(lib.ModPackUpdateEvent.name, true)
+			).catch(err => logger.error(`Error setting mod pack subscriptions:\n${err.stack}`));
+			this.send(
+				new lib.SubscriptionRequest(lib.UserUpdateEvent.name, true)
 			).catch(err => logger.error(`Error setting user subscriptions:\n${err.stack}`));
 		});
 

--- a/test/lib/subscriptions.js
+++ b/test/lib/subscriptions.js
@@ -484,7 +484,7 @@ describe("lib/subscriptions", function() {
 			});
 			it("should throw an error if the handler was not subscribed", function() {
 				function callback(value) { calledWith = value; }
-				assert.throws(
+				assert.rejects(
 					() => registeredEvent.unsubscribe(callback),
 					new Error("handler is not registered")
 				);
@@ -524,7 +524,7 @@ describe("lib/subscriptions", function() {
 			});
 			it("should throw an error if the handler was not subscribed", function() {
 				function callback() {}
-				assert.throws(
+				assert.rejects(
 					() => channelEvent.unsubscribeFromChannel("channelOne", callback),
 					new Error("handler is not registered")
 				);
@@ -532,7 +532,7 @@ describe("lib/subscriptions", function() {
 				let calledWith = null;
 				function callbackTwo(value) { calledWith = value; }
 				channelEvent.subscribeToChannel("channelOne", callbackTwo);
-				assert.throws(
+				assert.rejects(
 					() => channelEvent.unsubscribeFromChannel("channelOne", callback),
 					new Error("handler is not registered")
 				);

--- a/test/lib/subscriptions.js
+++ b/test/lib/subscriptions.js
@@ -1,231 +1,566 @@
 "use strict";
+const events = require("events");
 const assert = require("assert").strict;
 const lib = require("@clusterio/lib");
+const { MockController, MockConnector, MockControl } = require("../mock");
+
+const addr = lib.Address.fromShorthand;
 
 describe("lib/subscriptions", function() {
+	class UnregisteredEvent {
+		static type = "event";
+		static src = ["controller", "control"];
+		static dst = ["controller", "control"];
+		static permission = null;
+	}
+
+	class RegisteredEvent {
+		static type = "event";
+		static src = ["controller", "control"];
+		static dst = ["controller", "control"];
+		static permission = null;
+	}
+	lib.Link.register(RegisteredEvent);
+
+	class ChannelEvent {
+		static type = "event";
+		static src = ["controller", "control"];
+		static dst = ["controller", "control"];
+		static permission = null;
+	}
+	lib.Link.register(ChannelEvent);
+
+	class StringPermissionEvent {
+		static type = "event";
+		static src = ["controller", "control"];
+		static dst = ["controller", "control"];
+		static permission = "StringPermission";
+	}
+	lib.Link.register(StringPermissionEvent);
+
+	class FunctionPermissionEvent {
+		static type = "event";
+		static src = ["controller", "control"];
+		static dst = ["controller", "control"];
+		static permission(user, message) {
+			user.checkPermission("FunctionPermission");
+		};
+	}
+	lib.Link.register(FunctionPermissionEvent);
+
+	class MockUser {
+		checkPermission(permission) {
+			this.lastPermissionCheck = permission;
+		}
+	}
+
 	describe("class SubscriptionResponse", function() {
-		describe("constructor()", function() {
-			it("should be constructable without an event replay", function() {
-				assert(false);
-			});
-			it("should be constructable with an event replay", function() {
-				assert(false);
-			});
-		});
-
-		describe("toJSON()", function() {
-			it("should be serialisable to json without an event replay", function() {
-				assert(false);
-			});
-			it("should be serialisable to json with an event replay", function() {
-				assert(false);
-			});
-		});
-
-		describe("fromJSON()", function() {
-			it("should be deserialisable from json without an event replay", function() {
-				assert(false);
-			});
-			it("should be deserialisable from json with an event replay", function() {
-				assert(false);
-			});
-		});
-
 		it("should be round trip json serialisable without an event replay", function() {
-			assert(false);
+			const response = new lib.SubscriptionResponse();
+			const json = JSON.stringify(response);
+			assert.equal(typeof json, "string");
+			const reconstructed = lib.SubscriptionResponse.fromJSON(JSON.parse(json));
+			assert.deepEqual(reconstructed, response);
 		});
 
 		it("should be round trip json serialisable with an event replay", function() {
-			assert(false);
+			const response = new lib.SubscriptionResponse(new RegisteredEvent());
+			const json = JSON.stringify(response);
+			assert.equal(typeof json, "string");
+			const reconstructed = lib.SubscriptionResponse.fromJSON(JSON.parse(json));
+			assert.deepEqual(reconstructed, response);
+		});
+
+		it("should be round trip json serialisable with a null event replay", function() {
+			const response = new lib.SubscriptionResponse(null);
+			const json = JSON.stringify(response);
+			assert.equal(typeof json, "string");
+			const reconstructed = lib.SubscriptionResponse.fromJSON(JSON.parse(json));
+			assert.deepEqual(reconstructed, response);
+		});
+
+		it("should be throw when given an unregistered event", function() {
+			assert.throws(
+				() => new lib.SubscriptionResponse(new UnregisteredEvent()),
+				new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+			);
 		});
 	});
 
 	describe("class SubscriptionRequest", function() {
-		describe("constructor()", function() {
-			it("should be constructable with only an allChannels argument", function() {
-				assert(false);
-			});
-			it("should be constructable with without a lastRequestTime", function() {
-				assert(false);
-			});
-			it("should be constructable with with a lastRequestTime", function() {
-				assert(false);
-			});
-		});
-
 		describe("permission()", function() {
 			it("should do nothing when the event has no permission property", function() {
-				assert(false);
+				const mockUser = new MockUser();
+				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
+				lib.SubscriptionRequest.permission(mockUser, new lib.MessageRequest(
+					0,
+					addr({ controlId: 0 }),
+					addr("controller"),
+					lib.SubscriptionRequest.name,
+					JSON.stringify(request)
+				));
+				assert.equal(mockUser.lastPermissionCheck, undefined);
 			});
 			it("should check user permission when the permission property is a string", function() {
-				assert(false);
+				const mockUser = new MockUser();
+				const request = new lib.SubscriptionRequest(StringPermissionEvent.name, true);
+				lib.SubscriptionRequest.permission(mockUser, new lib.MessageRequest(
+					0,
+					addr({ controlId: 0 }),
+					addr("controller"),
+					lib.SubscriptionRequest.name,
+					request.toJSON()
+				));
+				assert.equal(mockUser.lastPermissionCheck, "StringPermission");
 			});
 			it("should call the permission property when it is a function", function() {
-				assert(false);
+				const mockUser = new MockUser();
+				const request = new lib.SubscriptionRequest(FunctionPermissionEvent.name, true);
+				lib.SubscriptionRequest.permission(mockUser, new lib.MessageRequest(
+					0,
+					addr({ controlId: 0 }),
+					addr("controller"),
+					lib.SubscriptionRequest.name,
+					request.toJSON()
+				));
+				assert.equal(mockUser.lastPermissionCheck, "FunctionPermission");
 			});
-		});
-
-		it("should be serialisable to json", function() {
-			assert(false);
-		});
-
-		it("should be deserialisable from json", function() {
-			assert(false);
 		});
 
 		it("should be round trip json serialisable", function() {
-			assert(false);
+			const request = new lib.SubscriptionRequest(RegisteredEvent.name, true, ["channelOne"], 123);
+			const json = JSON.stringify(request);
+			assert.equal(typeof json, "string");
+			const reconstructed = lib.SubscriptionRequest.fromJSON(JSON.parse(json));
+			assert.deepEqual(reconstructed, request);
+		});
+
+		it("should be throw when given an unregistered event", function() {
+			assert.throws(
+				() => new lib.SubscriptionRequest(UnregisteredEvent.name, true),
+				new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+			);
 		});
 	});
 
 	describe("class SubscriptionController", function() {
+		let mockController, subscriptions;
+		const connectorSetupDate = [{
+			id: 1,
+			request: new lib.SubscriptionRequest(RegisteredEvent.name, true),
+			src: addr({ controlId: 1 }),
+			dst: addr("controller"),
+		}, {
+			id: 2,
+			request: new lib.SubscriptionRequest(RegisteredEvent.name, true),
+			src: addr({ controlId: 2 }),
+			dst: addr("controller"),
+		}, {
+			id: 3,
+			request: new lib.SubscriptionRequest(ChannelEvent.name, true),
+			src: addr({ controlId: 3 }),
+			dst: addr("controller"),
+		}, {
+			id: 4,
+			request: new lib.SubscriptionRequest(ChannelEvent.name, false, ["channelOne"]),
+			src: addr({ controlId: 4 }),
+			dst: addr("controller"),
+		}, {
+			id: 5,
+			request: new lib.SubscriptionRequest(ChannelEvent.name, false, ["channelTwo"]),
+			src: addr({ controlId: 5 }),
+			dst: addr("controller"),
+		}];
+
+		function awaitMessages(ids) {
+			return Promise.all(ids.map(function(id) {
+				const link = mockController.wsServer.controlConnections.get(id);
+				return events.once(link.connector, "send");
+			}));
+		}
+
+		function assertLastEvent(connectorId, Event) {
+			const link = mockController.wsServer.controlConnections.get(connectorId);
+			const lastMessage = link.connector.sentMessages.at(-1);
+			const name = Event.plugin ? `${Event.plugin}:${Event.name}` : Event.name;
+			assert.equal(lastMessage.name, name);
+		}
+
+		function assertNoEvent(connectorId) {
+			const link = mockController.wsServer.controlConnections.get(connectorId);
+			assert.equal(link.connector.sentMessages.length, 0);
+		}
+
+		beforeEach(function() {
+			mockController = new MockController();
+			mockController.wsServer = {
+				controlConnections: new Map(connectorSetupDate.map(function (connectorData) {
+					return [connectorData.id, new lib.Link(new MockConnector(connectorData.src, connectorData.dst))];
+				})),
+			};
+			subscriptions = new lib.SubscriptionController(mockController);
+		});
+
 		it("should handle the SubscriptionRequest event", function() {
-			assert(false);
+			assert.equal(mockController.handles.has(lib.SubscriptionRequest), true);
 		});
 
 		describe("handle()", function() {
 			it("should accept registered events", function() {
-				assert(false);
+				subscriptions.handle(RegisteredEvent);
 			});
 			it("should not accept unregistered events", function() {
-				assert(false);
+				assert.throws(
+					() => subscriptions.handle(UnregisteredEvent),
+					new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+				);
 			});
 			it("should not accept events already handled by the class", function() {
-				assert(false);
+				subscriptions.handle(RegisteredEvent);
+				assert.throws(
+					() => subscriptions.handle(RegisteredEvent),
+					new Error(`Event ${RegisteredEvent.name} is already registered`)
+				);
 			});
 		});
 
 		describe("broadcast()", function() {
+			beforeEach(function() {
+				subscriptions.handle(RegisteredEvent);
+				subscriptions.handle(ChannelEvent, () => "channelOne");
+				for (let connectorData of connectorSetupDate) {
+					subscriptions._handleRequest(connectorData.request, connectorData.src, connectorData.dst);
+				}
+			});
+
 			it("should not accept unregistered events", function() {
-				assert(false);
+				assert.throws(
+					() => subscriptions.broadcast(new UnregisteredEvent()),
+					new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+				);
 			});
 			it("should not accept events not handled by the class", function() {
-				assert(false);
+				assert.throws(
+					() => subscriptions.broadcast(new StringPermissionEvent()),
+					new Error(`Event ${StringPermissionEvent.name} is not a registered as subscribable`)
+				);
 			});
-			it("should notify all links who subscribed all notifications, when channels are disabled", function() {
-				assert(false);
+			it("should notify all links who subscribed to all channels", async function() {
+				const messages = awaitMessages([1, 2]);
+				subscriptions.broadcast(new RegisteredEvent());
+				await messages;
+				assertLastEvent(1, RegisteredEvent); // RegisteredEvent: All
+				assertLastEvent(2, RegisteredEvent); // RegisteredEvent: All
+				assertNoEvent(3); // ChannelEvent: All
+				assertNoEvent(4); // ChannelEvent: channelOne
+				assertNoEvent(5); // ChannelEvent: channelTwo
 			});
-			it("should notify all links who subscribed all notifications, when channels are enabled", function() {
-				assert(false);
+			it("should not notify a link who unsubscribed from all all channels", async function() {
+				const messages = awaitMessages([2]);
+				const connectorData = connectorSetupDate[1];
+				const request = new lib.SubscriptionRequest(RegisteredEvent.name, false);
+				await subscriptions._handleRequest(request, connectorData.src, connectorData.dst);
+				subscriptions.broadcast(new RegisteredEvent());
+				await messages;
+				assertNoEvent(1);
+				assertLastEvent(2, RegisteredEvent);
+				assertNoEvent(3);
+				assertNoEvent(4);
+				assertNoEvent(5);
 			});
-			it("should not notify a link who unsubscribed from all notifications", function() {
-				assert(false);
+			it("should notify all links who subscribed the specific channel", async function() {
+				const messages = awaitMessages([3, 4]);
+				subscriptions.broadcast(new ChannelEvent());
+				await messages;
+				assertNoEvent(1);
+				assertNoEvent(2);
+				assertLastEvent(3, ChannelEvent);
+				assertNoEvent(4, ChannelEvent);
+				assertNoEvent(5);
 			});
-			it("should notify all links who subscribed the specific channel", function() {
-				assert(false);
+			it("should not notify a link who unsubscribed from the specific channel", async function() {
+				const messages = awaitMessages([3]);
+				const connectorData = connectorSetupDate[4];
+				const request = new lib.SubscriptionRequest(ChannelEvent.name, false, []);
+				await subscriptions._handleRequest(request, connectorData.src, connectorData.dst);
+				subscriptions.broadcast(new ChannelEvent());
+				await messages;
+				assertNoEvent(1);
+				assertNoEvent(2);
+				assertLastEvent(3, ChannelEvent);
+				assertNoEvent(4);
+				assertNoEvent(5);
 			});
-			it("should not notify a link who did subscribe the specific channel", function() {
-				assert(false);
-			});
-			it("should not notify a link who unsubscribed from the specific channel", function() {
-				assert(false);
-			});
-			it("should not notify links which are closed or closing", function() {
-				assert(false);
+			it("should not notify links which are closed or closing", async function() {
+				const messages = awaitMessages([2]);
+				const link = mockController.wsServer.controlConnections.get(1);
+				link.connector.closing = true;
+				subscriptions.broadcast(new RegisteredEvent());
+				await messages;
+				assertNoEvent(1);
+				assertLastEvent(2, RegisteredEvent);
+				assertNoEvent(3);
+				assertNoEvent(4);
+				assertNoEvent(5);
 			});
 		});
 
-		describe("_handleEvent()", function() {
+		describe("_handleRequest()", function() {
+			beforeEach(function() {
+				subscriptions.handle(RegisteredEvent);
+				subscriptions.handle(ChannelEvent, () => "channelOne");
+			});
+
 			it("should not accept subscriptions to unregistered events", function() {
-				assert(false);
+				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
+				request.eventName = UnregisteredEvent.name;
+				assert.throws(
+					() => subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst),
+					new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+				);
 			});
 			it("should not accept subscriptions to events not handled by the class", function() {
-				assert(false);
+				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
+				request.eventName = StringPermissionEvent.name;
+				assert.throws(
+					() => subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst),
+					new Error(`Unregistered Event class ${StringPermissionEvent.name}`)
+				);
 			});
-			it("should accept a subscription to all notifications for an event", function() {
-				assert(false);
+			it("should accept a subscription to all channels", async function() {
+				const messages = awaitMessages([1]);
+				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
+				await subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new RegisteredEvent());
+				await messages;
+				assertLastEvent(1, RegisteredEvent);
 			});
-			it("should accept a unsubscription from all notifications for an event", function() {
-				assert(false);
+			it("should accept a unsubscription from all channels", async function() {
+				const messages = awaitMessages([1]);
+				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
+				await subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new RegisteredEvent());
+				await messages;
+				assertLastEvent(1, RegisteredEvent);
+
+				const link = mockController.wsServer.controlConnections.get(1);
+				link.connector.sentMessages.pop();
+
+				const unsubRequest = new lib.SubscriptionRequest(RegisteredEvent.name, false);
+				await subscriptions._handleRequest(unsubRequest, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new RegisteredEvent());
+				assertNoEvent(1);
 			});
-			it("should accept a subscription to a specific channel for an event", function() {
-				assert(false);
+			it("should accept a subscription to a specific channel", async function() {
+				const messages = awaitMessages([1]);
+				const request = new lib.SubscriptionRequest(ChannelEvent.name, false, ["channelOne"]);
+				await subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new ChannelEvent());
+				await messages;
+				assertLastEvent(1, ChannelEvent);
 			});
-			it("should accept a unsubscription from a specific channel for an event", function() {
-				assert(false);
+			it("should accept a unsubscription from a specific channel", async function() {
+				const messages = awaitMessages([1]);
+				const request = new lib.SubscriptionRequest(ChannelEvent.name, false, ["channelOne"]);
+				await subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new ChannelEvent());
+				await messages;
+				assertLastEvent(1, ChannelEvent);
+
+				const link = mockController.wsServer.controlConnections.get(1);
+				link.connector.sentMessages.pop();
+
+				const unsubRequest = new lib.SubscriptionRequest(ChannelEvent.name, false, []);
+				await subscriptions._handleRequest(unsubRequest, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new ChannelEvent());
+				assertNoEvent(1);
 			});
-			it("should accept a respond with an event replay when returned by the handler", function() {
-				assert(false);
+			it("should accept a respond with an event replay when returned by the handler", async function() {
+				const messages = awaitMessages([1]);
+				subscriptions.handle(StringPermissionEvent, undefined, async function() {
+					return new StringPermissionEvent();
+				});
+
+				const request = new lib.SubscriptionRequest(StringPermissionEvent.name, true);
+				await subscriptions._handleRequest(request, connectorSetupDate[0].src, connectorSetupDate[0].dst);
+				subscriptions.broadcast(new StringPermissionEvent());
+				await messages;
+				assertLastEvent(1, StringPermissionEvent);
+
+				const link = mockController.wsServer.controlConnections.get(1);
+				const lastMessage = link.connector.sentMessages.pop();
+				const response = lib.SubscriptionResponse.fromJSON(lastMessage.data);
+				assert.deepEqual(response, new lib.SubscriptionResponse(new StringPermissionEvent()));
 			});
 		});
 	});
 
 	describe("class EventSubscriber", function() {
+		let channelEvent, mockControl, registeredEvent;
+		beforeEach(function() {
+			mockControl = new MockControl(new MockConnector(
+				addr({ controlId: 1 }),
+				addr("controller"),
+			));
+			registeredEvent = new lib.EventSubscriber(RegisteredEvent, undefined, mockControl);
+			channelEvent = new lib.EventSubscriber(ChannelEvent, undefined, mockControl);
+		});
+
+		function assertLastRequest(request) {
+			const Request = request.constructor;
+			const lastMessage = mockControl.connector.sentMessages.at(-1);
+			const name = Request.plugin ? `${Request.plugin}:${Request.name}` : Request.name;
+			assert.equal(lastMessage.name, name);
+			assert.deepEqual(lastMessage.data, request);
+		}
+
 		describe("constructor()", function() {
 			it("should not accept unregistered events", function() {
-				assert(false);
+				assert.throws(
+					() => new lib.EventSubscriber(UnregisteredEvent),
+					new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+				);
 			});
-			it("should handle the provided event if a control link is given", function() {
-				assert(false);
+			it("should handle the provided event, if a control link is provided", function() {
+				assert.equal(mockControl._eventHandlers.has(RegisteredEvent), true);
+				assert.equal(mockControl._eventHandlers.has(ChannelEvent), true);
 			});
-			it("should call and use the return of a pre-handler if provided", function() {
-				assert(false);
+			it("should call and use the return of a pre-handler, if provided", function() {
+				let calledWith = null;
+				function prehandler() { return "PreHandlerReturn"; }
+				const eventSubscriber = new lib.EventSubscriber(StringPermissionEvent, prehandler, mockControl);
+				eventSubscriber.subscribe(function(value) { calledWith = value; });
+				eventSubscriber._handle(new StringPermissionEvent());
+				assert.equal(calledWith, "PreHandlerReturn");
 			});
 		});
 
 		describe("connectControl()", function() {
 			it("should handle the provided event", function() {
-				assert(false);
+				const control = new MockControl(new MockConnector(
+					addr({ controlId: 1 }),
+					addr("controller"),
+				));
+				registeredEvent.connectControl(control);
+				assert.equal(control._eventHandlers.has(RegisteredEvent), true);
 			});
 			it("should do nothing if the control is already connected", function() {
-				assert(false);
+				assert.equal(mockControl._eventHandlers.has(RegisteredEvent), true);
+				registeredEvent.connectControl(mockControl);
+				assert.equal(mockControl._eventHandlers.has(RegisteredEvent), true);
 			});
 		});
 
 		describe("subscribe()", function() {
 			it("should allow subscriptions to an event", function() {
-				assert(false);
-			});
-			it("should call all handlers who subscripted, when channels are disabled", function() {
-				assert(false);
-			});
-			it("should call all handlers who subscripted, when channels are enabled", function() {
-				assert(false);
+				let calledWith = null;
+				let calledWithTwo = null;
+				const event = new RegisteredEvent();
+				registeredEvent.subscribe(function(value) { calledWith = value; });
+				registeredEvent.subscribe(function(value) { calledWithTwo = value; });
+				registeredEvent._handle(event);
+				assert.deepEqual(calledWith, event);
+				assert.deepEqual(calledWithTwo, event);
 			});
 		});
 
 		describe("subscribeToChannel()", function() {
 			it("should allow subscriptions to a channel for an event", function() {
-				assert(false);
-			});
-			it("should call all handlers who subscripted to the specific channel", function() {
-				assert(false);
-			});
-			it("should not call a handler who did not subscribe to the specific channel", function() {
-				assert(false);
+				let calledWith = null;
+				let calledWithTwo = null;
+				const event = new ChannelEvent();
+				channelEvent.subscribeToChannel("channelOne", function(value) { calledWith = value; });
+				channelEvent.subscribeToChannel("channelTwo", function(value) { calledWithTwo = value; });
+				channelEvent._handle(event);
+				assert.deepEqual(calledWith, event);
+				assert.deepEqual(calledWithTwo, null);
 			});
 		});
 
 		describe("unsubscribe()", function() {
 			it("should allow unsubscribing from an event", function() {
-				assert(false);
+				let calledWith = null;
+				let event = new RegisteredEvent();
+				function callback(value) { calledWith = value; }
+				registeredEvent.subscribe(callback);
+				registeredEvent._handle(event);
+				assert.deepEqual(calledWith, event);
+
+				calledWith = null;
+				event = new RegisteredEvent();
+				registeredEvent.unsubscribe(callback);
+				registeredEvent._handle(event);
+				assert.equal(calledWith, null);
 			});
 			it("should throw an error if the handler was not subscribed", function() {
-				assert(false);
+				function callback(value) { calledWith = value; }
+				assert.throws(
+					() => registeredEvent.unsubscribe(callback),
+					new Error("handler is not registered")
+				);
 			});
 		});
 
 		describe("unsubscribeFromChannel()", function() {
 			it("should allow unsubscribing from a channel for an event", function() {
-				assert(false);
+				let calledWith = null;
+				let event = new ChannelEvent();
+				function callback(value) { calledWith = value; }
+				channelEvent.subscribeToChannel("channelOne", callback);
+				channelEvent._handle(event);
+				assert.deepEqual(calledWith, event);
+
+				calledWith = null;
+				event = new ChannelEvent();
+				channelEvent.unsubscribeFromChannel("channelOne", callback);
+				channelEvent._handle(event);
+				assert.equal(calledWith, null);
 			});
 			it("should throw an error if the handler was not subscribed", function() {
-				assert(false);
+				function callback(value) { calledWith = value; }
+				assert.throws(
+					() => channelEvent.unsubscribeFromChannel("channelOne", callback),
+					new Error("handler is not registered")
+				);
 			});
 		});
 
 		describe("_updateSubscription()", function() {
-			it("should correctly request a subscription for all channels", function() {
-				assert(false);
+			it("should correctly request a subscription for all channels", async function() {
+				const expected = new lib.SubscriptionRequest(RegisteredEvent.name, true);
+				registeredEvent.subscribe(() => true);
+				await events.once(mockControl.connector, "send");
+				assertLastRequest(expected);
 			});
-			it("should correctly request a subscription for some channels", function() {
-				assert(false);
+			it("should correctly request a subscription for some channels", async function() {
+				const expected = new lib.SubscriptionRequest(ChannelEvent.name, false, ["channelOne"]);
+				channelEvent.subscribeToChannel("channelOne", () => true);
+				await events.once(mockControl.connector, "send");
+				assertLastRequest(expected);
 			});
-			it("should correctly request a subscription for no channels", function() {
-				assert(false);
+			it("should correctly request a subscription for no channels", async function() {
+				const expected = new lib.SubscriptionRequest(RegisteredEvent.name, false);
+				function callback() {}
+				registeredEvent.subscribe(callback);
+				await events.once(mockControl.connector, "send");
+				registeredEvent.unsubscribe(callback);
+				await events.once(mockControl.connector, "send");
+				assertLastRequest(expected);
 			});
-			it("should call handlers when a replay event is returned", function() {
-				assert(false);
+			it("should call handlers when a replay event is returned", async function() {
+				let calledWith = null;
+				const event = new RegisteredEvent();
+				const request = registeredEvent.subscribe(function(value) { calledWith = value; });
+				await events.once(mockControl.connector, "send");
+
+				const responseMessage = new lib.MessageResponse(
+					1,
+					mockControl.connector.dst,
+					mockControl.connector.src,
+					new lib.SubscriptionResponse(event)
+				);
+				mockControl.connector.emit("message", responseMessage);
+				assert.deepEqual(await request, event);
 			});
 		});
 	});

--- a/test/lib/subscriptions.js
+++ b/test/lib/subscriptions.js
@@ -1,0 +1,232 @@
+"use strict";
+const assert = require("assert").strict;
+const lib = require("@clusterio/lib");
+
+describe("lib/subscriptions", function() {
+	describe("class SubscriptionResponse", function() {
+		describe("constructor()", function() {
+			it("should be constructable without an event replay", function() {
+				assert(false);
+			});
+			it("should be constructable with an event replay", function() {
+				assert(false);
+			});
+		});
+
+		describe("toJSON()", function() {
+			it("should be serialisable to json without an event replay", function() {
+				assert(false);
+			});
+			it("should be serialisable to json with an event replay", function() {
+				assert(false);
+			});
+		});
+
+		describe("fromJSON()", function() {
+			it("should be deserialisable from json without an event replay", function() {
+				assert(false);
+			});
+			it("should be deserialisable from json with an event replay", function() {
+				assert(false);
+			});
+		});
+
+		it("should be round trip json serialisable without an event replay", function() {
+			assert(false);
+		});
+
+		it("should be round trip json serialisable with an event replay", function() {
+			assert(false);
+		});
+	});
+
+	describe("class SubscriptionRequest", function() {
+		describe("constructor()", function() {
+			it("should be constructable with only an allChannels argument", function() {
+				assert(false);
+			});
+			it("should be constructable with without a lastRequestTime", function() {
+				assert(false);
+			});
+			it("should be constructable with with a lastRequestTime", function() {
+				assert(false);
+			});
+		});
+
+		describe("permission()", function() {
+			it("should do nothing when the event has no permission property", function() {
+				assert(false);
+			});
+			it("should check user permission when the permission property is a string", function() {
+				assert(false);
+			});
+			it("should call the permission property when it is a function", function() {
+				assert(false);
+			});
+		});
+
+		it("should be serialisable to json", function() {
+			assert(false);
+		});
+
+		it("should be deserialisable from json", function() {
+			assert(false);
+		});
+
+		it("should be round trip json serialisable", function() {
+			assert(false);
+		});
+	});
+
+	describe("class SubscriptionController", function() {
+		it("should handle the SubscriptionRequest event", function() {
+			assert(false);
+		});
+
+		describe("handle()", function() {
+			it("should accept registered events", function() {
+				assert(false);
+			});
+			it("should not accept unregistered events", function() {
+				assert(false);
+			});
+			it("should not accept events already handled by the class", function() {
+				assert(false);
+			});
+		});
+
+		describe("broadcast()", function() {
+			it("should not accept unregistered events", function() {
+				assert(false);
+			});
+			it("should not accept events not handled by the class", function() {
+				assert(false);
+			});
+			it("should notify all links who subscribed all notifications, when channels are disabled", function() {
+				assert(false);
+			});
+			it("should notify all links who subscribed all notifications, when channels are enabled", function() {
+				assert(false);
+			});
+			it("should not notify a link who unsubscribed from all notifications", function() {
+				assert(false);
+			});
+			it("should notify all links who subscribed the specific channel", function() {
+				assert(false);
+			});
+			it("should not notify a link who did subscribe the specific channel", function() {
+				assert(false);
+			});
+			it("should not notify a link who unsubscribed from the specific channel", function() {
+				assert(false);
+			});
+			it("should not notify links which are closed or closing", function() {
+				assert(false);
+			});
+		});
+
+		describe("_handleEvent()", function() {
+			it("should not accept subscriptions to unregistered events", function() {
+				assert(false);
+			});
+			it("should not accept subscriptions to events not handled by the class", function() {
+				assert(false);
+			});
+			it("should accept a subscription to all notifications for an event", function() {
+				assert(false);
+			});
+			it("should accept a unsubscription from all notifications for an event", function() {
+				assert(false);
+			});
+			it("should accept a subscription to a specific channel for an event", function() {
+				assert(false);
+			});
+			it("should accept a unsubscription from a specific channel for an event", function() {
+				assert(false);
+			});
+			it("should accept a respond with an event replay when returned by the handler", function() {
+				assert(false);
+			});
+		});
+	});
+
+	describe("class EventSubscriber", function() {
+		describe("constructor()", function() {
+			it("should not accept unregistered events", function() {
+				assert(false);
+			});
+			it("should handle the provided event if a control link is given", function() {
+				assert(false);
+			});
+			it("should call and use the return of a pre-handler if provided", function() {
+				assert(false);
+			});
+		});
+
+		describe("connectControl()", function() {
+			it("should handle the provided event", function() {
+				assert(false);
+			});
+			it("should do nothing if the control is already connected", function() {
+				assert(false);
+			});
+		});
+
+		describe("subscribe()", function() {
+			it("should allow subscriptions to an event", function() {
+				assert(false);
+			});
+			it("should call all handlers who subscripted, when channels are disabled", function() {
+				assert(false);
+			});
+			it("should call all handlers who subscripted, when channels are enabled", function() {
+				assert(false);
+			});
+		});
+
+		describe("subscribeToChannel()", function() {
+			it("should allow subscriptions to a channel for an event", function() {
+				assert(false);
+			});
+			it("should call all handlers who subscripted to the specific channel", function() {
+				assert(false);
+			});
+			it("should not call a handler who did not subscribe to the specific channel", function() {
+				assert(false);
+			});
+		});
+
+		describe("unsubscribe()", function() {
+			it("should allow unsubscribing from an event", function() {
+				assert(false);
+			});
+			it("should throw an error if the handler was not subscribed", function() {
+				assert(false);
+			});
+		});
+
+		describe("unsubscribeFromChannel()", function() {
+			it("should allow unsubscribing from a channel for an event", function() {
+				assert(false);
+			});
+			it("should throw an error if the handler was not subscribed", function() {
+				assert(false);
+			});
+		});
+
+		describe("_updateSubscription()", function() {
+			it("should correctly request a subscription for all channels", function() {
+				assert(false);
+			});
+			it("should correctly request a subscription for some channels", function() {
+				assert(false);
+			});
+			it("should correctly request a subscription for no channels", function() {
+				assert(false);
+			});
+			it("should call handlers when a replay event is returned", function() {
+				assert(false);
+			});
+		});
+	});
+});

--- a/test/mock.js
+++ b/test/mock.js
@@ -178,9 +178,11 @@ class MockController {
 		]);
 		this.instances = new Map();
 		this.hosts = new Map();
+		this.handles = new Map();
 	}
 
-	handle() {
+	handle(eventClass, handler) {
+		this.handles.set(eventClass, handler);
 	}
 
 	getControllerUrl() {


### PR DESCRIPTION
Based on backlog item #514. This PR will reduce a large amount of boilerplate and introduce unit tests for this abstraction layer. This layer currently works on the assumption that all filtering and sorting is done on the client, so it does not fully meet the requirements of the item where it states "without loading all elements onto the client". This assumption was made so that the task could be broken into smaller parts and because the current implementation does the sorting and filtering on the client side.

This PR implements the following changes:
- A new Subscriptions library which includes `SubscriptionController` (for contoller / instance) and `EventSubscriber` (for control / instance)
- A refactor of `Controller` and `ControlConnection` to use `SubscriptionController`
- A refactor of `web_ui` websocket events to use `EventSubscriber`
- Update of `TestControl` to use the new `SubscriptionRequest` event
- Creation of new unit tests for the subscription library.

Out of scope for this PR:
- Refactoring `LogMessageEvent` to use `EventSubscriber`. The log event needs to handle three channel types, this would be possible through adding prefixes (eg `controler` `instance:<id>` `host:<id>`) However, this would require a refactor of `lib.logFilter` and `lib.queryLog` or a conversion function between the formats, both of which I am considering out of scope.
- Refactoring `AccountUpdate` to use `EventSubscriber`. This event doesn't need to use subscriptions because a control will only ever listen on one channel from the moment it starts until it stops. To remove the boilerplate the nodejs event emiter could be used as it includes both `.on` and `.off`. Because this is not related to subscriptions I am considering it out of scope.