### PR TITLE
Host port ranges

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -288,6 +288,7 @@ module.exports = {
 				":": "before",
 				"||": "before",
 				"&&": "before",
+				"??": "before",
 			},
 		}],
 		"padded-blocks": "off",

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -169,7 +169,7 @@ export default class Instance extends lib.Link {
 		let serverOptions = {
 			logger: this.logger,
 			version: this.config.get("factorio.version"),
-			gamePort: this.config.get("factorio.game_port") ?? undefined,
+			gamePort: this.config.get("factorio.game_port") ?? host.assignGamePort(this.id),
 			rconPort: this.config.get("factorio.rcon_port") ?? undefined,
 			rconPassword: this.config.get("factorio.rcon_password") ?? undefined,
 			enableWhitelist: this.config.get("factorio.enable_whitelist"),
@@ -449,7 +449,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 			new lib.InstanceStatusChangedEvent(
 				this.id,
 				status,
-				status !== "stopped" ? this.server.gamePort : undefined,
+				this.server.gamePort,
 			),
 		);
 	}

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -158,6 +158,7 @@ export interface HostConfigFields {
 	"host.controller_token": string;
 	"host.tls_ca": string | null;
 	"host.public_address": string;
+	"host.factorio_port_range": string;
 	"host.max_reconnect_delay": number;
 }
 
@@ -220,6 +221,14 @@ export class HostConfig extends classes.Config<HostConfigFields> {
 			type: "string",
 			initialValue: "localhost",
 		},
+		"host.factorio_port_range": {
+			title: "Factorio port range",
+			description:
+				"Range of UDP ports to use for game connections. Supports both comma separated values and " +
+				"ranges separated with a dash.",
+			type: "string",
+			initialValue: "34100-34199",
+		},
 		"host.max_reconnect_delay": {
 			title: "Max Reconnect Delay",
 			description: "Maximum delay to wait before attempting to reconnect WebSocket",
@@ -237,6 +246,7 @@ export interface InstanceConfigFields {
 
 	"factorio.version": string;
 	"factorio.game_port": number | null;
+	"factorio.host_assigned_game_port": number | null;
 	"factorio.rcon_port": number | null;
 	"factorio.rcon_password": string | null;
 	"factorio.player_online_autosave_slots": number;
@@ -286,8 +296,13 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			initialValue: "latest",
 		},
 		"factorio.game_port": {
-			description: "UDP port to run game on, uses a random port if null",
+			description: "UDP port to run game on, uses a port in host.factorio_port_range if null",
 			restartRequired: true,
+			type: "number",
+			optional: true,
+		},
+		"factorio.host_assigned_game_port": {
+			access: ["host"],
 			type: "number",
 			optional: true,
 		},

--- a/test/host/Instance.js
+++ b/test/host/Instance.js
@@ -20,7 +20,7 @@ describe("class Instance", function() {
 		instanceConfig.set("instance.name", "foo");
 		src = addr({ instanceId: instanceConfig.get("instance.id") });
 		connector = new MockConnector(src, dst);
-		instance = new Instance({}, connector, "dir", "factorioDir", instanceConfig);
+		instance = new Instance({ assignGamePort: () => 1 }, connector, "dir", "factorioDir", instanceConfig);
 		instance.server = new MockServer();
 	});
 


### PR DESCRIPTION
Add host.factorio_port_range config to hosts that specify a pool of ports that gets automatically assigned to instances which do not have a game_port set on them.  This allows setting up a port range that's forwarded to the host on the router and then configure that port range
 on the host and have instances automatically get assigned an available port when they start up.
