### PR TITLE
Sort hosts in AssignInstanceModal

### DIFF
--- a/packages/web_ui/src/components/AssignInstanceModal.tsx
+++ b/packages/web_ui/src/components/AssignInstanceModal.tsx
@@ -9,6 +9,7 @@ import { notifyErrorHandler } from "../util/notify";
 import { useHosts } from "../model/host";
 
 const { Paragraph } = Typography;
+const strcmp = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }).compare;
 
 
 type AssignInstanceModalProps = {
@@ -80,7 +81,7 @@ export default function AssignInstanceModal(props: AssignInstanceModalProps) {
 						<Select.Option value={"null"}>
 							<Typography.Text italic>Unassigned</Typography.Text>
 						</Select.Option>
-						{[...hosts.values()].map((host) => <Select.Option
+						{[...hosts.values()].sort((a, b) => strcmp(a.name, b.name)).map((host) => <Select.Option
 							key={host["id"]}
 							value={host["id"]}
 							disabled={!host["connected"]}


### PR DESCRIPTION
Requested by Illisis on Discord. The assign instance modal is not sorted, making selection tedious:

![image](https://github.com/clusterio/clusterio/assets/14362102/9ac1019d-f168-4077-9b3b-cb5ce9d66ee2)