### PR TITLE
Implement autosaving of data held in memory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,7 +137,11 @@ module.exports = {
 		"func-call-spacing": "error",
 		"func-name-matching": "error",
 		"func-names": "off",
-		"func-style": ["error", "declaration"],
+		"func-style": ["error", "declaration", {
+			// Allow arrow functions as it better expresses referencing this
+			// of the containing scope, which is unweilding in plain functions.
+			"allowArrowFunctions": true,
+		}],
 		"function-call-argument-newline": "off",
 		"function-paren-newline": "off",
 		"generator-star-spacing": ["error", { "before": false, "after": true }],

--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -383,7 +383,13 @@ async function startup() {
 		return;
 	}
 
-	controller = new Controller(clusterLogger, pluginInfos, controllerConfigPath, controllerConfig);
+	controller = new Controller(
+		clusterLogger,
+		pluginInfos,
+		controllerConfigPath,
+		controllerConfig,
+		...await Controller.bootstrap(controllerConfig)
+	);
 
 	let secondSigint = false;
 	process.on("SIGINT", () => {

--- a/packages/controller/src/BaseConnection.ts
+++ b/packages/controller/src/BaseConnection.ts
@@ -50,7 +50,7 @@ export default class BaseConnection extends lib.Link {
 
 	async handleModPackGetRequest(request: lib.ModPackGetRequest): Promise<lib.ModPack> {
 		let { id } = request;
-		let modPack = this._controller.modPacks!.get(id);
+		let modPack = this._controller.modPacks.get(id);
 		if (!modPack) {
 			throw new lib.RequestError(`Mod pack with ID ${id} does not exist`);
 		}
@@ -62,7 +62,7 @@ export default class BaseConnection extends lib.Link {
 		if (id === null) {
 			throw new lib.RequestError("Default mod pack not set on controller");
 		}
-		let modPack = this._controller.modPacks!.get(id);
+		let modPack = this._controller.modPacks.get(id);
 		if (!modPack) {
 			throw new lib.RequestError(`Default mod pack configured (${id}) does not exist`);
 		}

--- a/packages/controller/src/BaseControllerPlugin.ts
+++ b/packages/controller/src/BaseControllerPlugin.ts
@@ -41,6 +41,19 @@ export default class BaseControllerPlugin {
 	async init() { }
 
 	/**
+	 * Called when the controller saves data in memory to disk
+	 *
+	 * Invoked on the configured controller.autosave_interval by the
+	 * controller and intended to be used to flush any in memory data that
+	 * has changed to disk.
+	 *
+	 * This will also be called during graceful shutdown after {@link
+	 * BaseControllerPlugin.onShutdown} have been invoked and all links have
+	 * been disconnected.
+	 */
+	async onSaveData() { }
+
+	/**
 	 * Called when the status of an instance changes
 	 *
 	 * Invoked when the controller has changed the status of an instance

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -185,7 +185,7 @@ export default class ControlConnection extends BaseConnection {
 	}
 
 	async handleHostRevokeTokensRequest(request: lib.HostRevokeTokensRequest) {
-		const host = this._controller.hosts?.get(request.hostId);
+		const host = this._controller.hosts.get(request.hostId);
 		if (!host) {
 			throw new Error(`Unknown host id (${request.hostId})`);
 		}
@@ -202,7 +202,7 @@ export default class ControlConnection extends BaseConnection {
 
 	async handleHostListRequest(): Promise<lib.HostDetails[]> {
 		let list = [];
-		for (let host of this._controller.hosts!.values()) {
+		for (let host of this._controller.hosts.values()) {
 			list.push(new lib.HostDetails(
 				host.agent,
 				host.version,
@@ -266,7 +266,7 @@ export default class ControlConnection extends BaseConnection {
 
 	async handleInstanceDetailsListRequest() {
 		let list = [];
-		for (let instance of this._controller.instances!.values()) {
+		for (let instance of this._controller.instances.values()) {
 			let assigned_host: number|null|undefined = instance.config.get("instance.assigned_host");
 			if (assigned_host === null) {
 				assigned_host = undefined;
@@ -424,7 +424,7 @@ export default class ControlConnection extends BaseConnection {
 	}
 
 	async handleModPackListRequest() {
-		return [...this._controller.modPacks!.values()];
+		return [...this._controller.modPacks.values()];
 	}
 
 	async handleModPackCreateRequest(request: lib.ModPackCreateRequest) {
@@ -432,37 +432,37 @@ export default class ControlConnection extends BaseConnection {
 		if (modPack.id === undefined) {
 			throw new lib.RequestError("Mod pack need an ID to be created");
 		}
-		if (this._controller.modPacks!.has(modPack.id)) {
+		if (this._controller.modPacks.has(modPack.id)) {
 			throw new lib.RequestError(`Mod pack with ID ${modPack.id} already exist`);
 		}
-		this._controller.modPacks!.set(modPack.id, modPack);
+		this._controller.modPacks.set(modPack.id, modPack);
 		this._controller.modPackUpdated(modPack);
 	}
 
 	async handleModPackUpdateRequest(request: lib.ModPackUpdateRequest) {
 		let modPack = request.modPack;
-		if (modPack.id === undefined || !this._controller.modPacks!.has(modPack.id)) {
+		if (modPack.id === undefined || !this._controller.modPacks.has(modPack.id)) {
 			throw new lib.RequestError(`Mod pack with ID ${modPack.id} does not exist`);
 		}
-		this._controller.modPacks!.set(modPack.id, modPack);
+		this._controller.modPacks.set(modPack.id, modPack);
 		this._controller.modPackUpdated(modPack);
 	}
 
 	async handleModPackDeleteRequest(request: lib.ModPackDeleteRequest) {
 		let { id } = request;
-		let modPack = this._controller.modPacks!.get(id);
+		let modPack = this._controller.modPacks.get(id);
 		if (!modPack) {
 			throw new lib.RequestError(`Mod pack with ID ${id} does not exist`);
 		}
 		modPack.isDeleted = true;
-		this._controller.modPacks!.delete(id);
+		this._controller.modPacks.delete(id);
 		this._controller.modPackUpdated(modPack);
 	}
 
 	async handleModGetRequest(request: lib.ModGetRequest) {
 		let { name, version } = request;
 		let filename = `${name}_${version}.zip`;
-		let mod = this._controller.mods!.get(filename);
+		let mod = this._controller.mods.get(filename);
 		if (!mod) {
 			throw new lib.RequestError(`Mod ${filename} does not exist`);
 		}
@@ -470,7 +470,7 @@ export default class ControlConnection extends BaseConnection {
 	}
 
 	async handleModListRequest() {
-		return [...this._controller.mods!.values()];
+		return [...this._controller.mods.values()];
 	}
 
 	static termsMatchesMod(terms: lib.ParsedTerm[], mod: lib.ModInfo) {
@@ -510,7 +510,7 @@ export default class ControlConnection extends BaseConnection {
 
 		type ModVersions = { name: string, versions: lib.ModInfo[] };
 		let results: Map<string, ModVersions> = new Map();
-		for (let mod of this._controller.mods!.values()) {
+		for (let mod of this._controller.mods.values()) {
 			if (
 				mod.factorioVersion !== factorioVersion
 				|| !ControlConnection.termsMatchesMod(query.terms, mod)
@@ -565,7 +565,7 @@ export default class ControlConnection extends BaseConnection {
 	async handleModDownloadRequest(request: lib.ModDownloadRequest) {
 		let { name, version } = request;
 		let filename = `${name}_${version}.zip`;
-		let mod = this._controller.mods!.get(filename);
+		let mod = this._controller.mods.get(filename);
 		if (!mod) {
 			throw new lib.RequestError(`Mod ${filename} does not exist`);
 		}

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -665,6 +665,7 @@ export default class ControlConnection extends BaseConnection {
 		// Start at 5 to leave space for future default roles
 		let id = Math.max(5, lastId+1);
 		this._controller.userManager.roles.set(id, new lib.Role({ id, ...request }));
+		this._controller.userManager.dirty = true;
 		return id;
 	}
 
@@ -699,6 +700,7 @@ export default class ControlConnection extends BaseConnection {
 		}
 
 		this._controller.userManager.roles.delete(id);
+		this._controller.userManager.dirty = true;
 		for (let user of this._controller.userManager.users.values()) {
 			user.roles.delete(role);
 			this._controller.userPermissionsUpdated(user);

--- a/packages/controller/src/ControllerRouter.ts
+++ b/packages/controller/src/ControllerRouter.ts
@@ -40,7 +40,7 @@ export default class ControllerRouter {
 				msg = `Host ${dst.id} is offline`;
 			}
 		} else if (dst.type === lib.Address.instance) {
-			let instance = this.controller.instances!.get(dst.id);
+			let instance = this.controller.instances.get(dst.id);
 			if (!instance) {
 				msg = `Instance ${dst.id} does not exist`;
 			} else {

--- a/packages/controller/src/HostConnection.ts
+++ b/packages/controller/src/HostConnection.ts
@@ -46,9 +46,9 @@ export default class HostConnection extends BaseConnection {
 		this.plugins = new Map(Object.entries(registerData.plugins));
 		this._checkPluginVersions();
 
-		let currentHostInfo = this._controller.hosts!.get(this._id);
+		let currentHostInfo = this._controller.hosts.get(this._id);
 
-		this._controller.hosts!.set(this._id, {
+		this._controller.hosts.set(this._id, {
 			agent: this._agent,
 			id: this._id,
 			name: this._name,
@@ -70,7 +70,7 @@ export default class HostConnection extends BaseConnection {
 
 		this.connector.on("close", () => {
 			// Update status to unknown for instances on this host.
-			for (let instance of this._controller.instances!.values()) {
+			for (let instance of this._controller.instances.values()) {
 				if (instance.config.get("instance.assigned_host") !== this._id) {
 					continue;
 				}
@@ -105,7 +105,7 @@ export default class HostConnection extends BaseConnection {
 				break;
 
 			case lib.Address.instance:
-				let instance = this._controller.instances!.get(message.src.id);
+				let instance = this._controller.instances.get(message.src.id);
 				if (!instance || instance.config.get("instance.assigned_host") !== this._id) {
 					throw new lib.InvalidMessage(
 						`Received message with invalid src ${message.src} from ${origin}`
@@ -157,7 +157,7 @@ export default class HostConnection extends BaseConnection {
 	}
 
 	async handleInstanceStatusChangedEvent(request: lib.InstanceStatusChangedEvent) {
-		let instance = this._controller.instances!.get(request.instanceId);
+		let instance = this._controller.instances.get(request.instanceId);
 
 		// It's possible to get updates from an instance that does not exist
 		// or is not assigned to the host it originated from if it was
@@ -187,7 +187,7 @@ export default class HostConnection extends BaseConnection {
 
 	async handleInstancesUpdateRequest(request: lib.InstancesUpdateRequest) {
 		// Push updated instance configs
-		for (let instance of this._controller.instances!.values()) {
+		for (let instance of this._controller.instances.values()) {
 			if (instance.config.get("instance.assigned_host") === this._id) {
 				await this.send(
 					new lib.InstanceAssignInternalRequest(instance.id, instance.config.serialize("host"))
@@ -200,7 +200,7 @@ export default class HostConnection extends BaseConnection {
 			let instanceConfig = new lib.InstanceConfig("controller");
 			await instanceConfig.load(instanceData.config as lib.SerializedConfig, "host");
 
-			let controllerInstance = this._controller.instances!.get(instanceConfig.get("instance.id"));
+			let controllerInstance = this._controller.instances.get(instanceConfig.get("instance.id"));
 			if (controllerInstance) {
 				// Check if this instance is assigned somewhere else.
 				if (controllerInstance.config.get("instance.assigned_host") !== this._id) {
@@ -227,7 +227,7 @@ export default class HostConnection extends BaseConnection {
 			let newInstance = new InstanceInfo(
 				{ config: instanceConfig, status: instanceData.status as InstanceStatus }
 			);
-			this._controller.instances!.set(instanceConfig.get("instance.id"), newInstance);
+			this._controller.instances.set(instanceConfig.get("instance.id"), newInstance);
 			this._controller.instancesDirty = true;
 			this._controller.addInstanceHooks(newInstance);
 			await this.send(
@@ -292,7 +292,7 @@ export default class HostConnection extends BaseConnection {
 		user.recalculatePlayerStats();
 		this._controller.userUpdated(user);
 
-		let instance = this._controller.instances!.get(instanceId)!;
+		let instance = this._controller.instances.get(instanceId)!;
 		await lib.invokeHook(this._controller.plugins, "onPlayerEvent", instance, {
 			type: event.type,
 			name: event.name,

--- a/packages/controller/src/HostConnection.ts
+++ b/packages/controller/src/HostConnection.ts
@@ -57,6 +57,7 @@ export default class HostConnection extends BaseConnection {
 			plugins: registerData.plugins,
 			token_valid_after: currentHostInfo?.token_valid_after,
 		});
+		this._controller.hostsDirty = true;
 
 		for (let event of ["connect", "drop", "resume", "close"] as const) {
 			// eslint-disable-next-line no-loop-func

--- a/packages/controller/src/HostConnection.ts
+++ b/packages/controller/src/HostConnection.ts
@@ -77,7 +77,7 @@ export default class HostConnection extends BaseConnection {
 
 				let prev = instance.status;
 				instance.status = "unknown";
-				this._controller.instanceUpdated(instance);
+				this._controller.instanceDetailsUpdated(instance);
 				lib.invokeHook(this._controller.plugins, "onInstanceStatusChanged", instance, prev);
 			}
 		});
@@ -181,7 +181,7 @@ export default class HostConnection extends BaseConnection {
 		instance.status = request.status as lib.InstanceStatus;
 		instance.game_port = request.gamePort || null;
 		logger.verbose(`Instance ${instance.config.get("instance.name")} State: ${instance.status}`);
-		this._controller.instanceUpdated(instance);
+		this._controller.instanceDetailsUpdated(instance);
 		await lib.invokeHook(this._controller.plugins, "onInstanceStatusChanged", instance, prev);
 	}
 
@@ -215,7 +215,7 @@ export default class HostConnection extends BaseConnection {
 					let prev = controllerInstance.status;
 					controllerInstance.status = instanceData.status as InstanceStatus;
 					logger.verbose(`Instance ${instanceConfig.get("instance.name")} State: ${instanceData.status}`);
-					this._controller.instanceUpdated(controllerInstance);
+					this._controller.instanceDetailsUpdated(controllerInstance);
 					await lib.invokeHook(
 						this._controller.plugins, "onInstanceStatusChanged", controllerInstance, prev
 					);
@@ -228,12 +228,14 @@ export default class HostConnection extends BaseConnection {
 				{ config: instanceConfig, status: instanceData.status as InstanceStatus }
 			);
 			this._controller.instances!.set(instanceConfig.get("instance.id"), newInstance);
+			this._controller.instancesDirty = true;
 			this._controller.addInstanceHooks(newInstance);
 			await this.send(
 				new lib.InstanceAssignInternalRequest(
 					instanceConfig.get("instance.id"), instanceConfig.serialize("host")
 				)
 			);
+			this._controller.instanceDetailsUpdated(newInstance);
 			await lib.invokeHook(this._controller.plugins, "onInstanceStatusChanged", newInstance);
 		}
 

--- a/packages/controller/src/UserManager.ts
+++ b/packages/controller/src/UserManager.ts
@@ -10,6 +10,7 @@ import * as lib from "@clusterio/lib";
 export default class UserManager {
 	roles: Map<number, lib.Role> = new Map();
 	users: Map<string, lib.User> = new Map();
+	dirty = false;
 
 	constructor(
 		private _config: lib.ControllerConfig
@@ -41,10 +42,6 @@ export default class UserManager {
 	}
 
 	async save(filePath:string): Promise<void> {
-		if (this.roles.size === 0 || this.users.size === 0) {
-			return;
-		}
-
 		let serializedRoles = [];
 		for (let role of this.roles.values()) {
 			serializedRoles.push(role.serialize());
@@ -59,6 +56,7 @@ export default class UserManager {
 			users: serializedUsers,
 			roles: serializedRoles,
 		};
+		this.dirty = false;
 		await lib.safeOutputFile(filePath, JSON.stringify(serialized, null, "\t"));
 	}
 
@@ -80,6 +78,7 @@ export default class UserManager {
 
 		let user = new lib.User({ name, roles }, this.roles);
 		this.users.set(name, user);
+		this.dirty = true;
 		return user;
 	}
 

--- a/packages/controller/src/WsServer.ts
+++ b/packages/controller/src/WsServer.ts
@@ -242,7 +242,7 @@ ${err.stack}`
 				throw new Error("missmatched host id");
 			}
 
-			let host = this.controller.hosts!.get(data.id);
+			let host = this.controller.hosts.get(data.id);
 			if (!tokenPayload.iat || tokenPayload.iat < (host?.token_valid_after??0)) {
 				throw new Error("invalid token");
 			}
@@ -274,13 +274,13 @@ ${err.stack}`
 		connector.on("close", () => {
 			if (this.hostConnections.get(data.id) === connection) {
 				this.hostConnections.delete(data.id);
-				this.controller.hostUpdated(this.controller.hosts!.get(data.id) as HostInfo);
+				this.controller.hostUpdated(this.controller.hosts.get(data.id) as HostInfo);
 			} else {
 				logger.warn("Unlisted HostConnection closed");
 			}
 		});
 		this.hostConnections.set(data.id, connection);
-		this.controller.hostUpdated(this.controller.hosts!.get(data.id) as HostInfo);
+		this.controller.hostUpdated(this.controller.hosts.get(data.id) as HostInfo);
 		let src = new lib.Address(lib.Address.host, data.id);
 		connector.ready(socket, src, sessionToken, undefined);
 	}

--- a/packages/controller/src/routes.ts
+++ b/packages/controller/src/routes.ts
@@ -137,7 +137,7 @@ function validateHostToken(req: Request, res: Response, next: any) {
 		if (typeof tokenPayload === "string") {
 			throw new Error("unexpected JsonWebToken type");
 		}
-		let host = (req.app.locals.controller as Controller).hosts!.get(tokenPayload.host);
+		let host = (req.app.locals.controller as Controller).hosts.get(tokenPayload.host);
 		if (!host) {
 			throw new Error("invalid host");
 		}

--- a/packages/lib/src/config/classes.ts
+++ b/packages/lib/src/config/classes.ts
@@ -85,6 +85,9 @@ export class Config extends events.EventEmitter {
 	_groups = new Map<string, ConfigGroup>();
 	_unknownGroups = new Map<string, SerializedGroup>();
 
+	/** Set to true when a field in the config is changed. */
+	dirty = false;
+
 	/**
 	 * Create a new instance of the given config
 	 *
@@ -566,6 +569,7 @@ export class ConfigGroup {
 		let prev = this._fields.get(name);
 		this._fields.set(name, value);
 		if (this.config && !isDeepStrictEqual(value, prev)) {
+			this.config.dirty = true;
 			this.config.emit("fieldChanged", this, name, prev);
 		}
 	}
@@ -604,6 +608,7 @@ export class ConfigGroup {
 		}
 		this._fields.set(name, updated);
 		if (this.config && !isDeepStrictEqual(updated, prev)) {
+			this.config.dirty = true;
 			this.config.emit("fieldChanged", this, name, prev);
 		}
 	}
@@ -663,6 +668,7 @@ export class ConfigGroup {
 			let prev = this._fields.get(name);
 			this._fields.set(name, value);
 			if (notify && this.config && !isDeepStrictEqual(value, prev)) {
+				this.config.dirty = true;
 				this.config.emit("fieldChanged", this, name, prev);
 			}
 		}

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -32,6 +32,13 @@ ControllerGroup.define({
 	initial_value: "database",
 });
 ControllerGroup.define({
+	name: "autosave_interval",
+	title: "Autosave Interval",
+	description: "Interval in seconds to autosave data in memory to disk.",
+	type: "number",
+	initial_value: 60,
+});
+ControllerGroup.define({
 	name: "http_port",
 	title: "HTTP Port",
 	description: "Port to listen for HTTP connections on, set to null to not listen for HTTP connections.",
@@ -157,6 +164,7 @@ export class ControllerConfig extends classes.Config {
 	get(name: "controller.proxy_stream_timeout"): number;
 	get(name: "controller.default_mod_pack_id"): number | null;
 	get(name: "controller.default_role_id"): number | null;
+	get(name: "controller.autosave_interval"): number;
 	get(name: string): unknown;
 	get(name: string) {
 		return super.get(name);

--- a/plugins/inventory_sync/controller.ts
+++ b/plugins/inventory_sync/controller.ts
@@ -84,7 +84,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 		if (
 			!acquisitionRecord
 			|| acquisitionRecord.instanceId === instanceId
-			|| !this.controller.instances!.has(acquisitionRecord.instanceId)
+			|| !this.controller.instances.has(acquisitionRecord.instanceId)
 			|| acquisitionRecord.expires && acquisitionRecord.expires < Date.now()
 		) {
 			this.acquiredPlayers.set(playerName, { instanceId });
@@ -98,7 +98,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 		let { instanceId, playerName } = request;
 		if (!this.acquire(instanceId, playerName)) {
 			let acquisitionRecord = this.acquiredPlayers.get(playerName);
-			let instance = this.controller.instances!.get(acquisitionRecord!.instanceId)!;
+			let instance = this.controller.instances.get(acquisitionRecord!.instanceId)!;
 			return {
 				status: "busy",
 				message: instance.config.get("instance.name"),
@@ -127,7 +127,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 
 	async handleUploadRequest(request: msg.UploadRequest) {
 		let { instanceId, playerName, playerData } = request;
-		let instanceName = this.controller.instances!.get(instanceId)!.config.get("instance.name");
+		let instanceName = this.controller.instances.get(instanceId)!.config.get("instance.name");
 		let store = true;
 		let acquisitionRecord = this.acquiredPlayers.get(playerName);
 		if (!acquisitionRecord) {
@@ -162,7 +162,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 
 	async handleDownloadRequest(request: msg.DownloadRequest) {
 		let { instanceId, playerName } = request;
-		let instanceName = this.controller.instances!.get(instanceId)!.config.get("instance.name");
+		let instanceName = this.controller.instances.get(instanceId)!.config.get("instance.name");
 
 		let acquisitionRecord = this.acquiredPlayers.get(playerName);
 		if (!acquisitionRecord) {

--- a/plugins/inventory_sync/info.ts
+++ b/plugins/inventory_sync/info.ts
@@ -5,13 +5,6 @@ class ControllerConfigGroup extends lib.PluginConfigGroup { }
 ControllerConfigGroup.defaultAccess = ["controller", "host", "control"];
 ControllerConfigGroup.groupName = "inventory_sync";
 ControllerConfigGroup.define({
-	name: "autosave_interval",
-	title: "Autosave Interval",
-	description: "Interval the player data is autosaved at in seconds.",
-	type: "number",
-	initial_value: 600, // 10 minutes
-});
-ControllerConfigGroup.define({
 	name: "player_lock_timeout",
 	title: "Player Lock Timeout",
 	description:

--- a/plugins/player_auth/controller.ts
+++ b/plugins/player_auth/controller.ts
@@ -47,7 +47,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 
 		this.controller.app.get("/api/player_auth/servers", (req: Request, res: Response) => {
 			let servers: string[] = [];
-			for (let instance of this.controller.instances!.values()) {
+			for (let instance of this.controller.instances.values()) {
 				if (instance.status === "running" && instance.config.get("player_auth.load_plugin")) {
 					servers.push(instance.config.get("factorio.settings")["name"] as string || "unnamed server");
 				}

--- a/plugins/subspace_storage/controller.ts
+++ b/plugins/subspace_storage/controller.ts
@@ -176,7 +176,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 			}
 
 		} else {
-			let instance = this.controller.instances!.get(instanceId);
+			let instance = this.controller.instances.get(instanceId);
 			let instanceName = instance ? instance.config.get("instance.name") : "unkonwn";
 
 			// use fancy neural net to calculate a "fair" dole division rate.

--- a/plugins/subspace_storage/controller.ts
+++ b/plugins/subspace_storage/controller.ts
@@ -75,9 +75,9 @@ export class ControllerPlugin extends BaseControllerPlugin {
 	itemUpdateRateLimiter!: lib.RateLimiter;
 	itemsLastUpdate!: Map<string, number>;
 	subscribedControlLinks!: Set<ControlConnection>;
-	autosaveId!: ReturnType<typeof setInterval>;
 	doleMagicId!: ReturnType<typeof setInterval>;
 	neuralDole!: dole.NeuralDole;
+	storageDirty = false;
 
 	async init() {
 		this.items = await loadDatabase(this.controller.config, this.logger);
@@ -92,11 +92,6 @@ export class ControllerPlugin extends BaseControllerPlugin {
 			},
 		});
 		this.itemsLastUpdate = new Map(this.items.getEntries());
-		this.autosaveId = setInterval(() => {
-			saveDatabase(this.controller.config, this.items, this.logger).catch(err => {
-				this.logger.error(`Unexpected error autosaving items:\n${err.stack}`);
-			});
-		}, this.controller.config.get("subspace_storage.autosave_interval") as number * 1000);
 
 		this.neuralDole = new dole.NeuralDole({ items: this.items });
 		this.doleMagicId = setInterval(() => {
@@ -117,6 +112,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 
 	updateStorage() {
 		this.itemUpdateRateLimiter.activate();
+		this.storageDirty = true;
 	}
 
 	broadcastStorage() {
@@ -254,8 +250,13 @@ export class ControllerPlugin extends BaseControllerPlugin {
 
 	async onShutdown() {
 		this.itemUpdateRateLimiter.cancel();
-		clearInterval(this.autosaveId);
 		clearInterval(this.doleMagicId);
-		await saveDatabase(this.controller.config, this.items, this.logger);
+	}
+
+	async onSaveData() {
+		if (this.storageDirty) {
+			this.storageDirty = false;
+			await saveDatabase(this.controller.config, this.items, this.logger);
+		}
 	}
 }

--- a/plugins/subspace_storage/info.ts
+++ b/plugins/subspace_storage/info.ts
@@ -5,13 +5,6 @@ class ControllerConfigGroup extends lib.PluginConfigGroup {}
 ControllerConfigGroup.defaultAccess = ["controller", "host", "control"];
 ControllerConfigGroup.groupName = "subspace_storage";
 ControllerConfigGroup.define({
-	name: "autosave_interval",
-	title: "Autosave Interval",
-	description: "Interval the storage is autosaved at in seconds.",
-	type: "number",
-	initial_value: 60,
-});
-ControllerConfigGroup.define({
 	name: "division_method",
 	title: "Division Method",
 	description: "Method for dividing resource requests between instances.",

--- a/test/host.js
+++ b/test/host.js
@@ -20,6 +20,7 @@ describe("Host testing", function() {
 			await referenceConfig.init();
 			referenceConfig.set("instance.id", 1);
 			referenceConfig.set("instance.name", "test");
+			referenceConfig.dirty = false;
 
 			assert.deepEqual(instanceInfos, new Map([
 				[1, {


### PR DESCRIPTION
Add controller.autosave_interval config that specifies the frequency which controller config, hosts, instances, users, mod packs and plugin specific data which is held in memory should be automatically flushed to disk if they have changed since the last time they were saved.  This prevents data loss in the event of a server crash.

Plugins can use the onSaveData hook to save its own data at the same time as the controller does and this obsoletes making an autosave interval in the plugin.

Resolves #523.