### PR TITLE
Add VSCode workspace config

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"editor.detectIndentation": false,
+	"editor.insertSpaces": false,
+	"files.eol": "\n",
+	"files.insertFinalNewline": true,
+	"files.trimFinalNewlines": true,
+	"[markdown]": {
+		"editor.indentSize": 4,
+		"editor.insertSpaces": true,
+	},
+}

--- a/package.json
+++ b/package.json
@@ -1,45 +1,45 @@
 {
-  "name": "root",
-  "private": true,
-  "scripts": {
-    "build": "tsc --build",
-    "test": "pnpm run build && mocha --check-leaks -R spec --recursive test \"plugins/*/test/**\"",
-    "fast-test": "FAST_TEST=y pnpm test",
-    "cover": "nyc pnpm test",
-    "fast-cover": "FAST_TEST=y nyc pnpm test",
-    "ci-cover": "nyc --reporter=lcovonly pnpm run-script test",
-    "lint": "eslint \"*.js\" packages plugins test",
-    "lint-fix": "eslint --fix \"*.js\" packages plugins test",
-    "docs": "typedoc",
-    "bundle-dependencies": "bundle-dependencies"
-  },
-  "nyc": {
-    "exclude": [
-      "test/**",
-      "plugins/*/test/**"
-    ]
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "devDependencies": {
-    "@clusterio/controller": "workspace:*",
-    "@clusterio/ctl": "workspace:*",
-    "@clusterio/host": "workspace:*",
-    "@clusterio/lib": "workspace:*",
-    "@typescript-eslint/eslint-plugin": "^6.4.1",
-    "@typescript-eslint/parser": "^6.4.1",
-    "eslint": "^8.45.0",
-    "eslint-plugin-node": "^11.1.0",
-    "express": "^4.18.2",
-    "form-data": "^4.0.0",
-    "fs-extra": "^11.1.1",
-    "jsonwebtoken": "^9.0.1",
-    "jszip": "^3.10.0",
-    "mocha": "^10.2.0",
-    "nyc": "^15.1.0",
-    "phin": "^3.7.0",
-    "typedoc": "^0.24.8",
-    "typescript": "^5.1.6"
-  }
+	"name": "root",
+	"private": true,
+	"scripts": {
+		"build": "tsc --build",
+		"test": "pnpm run build && mocha --check-leaks -R spec --recursive test \"plugins/*/test/**\"",
+		"fast-test": "FAST_TEST=y pnpm test",
+		"cover": "nyc pnpm test",
+		"fast-cover": "FAST_TEST=y nyc pnpm test",
+		"ci-cover": "nyc --reporter=lcovonly pnpm run-script test",
+		"lint": "eslint \"*.js\" packages plugins test",
+		"lint-fix": "eslint --fix \"*.js\" packages plugins test",
+		"docs": "typedoc",
+		"bundle-dependencies": "bundle-dependencies"
+	},
+	"nyc": {
+		"exclude": [
+			"test/**",
+			"plugins/*/test/**"
+		]
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"devDependencies": {
+		"@clusterio/controller": "workspace:*",
+		"@clusterio/ctl": "workspace:*",
+		"@clusterio/host": "workspace:*",
+		"@clusterio/lib": "workspace:*",
+		"@typescript-eslint/eslint-plugin": "^6.4.1",
+		"@typescript-eslint/parser": "^6.4.1",
+		"eslint": "^8.45.0",
+		"eslint-plugin-node": "^11.1.0",
+		"express": "^4.18.2",
+		"form-data": "^4.0.0",
+		"fs-extra": "^11.1.1",
+		"jsonwebtoken": "^9.0.1",
+		"jszip": "^3.10.0",
+		"mocha": "^10.2.0",
+		"nyc": "^15.1.0",
+		"phin": "^3.7.0",
+		"typedoc": "^0.24.8",
+		"typescript": "^5.1.6"
+	}
 }

--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -164,7 +164,7 @@ async function handleBootstrapCommand(
 			userManager.signUserToken(admin.name),
 		);
 
-		let content = JSON.stringify(controlConfig.serialize(), null, 4);
+		let content = JSON.stringify(controlConfig.serialize(), null, "\t");
 		if (args.output === "-") {
 			// eslint-disable-next-line no-console
 			console.log(content);
@@ -343,7 +343,7 @@ async function initialize(): Promise<InitializeParameters> {
 		let bytes = await asyncRandomBytes(256);
 		controllerConfig.set("controller.auth_secret", bytes.toString("base64"));
 		await lib.safeOutputFile(
-			controllerConfigPath, JSON.stringify(controllerConfig.serialize(), null, 4)
+			controllerConfigPath, JSON.stringify(controllerConfig.serialize(), null, "\t")
 		);
 	}
 

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -1,58 +1,58 @@
 {
-  "name": "@clusterio/controller",
-  "description": "Implementation of Clusterio controller",
-  "author": "Hornwitser",
-  "license": "MIT",
-  "version": "2.0.0-alpha.13",
-  "main": "dist/controller.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "bin": {
-    "clusteriocontroller": "./dist/controller.js"
-  },
-  "keywords": [
-    "factorio"
-  ],
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "busboy": "^1.6.0",
-    "compression": "^1.7.4",
-    "express": "^4.18.2",
-    "fs-extra": "^11.1.1",
-    "jsonwebtoken": "^9.0.1",
-    "jszip": "^3.10.1",
-    "set-blocking": "^2.0.0",
-    "webpack-cli": "^5.1.4",
-    "winston": "^3.10.0",
-    "winston-daily-rotate-file": "^4.7.1",
-    "ws": "^8.13.0",
-    "yargs": "^17.7.2"
-  },
-  "devDependencies": {
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/busboy": "^1.5.0",
-    "@types/compression": "^1.7.2",
-    "@types/express": "^4.17.17",
-    "@types/fs-extra": "^11.0.1",
-    "@types/jsonwebtoken": "^9.0.2",
-    "@types/node": "^20.4.5",
-    "@types/set-blocking": "^2.0.0",
-    "@types/ws": "^8.5.5",
-    "@types/yargs": "^17.0.24",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.14",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-dev-middleware": "^6.1.1",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/controller",
+	"description": "Implementation of Clusterio controller",
+	"author": "Hornwitser",
+	"license": "MIT",
+	"version": "2.0.0-alpha.13",
+	"main": "dist/controller.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"bin": {
+		"clusteriocontroller": "./dist/controller.js"
+	},
+	"keywords": [
+		"factorio"
+	],
+	"engines": {
+		"node": ">=18"
+	},
+	"dependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"busboy": "^1.6.0",
+		"compression": "^1.7.4",
+		"express": "^4.18.2",
+		"fs-extra": "^11.1.1",
+		"jsonwebtoken": "^9.0.1",
+		"jszip": "^3.10.1",
+		"set-blocking": "^2.0.0",
+		"webpack-cli": "^5.1.4",
+		"winston": "^3.10.0",
+		"winston-daily-rotate-file": "^4.7.1",
+		"ws": "^8.13.0",
+		"yargs": "^17.7.2"
+	},
+	"devDependencies": {
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/busboy": "^1.5.0",
+		"@types/compression": "^1.7.2",
+		"@types/express": "^4.17.17",
+		"@types/fs-extra": "^11.0.1",
+		"@types/jsonwebtoken": "^9.0.2",
+		"@types/node": "^20.4.5",
+		"@types/set-blocking": "^2.0.0",
+		"@types/ws": "^8.5.5",
+		"@types/yargs": "^17.0.24",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-router-dom": "^6.4.14",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-dev-middleware": "^6.1.1",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -321,7 +321,7 @@ export default class Controller {
 		}
 
 		logger.info("Saving config");
-		await lib.safeOutputFile(this.configPath, JSON.stringify(this.config.serialize(), null, 4));
+		await lib.safeOutputFile(this.configPath, JSON.stringify(this.config.serialize(), null, "\t"));
 
 		if (this.devMiddleware) {
 			await new Promise((resolve, reject) => { this.devMiddleware.close(resolve); });
@@ -384,7 +384,7 @@ export default class Controller {
 	}
 
 	static async saveHosts(filePath: string, hosts: Map<number, HostInfo>) {
-		await lib.safeOutputFile(filePath, JSON.stringify([...hosts.entries()], null, 4));
+		await lib.safeOutputFile(filePath, JSON.stringify([...hosts.entries()], null, "\t"));
 	}
 
 	static async loadInstances(filePath: string): Promise<Map<number, InstanceInfo>> {
@@ -420,7 +420,7 @@ export default class Controller {
 			serialized.push(instance.config.serialize());
 		}
 
-		await lib.safeOutputFile(filePath, JSON.stringify(serialized, null, 4));
+		await lib.safeOutputFile(filePath, JSON.stringify(serialized, null, "\t"));
 	}
 
 	static async loadModPacks(filePath: string): Promise<Map<number, lib.ModPack>> {
@@ -437,7 +437,7 @@ export default class Controller {
 	}
 
 	static async saveModPacks(filePath: string, modPacks: Map<number, lib.ModPack>) {
-		await lib.safeOutputFile(filePath, JSON.stringify([...modPacks.values()], null, 4));
+		await lib.safeOutputFile(filePath, JSON.stringify([...modPacks.values()], null, "\t"));
 	}
 
 	static async loadModInfos(modsDirectory: string): Promise<Map<string, lib.ModInfo>> {

--- a/packages/controller/src/UserManager.ts
+++ b/packages/controller/src/UserManager.ts
@@ -59,7 +59,7 @@ export default class UserManager {
 			users: serializedUsers,
 			roles: serializedRoles,
 		};
-		await lib.safeOutputFile(filePath, JSON.stringify(serialized, null, 4));
+		await lib.safeOutputFile(filePath, JSON.stringify(serialized, null, "\t"));
 	}
 
 	/**

--- a/packages/controller/typedoc.json
+++ b/packages/controller/typedoc.json
@@ -1,4 +1,4 @@
 {
-  "entryPoints": ["controller.ts"],
-  "includeVersion": true
+	"entryPoints": ["controller.ts"],
+	"includeVersion": true
 }

--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -199,7 +199,7 @@ async function migrateRename(args) {
 	async function migrateConfig(source, destination) {
 		if (await fs.pathExists(source) && !await fs.pathExists(destination)) {
 			await safeOutputFile(destination, JSON.stringify(
-				renameConfig(JSON.parse(await fs.readFile(source))), null, 4
+				renameConfig(JSON.parse(await fs.readFile(source))), null, "\t"
 			));
 			logger.info(`Migrated ${source} to ${destination}`);
 		}
@@ -211,7 +211,7 @@ async function migrateRename(args) {
 	let instancesFile = path.join("database", "instances.json");
 	if (await fs.pathExists(instancesFile)) {
 		await safeOutputFile(instancesFile, JSON.stringify(
-			JSON.parse(await fs.readFile(instancesFile)).map(renameConfig), null, 4
+			JSON.parse(await fs.readFile(instancesFile)).map(renameConfig), null, "\t"
 		));
 		logger.info(`Migrated ${instancesFile}`);
 	}
@@ -222,7 +222,7 @@ async function migrateRename(args) {
 		for (let role of users["roles"]) {
 			role["permissions"] = role["permissions"].map(rename);
 		}
-		await safeOutputFile(usersFile, JSON.stringify(users, null, 4));
+		await safeOutputFile(usersFile, JSON.stringify(users, null, "\t"));
 		logger.info(`Migrated ${usersFile}`);
 	}
 
@@ -352,7 +352,7 @@ async function installClusterio(mode, plugins) {
 			}
 		}
 		try {
-			await safeOutputFile("plugin-list.json", JSON.stringify([...pluginList], null, 4));
+			await safeOutputFile("plugin-list.json", JSON.stringify([...pluginList], null, "\t"));
 		} catch (err) {
 			throw new InstallError(`Error writing plugin-list.json: ${err.message}`);
 		}

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@clusterio/create",
-  "description": "Installer for clusterio",
-  "author": "Hornwitser",
-  "license": "MIT",
-  "version": "2.0.0-alpha.13b",
-  "main": "create.js",
-  "bin": {
-    "clusteriocreate": "./create.js"
-  },
-  "keywords": [
-    "factorio",
-    "clusterio"
-  ],
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {
-    "chalk": "^4.1.2",
-    "fs-extra": "^11.1.1",
-    "inquirer": "^8.2.4",
-    "phin": "^3.7.0",
-    "yargs": "^17.7.2"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/create",
+	"description": "Installer for clusterio",
+	"author": "Hornwitser",
+	"license": "MIT",
+	"version": "2.0.0-alpha.13b",
+	"main": "create.js",
+	"bin": {
+		"clusteriocreate": "./create.js"
+	},
+	"keywords": [
+		"factorio",
+		"clusterio"
+	],
+	"engines": {
+		"node": ">=18"
+	},
+	"dependencies": {
+		"chalk": "^4.1.2",
+		"fs-extra": "^11.1.1",
+		"inquirer": "^8.2.4",
+		"phin": "^3.7.0",
+		"yargs": "^17.7.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -324,7 +324,7 @@ I           version of clusterio.  Expect things to break. I
 	);
 	startControl().catch(err => {
 		if (err.errors) {
-			logger.fatal(JSON.stringify(err.errors, null, 4));
+			logger.fatal(JSON.stringify(err.errors, null, "\t"));
 		}
 		if (!(err instanceof lib.StartupError)) {
 			logger.fatal(`

--- a/packages/ctl/package.json
+++ b/packages/ctl/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "@clusterio/ctl",
-  "description": "Clusterio command line management tool",
-  "author": "Hornwitser",
-  "license": "MIT",
-  "version": "2.0.0-alpha.13",
-  "main": "dist/ctl.js",
-  "scripts": {
-    "prepare": "tsc --build",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "bin": {
-    "clusterioctl": "./dist/ctl.js"
-  },
-  "keywords": [
-    "factorio"
-  ],
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "as-table": "^1.0.55",
-    "fs-extra": "^11.1.1",
-    "phin": "^3.7.0",
-    "set-blocking": "^2.0.0",
-    "winston": "^3.10.0",
-    "yargs": "^17.7.2"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.1",
-    "@types/node": "^20.4.5",
-    "@types/set-blocking": "^2.0.0",
-    "@types/yargs": "^17.0.24",
-    "typescript": "^5.1.6"
-  }
+	"name": "@clusterio/ctl",
+	"description": "Clusterio command line management tool",
+	"author": "Hornwitser",
+	"license": "MIT",
+	"version": "2.0.0-alpha.13",
+	"main": "dist/ctl.js",
+	"scripts": {
+		"prepare": "tsc --build",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"bin": {
+		"clusterioctl": "./dist/ctl.js"
+	},
+	"keywords": [
+		"factorio"
+	],
+	"engines": {
+		"node": ">=18"
+	},
+	"dependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"as-table": "^1.0.55",
+		"fs-extra": "^11.1.1",
+		"phin": "^3.7.0",
+		"set-blocking": "^2.0.0",
+		"winston": "^3.10.0",
+		"yargs": "^17.7.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.1",
+		"@types/node": "^20.4.5",
+		"@types/set-blocking": "^2.0.0",
+		"@types/yargs": "^17.0.24",
+		"typescript": "^5.1.6"
+	}
 }

--- a/packages/ctl/src/commands.ts
+++ b/packages/ctl/src/commands.ts
@@ -265,7 +265,7 @@ hostCommands.add(new lib.Command({
 			new lib.HostConfigCreateRequest(args.id, args.name, args.generateToken)
 		);
 
-		let content = JSON.stringify(rawConfig.serializedConfig, null, 4);
+		let content = JSON.stringify(rawConfig.serializedConfig, null, "\t");
 		if (args.output === "-") {
 			print(content);
 		} else {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "@clusterio/host",
-  "description": "Implementation of Clusterio host server",
-  "author": "Hornwitser",
-  "license": "MIT",
-  "version": "2.0.0-alpha.13",
-  "main": "dist/host.js",
-  "scripts": {
-    "prepare": "tsc --build",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "bin": {
-    "clusteriohost": "./dist/host.js"
-  },
-  "keywords": [
-    "factorio"
-  ],
-  "engines": {
-    "node": ">=18"
-  },
-  "dependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@sinclair/typebox": "^0.30.4",
-    "fs-extra": "^11.1.1",
-    "jimp": "^0.22.8",
-    "jszip": "^3.10.1",
-    "phin": "^3.7.0",
-    "pidusage": "^3.0.2",
-    "rcon-client": "^4.2.3",
-    "semver": "^7.5.4",
-    "set-blocking": "^2.0.0",
-    "winston": "^3.10.0",
-    "winston-daily-rotate-file": "^4.7.1",
-    "yargs": "^17.7.2"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.1",
-    "@types/node": "^20.4.5",
-    "@types/pidusage": "^2.0.2",
-    "@types/semver": "^7.5.0",
-    "@types/set-blocking": "^2.0.0",
-    "@types/yargs": "^17.0.24",
-    "typescript": "^5.1.6"
-  }
+	"name": "@clusterio/host",
+	"description": "Implementation of Clusterio host server",
+	"author": "Hornwitser",
+	"license": "MIT",
+	"version": "2.0.0-alpha.13",
+	"main": "dist/host.js",
+	"scripts": {
+		"prepare": "tsc --build",
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"bin": {
+		"clusteriohost": "./dist/host.js"
+	},
+	"keywords": [
+		"factorio"
+	],
+	"engines": {
+		"node": ">=18"
+	},
+	"dependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@sinclair/typebox": "^0.30.4",
+		"fs-extra": "^11.1.1",
+		"jimp": "^0.22.8",
+		"jszip": "^3.10.1",
+		"phin": "^3.7.0",
+		"pidusage": "^3.0.2",
+		"rcon-client": "^4.2.3",
+		"semver": "^7.5.4",
+		"set-blocking": "^2.0.0",
+		"winston": "^3.10.0",
+		"winston-daily-rotate-file": "^4.7.1",
+		"yargs": "^17.7.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.1",
+		"@types/node": "^20.4.5",
+		"@types/pidusage": "^2.0.2",
+		"@types/semver": "^7.5.0",
+		"@types/set-blocking": "^2.0.0",
+		"@types/yargs": "^17.0.24",
+		"typescript": "^5.1.6"
+	}
 }

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -215,7 +215,7 @@ class HostRouter {
 			}
 			logger.warn(`Failed to deliver ${(message as any).name || "message"} (${message.type}): ${err.message}`);
 			if (err instanceof lib.InvalidMessage && err.errors) {
-				logger.warn(JSON.stringify(err.errors, null, 4));
+				logger.warn(JSON.stringify(err.errors, null, "\t"));
 			}
 		}
 	}
@@ -484,7 +484,7 @@ export default class Host extends lib.Link {
 		};
 		await lib.safeOutputFile(
 			path.join(instanceInfo.path, "instance.json"),
-			JSON.stringify(warnedOutput, null, 4)
+			JSON.stringify(warnedOutput, null, "\t")
 		);
 	}
 

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -520,7 +520,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 		let content = JSON.stringify({
 			players: [...this.playerStats],
 			player_autosave_slot: this._playerAutosaveSlot,
-		}, null, 4);
+		}, null, "\t");
 		await lib.safeOutputFile(this.path("instance-stats.json"), content);
 	}
 
@@ -599,7 +599,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 		};
 		await lib.safeOutputFile(
 			this.server.writePath("server-settings.json"),
-			JSON.stringify(serverSettings, null, 4)
+			JSON.stringify(serverSettings, null, "\t")
 		);
 	}
 
@@ -687,7 +687,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 		// Write mod-list.json
 		await fs.outputFile(this.path("mods", "mod-list.json"), JSON.stringify({
 			mods: [...this.activeModPack.mods.values()],
-		}, null, 2));
+		}, null, "\t"));
 
 		// Write mod-settings.dat
 		await fs.outputFile(this.path("mods", "mod-settings.dat"), this.activeModPack.toModSettingsDat());
@@ -706,7 +706,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 			this.logger.verbose("Writing server-adminlist.json");
 			lib.safeOutputFile(
 				this.server.writePath("server-adminlist.json"),
-				JSON.stringify([...this._host.adminlist], null, 4)
+				JSON.stringify([...this._host.adminlist], null, "\t")
 			);
 		}
 
@@ -716,7 +716,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 				this.server.writePath("server-banlist.json"),
 				JSON.stringify([...this._host.banlist].map(
 					([username, reason]) => ({ username, reason })
-				), null, 4),
+				), null, "\t"),
 			);
 		}
 
@@ -724,7 +724,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 			this.logger.verbose("Writing server-whitelist.json");
 			lib.safeOutputFile(
 				this.server.writePath("server-whitelist.json"),
-				JSON.stringify([...this._host.whitelist], null, 4)
+				JSON.stringify([...this._host.whitelist], null, "\t")
 			);
 		}
 

--- a/packages/host/src/patch.ts
+++ b/packages/host/src/patch.ts
@@ -103,7 +103,7 @@ export class SaveModule {
 		if (!lib.ModuleInfo.validate(moduleJson)) {
 			throw new Error(
 				`module/module.json in plugin ${plugin.info.name} failed validation:\n` +
-				`${JSON.stringify(lib.ModuleInfo.validate.errors, null, 4)}`
+				`${JSON.stringify(lib.ModuleInfo.validate.errors, null, "\t")}`
 			);
 		}
 
@@ -124,7 +124,7 @@ export class SaveModule {
 		if (!lib.ModuleInfo.validate(moduleJson)) {
 			throw new Error(
 				`${name}/module.json failed validation:\n` +
-				`${JSON.stringify(lib.ModuleInfo.validate.errors, null, 4)}`
+				`${JSON.stringify(lib.ModuleInfo.validate.errors, null, "\t")}`
 			);
 		}
 

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -1194,12 +1194,12 @@ export class FactorioServer extends events.EventEmitter {
 	async _writeMapSettings(mapGenSettings?: object, mapSettings?: object) {
 		if (mapGenSettings) {
 			await lib.safeOutputFile(
-				this.writePath("map-gen-settings.json"), JSON.stringify(mapGenSettings, null, 4)
+				this.writePath("map-gen-settings.json"), JSON.stringify(mapGenSettings, null, "\t")
 			);
 		}
 		if (mapSettings) {
 			await lib.safeOutputFile(
-				this.writePath("map-settings.json"), JSON.stringify(mapSettings, null, 4)
+				this.writePath("map-settings.json"), JSON.stringify(mapSettings, null, "\t")
 			);
 		}
 	}

--- a/packages/lib/build_mod.js
+++ b/packages/lib/build_mod.js
@@ -41,7 +41,7 @@ async function buildMod(args, info) {
 			}
 			delete info.additional_files;
 
-			zip.file(path.posix.join(modName, "info.json"), JSON.stringify(info, null, 4));
+			zip.file(path.posix.join(modName, "info.json"), JSON.stringify(info, null, "\t"));
 
 			let modPath = path.join(args.outputDir, `${modName}.zip`);
 			console.log(`Writing ${modPath}`);
@@ -62,7 +62,7 @@ async function buildMod(args, info) {
 			}
 			delete info.additional_files;
 
-			await fs.writeFile(path.join(modDir, "info.json"), JSON.stringify(info, null, 4));
+			await fs.writeFile(path.join(modDir, "info.json"), JSON.stringify(info, null, "\t"));
 		}
 	}
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "@clusterio/lib",
-  "description": "Shared library for Clusterio",
-  "version": "2.0.0-alpha.13",
-  "repository": "https://github.com/clusterio/clusterio",
-  "license": "MIT",
-  "scripts": {
-    "prepare": "tsc --build && pnpm run compile_validator",
-    "compile_validator": "node scripts/compile_validator.js"
-  },
-  "main": "dist/index.js",
-  "browser": "browser.js",
-  "keywords": [
-    "factorio"
-  ],
-  "engines": {
-    "node": ">=12"
-  },
-  "dependencies": {
-    "@sinclair/typebox": "^0.30.4",
-    "ajv": "^8.12.0",
-    "chalk": "^4.1.2",
-    "fast-deep-equal": "^3.1.3",
-    "fs-extra": "^11.1.1",
-    "jszip": "^3.10.1",
-    "klaw": "^4.1.0",
-    "set-blocking": "^2.0.0",
-    "triple-beam": "^1.4.1",
-    "winston": "^3.10.0",
-    "winston-transport": "^4.5.0",
-    "ws": "^8.13.0",
-    "yargs": "^17.7.2"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.1",
-    "@types/node": "^20.4.5",
-    "@types/set-blocking": "^2.0.0",
-    "@types/triple-beam": "^1.3.2",
-    "@types/ws": "^8.5.5",
-    "@types/yargs": "^17.0.24",
-    "typescript": "^5.1.6"
-  }
+	"name": "@clusterio/lib",
+	"description": "Shared library for Clusterio",
+	"version": "2.0.0-alpha.13",
+	"repository": "https://github.com/clusterio/clusterio",
+	"license": "MIT",
+	"scripts": {
+		"prepare": "tsc --build && pnpm run compile_validator",
+		"compile_validator": "node scripts/compile_validator.js"
+	},
+	"main": "dist/index.js",
+	"browser": "browser.js",
+	"keywords": [
+		"factorio"
+	],
+	"engines": {
+		"node": ">=12"
+	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.30.4",
+		"ajv": "^8.12.0",
+		"chalk": "^4.1.2",
+		"fast-deep-equal": "^3.1.3",
+		"fs-extra": "^11.1.1",
+		"jszip": "^3.10.1",
+		"klaw": "^4.1.0",
+		"set-blocking": "^2.0.0",
+		"triple-beam": "^1.4.1",
+		"winston": "^3.10.0",
+		"winston-transport": "^4.5.0",
+		"ws": "^8.13.0",
+		"yargs": "^17.7.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.1",
+		"@types/node": "^20.4.5",
+		"@types/set-blocking": "^2.0.0",
+		"@types/triple-beam": "^1.3.2",
+		"@types/ws": "^8.5.5",
+		"@types/yargs": "^17.0.24",
+		"typescript": "^5.1.6"
+	}
 }

--- a/packages/lib/src/database.ts
+++ b/packages/lib/src/database.ts
@@ -78,7 +78,7 @@ export async function loadJsonAsMap(filePath: string): Promise<Map<string, unkno
  */
 export async function saveMapAsJson(filePath: string, map: Map<string, unknown>) {
 	let obj = mapToObject(map);
-	await libFileOps.safeOutputFile(filePath, JSON.stringify(obj, null, 4));
+	await libFileOps.safeOutputFile(filePath, JSON.stringify(obj, null, "\t"));
 }
 
 /**
@@ -138,7 +138,7 @@ export async function loadJsonArrayAsMap(filePath: string): Promise<Map<unknown,
  * @throws {Error} if an error occured writing to the file.
  */
 export async function saveMapAsJsonArray(filePath: string, map: Map<unknown, { id: unknown }>) {
-	await libFileOps.safeOutputFile(filePath, JSON.stringify([...map.values()], null, 4));
+	await libFileOps.safeOutputFile(filePath, JSON.stringify([...map.values()], null, "\t"));
 }
 
 

--- a/packages/lib/src/link/connectors.ts
+++ b/packages/lib/src/link/connectors.ts
@@ -159,7 +159,7 @@ export abstract class WebSocketBaseConnector extends BaseConnector {
 		}
 		if (!libData.Message.validate(json)) {
 			logger.error(`Received malformed message: ${text}`);
-			// logger.error(JSON.stringify(libData.Message.validate.errors, null, 4));
+			// logger.error(JSON.stringify(libData.Message.validate.errors, null, "\t"));
 			this.close(4000, "Malformed message");
 			return undefined;
 		}

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -109,7 +109,7 @@ export class Link {
 				if (err instanceof libErrors.InvalidMessage) {
 					logger.error(err.message);
 					if (err.errors) {
-						logger.error(JSON.stringify(err.errors, null, 4));
+						logger.error(JSON.stringify(err.errors, null, "\t"));
 					}
 
 				} else {
@@ -364,7 +364,7 @@ export class Link {
 			response = handler(entry.requestFromJSON(message.data), message.src, message.dst);
 		} catch (err: any) {
 			if (err.errors) {
-				logger.error(JSON.stringify(err.errors, null, 4));
+				logger.error(JSON.stringify(err.errors, null, "\t"));
 			}
 			this.connector.sendResponseError(
 				new libData.ResponseError(err.message, err.code, err.stack), message.src
@@ -392,7 +392,7 @@ export class Link {
 				if (err instanceof libErrors.InvalidMessage) {
 					logger.error(err.message);
 					if (err.errors) {
-						logger.error(JSON.stringify(err.errors, null, 4));
+						logger.error(JSON.stringify(err.errors, null, "\t"));
 					}
 				} else if (!(err instanceof libErrors.RequestError)) {
 					logger.error(`Unexpected error responding to ${message.name}:\n${err.stack}`);

--- a/packages/lib/src/logging_utils.ts
+++ b/packages/lib/src/logging_utils.ts
@@ -306,7 +306,7 @@ export class LogIndex {
 	async save() {
 		await libFileOps.safeOutputFile(
 			path.join(this.logDirectory, "index.json"),
-			JSON.stringify(this.serialize(), null, 4)
+			JSON.stringify(this.serialize(), null, "\t")
 		);
 	}
 

--- a/packages/lib/src/shared_commands.ts
+++ b/packages/lib/src/shared_commands.ts
@@ -73,7 +73,7 @@ export async function handlePluginCommand(
 		}
 
 		pluginList.set(pluginInfo.name, pluginPath);
-		await libFileOps.safeOutputFile(pluginListPath, JSON.stringify([...pluginList], null, 4));
+		await libFileOps.safeOutputFile(pluginListPath, JSON.stringify([...pluginList], null, "\t"));
 		print(`Added ${pluginInfo.name}`);
 
 	} else if (command === "remove") {
@@ -83,7 +83,7 @@ export async function handlePluginCommand(
 			return;
 		}
 
-		await libFileOps.safeOutputFile(pluginListPath, JSON.stringify([...pluginList], null, 4));
+		await libFileOps.safeOutputFile(pluginListPath, JSON.stringify([...pluginList], null, "\t"));
 		print(`Removed ${args.name}`);
 
 	} else if (command === "list") {
@@ -162,7 +162,7 @@ export async function handleConfigCommand(
 
 		try {
 			instance.set(args.field as string, args.value);
-			await libFileOps.safeOutputFile(configPath, JSON.stringify(instance.serialize(), null, 4));
+			await libFileOps.safeOutputFile(configPath, JSON.stringify(instance.serialize(), null, "\t"));
 		} catch (err) {
 			if (err instanceof libConfig.InvalidField || err instanceof libConfig.InvalidValue) {
 				logger.error(err.message);

--- a/packages/lib/typedoc.json
+++ b/packages/lib/typedoc.json
@@ -1,4 +1,4 @@
 {
-  "entryPoints": ["index.ts"],
-  "includeVersion": true
+	"entryPoints": ["index.ts"],
+	"includeVersion": true
 }

--- a/packages/web_ui/package.json
+++ b/packages/web_ui/package.json
@@ -1,57 +1,57 @@
 {
-  "name": "@clusterio/web_ui",
-  "description": "Clusterio web interface implementation",
-  "author": "Hornwitser",
-  "license": "MIT",
-  "version": "2.0.0-alpha.13",
-  "browser": "src/index.ts",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [
-    "clusterio"
-  ],
-  "engines": {
-    "node": ">=12"
-  },
-  "dependencies": {
-    "@ant-design/icons": "^5.1.4",
-    "@babel/core": "^7.22.9",
-    "@babel/preset-react": "^7.22.5",
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "antd": "^5.7.3",
-    "assert": "^2.0.0",
-    "babel-loader": "^9.1.3",
-    "browserify-zlib": "^0.2.0",
-    "buffer": "^6.0.3",
-    "clean-webpack-plugin": "^4.0.0",
-    "css-loader": "^6.8.1",
-    "events": "^3.3.0",
-    "file-loader": "^6.2.0",
-    "null-loader": "^4.0.1",
-    "os-browserify": "^0.3.0",
-    "path-browserify": "^1.0.1",
-    "process": "^0.11.10",
-    "rc-field-form": "^1.37.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.14.2",
-    "stream-browserify": "^3.0.0",
-    "style-loader": "^3.3.3",
-    "terser-webpack-plugin": "^5.3.9",
-    "ts-loader": "^9.4.4",
-    "typescript": "^5.1.6",
-    "util": "^0.12.5",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-manifest-plugin": "^5.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "devDependencies": {
-    "@types/node": "^20.4.5",
-    "@types/react": "^18.2.21",
-    "@types/react-dom": "^18.2.7"
-  }
+	"name": "@clusterio/web_ui",
+	"description": "Clusterio web interface implementation",
+	"author": "Hornwitser",
+	"license": "MIT",
+	"version": "2.0.0-alpha.13",
+	"browser": "src/index.ts",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [
+		"clusterio"
+	],
+	"engines": {
+		"node": ">=12"
+	},
+	"dependencies": {
+		"@ant-design/icons": "^5.1.4",
+		"@babel/core": "^7.22.9",
+		"@babel/preset-react": "^7.22.5",
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"antd": "^5.7.3",
+		"assert": "^2.0.0",
+		"babel-loader": "^9.1.3",
+		"browserify-zlib": "^0.2.0",
+		"buffer": "^6.0.3",
+		"clean-webpack-plugin": "^4.0.0",
+		"css-loader": "^6.8.1",
+		"events": "^3.3.0",
+		"file-loader": "^6.2.0",
+		"null-loader": "^4.0.1",
+		"os-browserify": "^0.3.0",
+		"path-browserify": "^1.0.1",
+		"process": "^0.11.10",
+		"rc-field-form": "^1.37.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"react-router-dom": "^6.14.2",
+		"stream-browserify": "^3.0.0",
+		"style-loader": "^3.3.3",
+		"terser-webpack-plugin": "^5.3.9",
+		"ts-loader": "^9.4.4",
+		"typescript": "^5.1.6",
+		"util": "^0.12.5",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-manifest-plugin": "^5.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"devDependencies": {
+		"@types/node": "^20.4.5",
+		"@types/react": "^18.2.21",
+		"@types/react-dom": "^18.2.7"
+	}
 }

--- a/packages/web_ui/src/components/CreateSaveModal.tsx
+++ b/packages/web_ui/src/components/CreateSaveModal.tsx
@@ -79,8 +79,8 @@ export default function CreateSaveModal(props: CreateSaveModalProps) {
 		}
 		form.setFields([{ name: "exchangeString", errors: [], value: "" }]);
 		form.setFieldsValue({
-			mapGenSettings: JSON.stringify(result.map_gen_settings, null, 4),
-			mapSettings: JSON.stringify(result.map_settings, null, 4),
+			mapGenSettings: JSON.stringify(result.map_gen_settings, null, "\t"),
+			mapSettings: JSON.stringify(result.map_settings, null, "\t"),
 		});
 	}
 

--- a/packages/web_ui/src/components/LoadScenarioModal.tsx
+++ b/packages/web_ui/src/components/LoadScenarioModal.tsx
@@ -77,8 +77,8 @@ export default function LoadScenarioModal(props: LoadScenarioModalProps) {
 		}
 		form.setFields([{ name: "exchangeString", errors: [], value: "" }]);
 		form.setFieldsValue({
-			mapGenSettings: JSON.stringify(result.map_gen_settings, null, 4),
-			mapSettings: JSON.stringify(result.map_settings, null, 4),
+			mapGenSettings: JSON.stringify(result.map_gen_settings, null, "\t"),
+			mapSettings: JSON.stringify(result.map_settings, null, "\t"),
 		});
 	}
 

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "@clusterio/plugin-global_chat",
-  "version": "2.0.0-alpha.13",
-  "description": "Clusterio plugin forwarding between Factorio servers",
-  "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/clusterio#readme",
-  "license": "MIT",
-  "repository": "clusterio/clusterio",
-  "main": "dist/plugin/info.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "bugs": {
-    "url": "https://github.com/clusterio/clusterio/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.0"
-  },
-  "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/node": "^20.4.5",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "dependencies": {
-    "@sinclair/typebox": "^0.30.4"
-  }
+	"name": "@clusterio/plugin-global_chat",
+	"version": "2.0.0-alpha.13",
+	"description": "Clusterio plugin forwarding between Factorio servers",
+	"author": "Hornwitser <github@hornwitser.no>",
+	"homepage": "https://github.com/clusterio/clusterio#readme",
+	"license": "MIT",
+	"repository": "clusterio/clusterio",
+	"main": "dist/plugin/info.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	},
+	"bugs": {
+		"url": "https://github.com/clusterio/clusterio/issues"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0"
+	},
+	"devDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/node": "^20.4.5",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.30.4"
+	}
 }

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -1,43 +1,43 @@
 {
-  "name": "@clusterio/plugin-inventory_sync",
-  "version": "2.0.0-alpha.13",
-  "description": "Clusterio plugin forwarding between Factorio servers",
-  "author": "Danielv <danielv@danielv.no>",
-  "homepage": "https://github.com/clusterio/factorioClusterio#readme",
-  "license": "MIT",
-  "repository": "clusterio/factorioClusterio",
-  "main": "dist/plugin/info.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "bugs": {
-    "url": "https://github.com/clusterio/factorioClusterio/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.0"
-  },
-  "dependencies": {
-    "@sinclair/typebox": "^0.30.4",
-    "fs-extra": "^8.1.0"
-  },
-  "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/fs-extra": "^11.0.1",
-    "@types/node": "^20.4.5",
-    "antd": "^5.7.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/plugin-inventory_sync",
+	"version": "2.0.0-alpha.13",
+	"description": "Clusterio plugin forwarding between Factorio servers",
+	"author": "Danielv <danielv@danielv.no>",
+	"homepage": "https://github.com/clusterio/factorioClusterio#readme",
+	"license": "MIT",
+	"repository": "clusterio/factorioClusterio",
+	"main": "dist/plugin/info.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	},
+	"bugs": {
+		"url": "https://github.com/clusterio/factorioClusterio/issues"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0"
+	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.30.4",
+		"fs-extra": "^8.1.0"
+	},
+	"devDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/fs-extra": "^11.0.1",
+		"@types/node": "^20.4.5",
+		"antd": "^5.7.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "@clusterio/plugin-player_auth",
-  "version": "2.0.0-alpha.13",
-  "description": "Clusterio plugin authenticating logged in players to the web interface",
-  "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/clusterio#readme",
-  "license": "MIT",
-  "repository": "clusterio/clusterio",
-  "main": "dist/plugin/info.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "bugs": {
-    "url": "https://github.com/clusterio/clusterio/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.0"
-  },
-  "dependencies": {
-    "@sinclair/typebox": "^0.30.4",
-    "express": "^4.16.2",
-    "jsonwebtoken": "^8.2.1"
-  },
-  "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/express": "^4.17.17",
-    "@types/jsonwebtoken": "^9.0.2",
-    "@types/node": "^20.4.5",
-    "antd": "^5.7.3",
-    "phin": "^3.7.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/plugin-player_auth",
+	"version": "2.0.0-alpha.13",
+	"description": "Clusterio plugin authenticating logged in players to the web interface",
+	"author": "Hornwitser <github@hornwitser.no>",
+	"homepage": "https://github.com/clusterio/clusterio#readme",
+	"license": "MIT",
+	"repository": "clusterio/clusterio",
+	"main": "dist/plugin/info.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	},
+	"bugs": {
+		"url": "https://github.com/clusterio/clusterio/issues"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0"
+	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.30.4",
+		"express": "^4.16.2",
+		"jsonwebtoken": "^8.2.1"
+	},
+	"devDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/express": "^4.17.17",
+		"@types/jsonwebtoken": "^9.0.2",
+		"@types/node": "^20.4.5",
+		"antd": "^5.7.3",
+		"phin": "^3.7.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/plugins/research_sync/controller.ts
+++ b/plugins/research_sync/controller.ts
@@ -45,7 +45,7 @@ async function saveTechnologies(
 ) {
 	let filePath = path.join(controllerConfig.get("controller.database_directory"), "technologies.json");
 	logger.verbose(`writing ${filePath}`);
-	await lib.safeOutputFile(filePath, JSON.stringify([...technologies.entries()], null, 4));
+	await lib.safeOutputFile(filePath, JSON.stringify([...technologies.entries()], null, "\t"));
 }
 
 export class ControllerPlugin extends lib.BaseControllerPlugin {

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "@clusterio/plugin-research_sync",
-  "version": "2.0.0-alpha.13",
-  "description": "Clusterio plugin for synchronizing research between Factorio servers",
-  "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/clusterio#readme",
-  "license": "MIT",
-  "repository": "clusterio/clusterio",
-  "main": "dist/plugin/info.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "bugs": {
-    "url": "https://github.com/clusterio/clusterio/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.0"
-  },
-  "dependencies": {
-    "@sinclair/typebox": "^0.30.4",
-    "fs-extra": "^8.1.0"
-  },
-  "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/node": "^20.4.5",
-    "@types/fs-extra": "^11.0.1",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/plugin-research_sync",
+	"version": "2.0.0-alpha.13",
+	"description": "Clusterio plugin for synchronizing research between Factorio servers",
+	"author": "Hornwitser <github@hornwitser.no>",
+	"homepage": "https://github.com/clusterio/clusterio#readme",
+	"license": "MIT",
+	"repository": "clusterio/clusterio",
+	"main": "dist/plugin/info.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	},
+	"bugs": {
+		"url": "https://github.com/clusterio/clusterio/issues"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0"
+	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.30.4",
+		"fs-extra": "^8.1.0"
+	},
+	"devDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/node": "^20.4.5",
+		"@types/fs-extra": "^11.0.1",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@clusterio/plugin-statistics_exporter",
-  "version": "2.0.0-alpha.13",
-  "description": "Clusterio plugin for gathering statistics from Factorio servers",
-  "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/clusterio#readme",
-  "license": "MIT",
-  "repository": "clusterio/clusterio",
-  "main": "dist/plugin/info.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "bugs": {
-    "url": "https://github.com/clusterio/clusterio/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.0"
-  },
-  "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/node": "^20.4.5",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/plugin-statistics_exporter",
+	"version": "2.0.0-alpha.13",
+	"description": "Clusterio plugin for gathering statistics from Factorio servers",
+	"author": "Hornwitser <github@hornwitser.no>",
+	"homepage": "https://github.com/clusterio/clusterio#readme",
+	"license": "MIT",
+	"repository": "clusterio/clusterio",
+	"main": "dist/plugin/info.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	},
+	"bugs": {
+		"url": "https://github.com/clusterio/clusterio/issues"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0"
+	},
+	"devDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/node": "^20.4.5",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -1,44 +1,44 @@
 {
-  "name": "@clusterio/plugin-subspace_storage",
-  "version": "2.0.0-alpha.13",
-  "description": "Clusterio plugin for sharing storage between Factorio servers",
-  "author": "Hornwitser <github@hornwitser.no>",
-  "homepage": "https://github.com/clusterio/clusterio#readme",
-  "license": "MIT",
-  "repository": "clusterio/clusterio",
-  "main": "dist/plugin/info.js",
-  "scripts": {
-    "prepare": "tsc --build && webpack-cli --env production",
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
-  "bugs": {
-    "url": "https://github.com/clusterio/clusterio/issues"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "peerDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.0"
-  },
-  "dependencies": {
-    "@sinclair/typebox": "^0.30.4",
-    "fs-extra": "^8.1.0"
-  },
-  "devDependencies": {
-    "@clusterio/lib": "^2.0.0-alpha.13",
-    "@clusterio/web_ui": "^2.0.0-alpha.13",
-    "@types/express": "^4.17.17",
-    "@types/fs-extra": "^11.0.1",
-    "@types/node": "^20.4.5",
-    "antd": "^5.7.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.1.6",
-    "webpack": "^5.88.2",
-    "webpack-cli": "^5.1.4",
-    "webpack-merge": "^5.9.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@clusterio/plugin-subspace_storage",
+	"version": "2.0.0-alpha.13",
+	"description": "Clusterio plugin for sharing storage between Factorio servers",
+	"author": "Hornwitser <github@hornwitser.no>",
+	"homepage": "https://github.com/clusterio/clusterio#readme",
+	"license": "MIT",
+	"repository": "clusterio/clusterio",
+	"main": "dist/plugin/info.js",
+	"scripts": {
+		"prepare": "tsc --build && webpack-cli --env production",
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	},
+	"bugs": {
+		"url": "https://github.com/clusterio/clusterio/issues"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"peerDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.0"
+	},
+	"dependencies": {
+		"@sinclair/typebox": "^0.30.4",
+		"fs-extra": "^8.1.0"
+	},
+	"devDependencies": {
+		"@clusterio/lib": "^2.0.0-alpha.13",
+		"@clusterio/web_ui": "^2.0.0-alpha.13",
+		"@types/express": "^4.17.17",
+		"@types/fs-extra": "^11.0.1",
+		"@types/node": "^20.4.5",
+		"antd": "^5.7.3",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"typescript": "^5.1.6",
+		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
+		"webpack-merge": "^5.9.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
 }

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -107,7 +107,7 @@ describe("Integration of host/src/server", function() {
 				let settings = await server.exampleSettings();
 				settings.visibility = { public: false, lan: true };
 				settings.require_user_verification = false;
-				await fs.outputFile(server.writePath("server-settings.json"), JSON.stringify(settings, null, 4));
+				await fs.outputFile(server.writePath("server-settings.json"), JSON.stringify(settings, null, "\t"));
 
 				// Make sure the test does not fail due to create() failing.
 				let mapPath = server.writePath("saves", "test.zip");

--- a/test/lib/database.js
+++ b/test/lib/database.js
@@ -81,7 +81,7 @@ describe("lib/database", function() {
 
 			assert.equal(
 				await fs.readFile(testFile, { encoding: "utf-8" }),
-				'{\n    "c": {},\n    "d": "foo"\n}'
+				'{\n\t"c": {},\n\t"d": "foo"\n}'
 			);
 		});
 	});
@@ -155,7 +155,7 @@ describe("lib/database", function() {
 
 			assert.equal(
 				await fs.readFile(testFile, { encoding: "utf-8" }),
-				'[\n    {\n        "id": "c"\n    },\n    {\n        "id": "d"\n    }\n]'
+				'[\n\t{\n\t\t"id": "c"\n\t},\n\t{\n\t\t"id": "d"\n\t}\n]'
 			);
 		});
 	});

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,7 @@
 {
-    "$schema": "https://typedoc.org/schema.json",
-    "entryPoints": ["packages/lib/"],
-    "entryPointStrategy": "packages",
-    "cleanOutputDir": false,
-    "out": "docs/api"
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["packages/lib/"],
+	"entryPointStrategy": "packages",
+	"cleanOutputDir": false,
+	"out": "docs/api"
 }


### PR DESCRIPTION
Make developing with VSCode slightly nicer by configuring the editor to use the right line endings and indents by default.

This requires changing all the JSON files to use a consistent indenting, as a per path setting is not possible in VSCode (nor does it make much sense). I changed the indents on the JSON files to all use tabs to be consistent with the JavaScript code.