### PR TITLE
Fix inventory wipe on SE remote view

### DIFF
--- a/plugins/inventory_sync/module/inventory_sync.lua
+++ b/plugins/inventory_sync/module/inventory_sync.lua
@@ -56,6 +56,19 @@ function inventory_sync.serialize_player(player, player_record)
 		return
 	end
 
+	-- mod-compat: Exit Space Exploration satelite view to restore the real character
+	if remote.interfaces["space-exploration"] then
+		local status, result = pcall(function()
+			if remote.call("space-exploration", "remote_view_is_active", { player = player }) then
+				remote.call("space-exploration", "remote_view_stop", { player = player })
+			end
+		end)
+		if not status then
+			log("ERROR: Exiting remote view failed for " .. player.name .. ": " .. result)
+			player.print("ERROR: Exiting remote view failed: " .. result)
+		end
+	end
+
 	local serialized_player = serialize.serialize_player(player)
 	serialized_player.generation = player_record.generation
 


### PR DESCRIPTION
Exit the Space Exploration remote view if its active to prevent the empty remote view "character" being serialized as the inventory instead of the real character for the player.

Original-patch-by: @Reavershark
Fixes: #513