### PR TITLE
Explicit config creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,6 +322,7 @@ Many thanks to the following for contributing code in this release:
 - Controller no longer creates secret-api-token.txt.
 - Removed automatic creation of self-signed TLS certificate.
 - Node.js versions below 12 are no longer supported.
+- Controller, host and ctl programs fail when the config is not found instead of creating one silently. Configs can be created using 'config create' (host & controller) or 'control-config create' commands.
 
 ## Version 1.2.4
 

--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -350,9 +350,7 @@ async function initialize(): Promise<InitializeParameters> {
 
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				logger.info("Config not found, initializing new config");
-				controllerConfig = new lib.ControllerConfig("controller");
-	
+				throw new lib.StartupError(`Controller config "${controllerConfigPath}" not found.`);
 			} else {
 				throw new lib.StartupError(`Failed to load ${controllerConfigPath}: ${err.message}`);
 			}
@@ -362,7 +360,7 @@ async function initialize(): Promise<InitializeParameters> {
 	
 	if (command === "config") {
 		await lib.handleConfigCommand(
-			args, controllerConfigLoader, controllerConfigPath
+			args, controllerConfigLoader, controllerConfigPath, () => new lib.ControllerConfig("controller")
 		);
 	}
 	let controllerConfig = await controllerConfigLoader();

--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -356,8 +356,8 @@ async function initialize(): Promise<InitializeParameters> {
 			}
 		}
 		return controllerConfig;
-	}
-	
+	};
+
 	if (command === "config") {
 		await lib.handleConfigCommand(
 			args, controllerConfigLoader, controllerConfigPath, () => new lib.ControllerConfig("controller")

--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -341,23 +341,10 @@ async function initialize(): Promise<InitializeParameters> {
 	lib.addPluginConfigFields(pluginInfos);
 
 	const controllerConfigPath = args.config;
-	let controllerConfigLoader = async () => {
-		logger.info(`Loading config from ${controllerConfigPath}`);
-		let controllerConfig = new lib.ControllerConfig("controller");
-		try {
-			let jsonConfig = JSON.parse(await fs.readFile(controllerConfigPath, { encoding: "utf8" }));
-			controllerConfig = lib.ControllerConfig.fromJSON(jsonConfig, "controller");
-
-		} catch (err: any) {
-			if (err.code === "ENOENT") {
-				throw new lib.StartupError(`Controller config "${controllerConfigPath}" not found.`);
-			} else {
-				throw new lib.StartupError(`Failed to load ${controllerConfigPath}: ${err.message}`);
-			}
-		}
-		return controllerConfig;
-	};
-
+	let controllerConfigLoader = () => lib.loadConfig(
+		controllerConfigPath,
+		(json) => lib.ControllerConfig.fromJSON(json, "controller")
+	);
 	if (command === "config") {
 		await lib.handleConfigCommand(
 			args, controllerConfigLoader, controllerConfigPath, () => new lib.ControllerConfig("controller")

--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -853,6 +853,7 @@ async function main() {
 	let adminToken = null;
 	if (["standalone", "controller"].includes(answers.mode)) {
 		logger.info("Setting up controller");
+		await execController(["config", "create"]);
 		await execController(["bootstrap", "create-admin", answers.admin]);
 		let result = await execController(["bootstrap", "generate-user-token", answers.admin]);
 		adminToken = result.stdout.split("\n").slice(-2)[0];
@@ -860,6 +861,7 @@ async function main() {
 
 	if (answers.mode === "standalone") {
 		logger.info("Setting up host");
+		await execHost(["config", "create"]);
 		await execHost(["config", "set", "host.name", "local"]);
 
 		let result = await execHost(["config", "show", "host.id"]);
@@ -875,6 +877,7 @@ async function main() {
 
 	if (answers.mode === "host") {
 		logger.info("Setting up host");
+		await execHost(["create", "config"]);
 		let hostId = JSON.parse(Buffer.from(answers.controllerToken.split(".")[1], "base64")).host;
 		await execHost(["config", "set", "host.id", hostId]);
 		await execHost(["config", "set", "host.name", answers.hostName]);
@@ -890,6 +893,7 @@ async function main() {
 	}
 
 	if (answers.mode === "ctl") {
+		await execCtl(["control-config", "create"]);
 		await execCtl(["control-config", "set", "control.controller_url", answers.controllerUrl]);
 		await execCtl(["control-config", "set", "control.controller_token", answers.controllerToken]);
 	}

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -231,7 +231,7 @@ async function startControl() {
 			}
 		}
 		return controlConfig;
-	}
+	};
 
 	if (args._.length === 0) {
 		yargs.showHelp();

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -225,9 +225,7 @@ async function startControl() {
 
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				logger.verbose("Config not found, initializing new config");
-				controlConfig = new lib.ControlConfig("control");
-
+				throw new lib.StartupError(`Control config "${args.config}" not found.`);
 			} else {
 				throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
 			}
@@ -242,7 +240,7 @@ async function startControl() {
 
 	// Handle the control-config command before trying to connect.
 	if (args._[0] === "control-config") {
-		await lib.handleConfigCommand(args, controlConfigLoader, args.config);
+		await lib.handleConfigCommand(args, controlConfigLoader, args.config, () => new lib.ControlConfig("control"));
 		return;
 	}
 	let controlConfig = await controlConfigLoader();

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -216,20 +216,23 @@ async function startControl() {
 		.parse() as CtlArguments
 	;
 
-	logger.verbose(`Loading config from ${args.config}`);
-	let controlConfig;
-	try {
-		const jsonConfig = JSON.parse(await fs.readFile(args.config, "utf8"));
-		controlConfig = lib.ControlConfig.fromJSON(jsonConfig, "control");
+	let controlConfigLoader = async () => {
+		logger.verbose(`Loading config from ${args.config}`);
+		let controlConfig;
+		try {
+			const jsonConfig = JSON.parse(await fs.readFile(args.config, "utf8"));
+			controlConfig = lib.ControlConfig.fromJSON(jsonConfig, "control");
 
-	} catch (err: any) {
-		if (err.code === "ENOENT") {
-			logger.verbose("Config not found, initializing new config");
-			controlConfig = new lib.ControlConfig("control");
+		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				logger.verbose("Config not found, initializing new config");
+				controlConfig = new lib.ControlConfig("control");
 
-		} else {
-			throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
+			} else {
+				throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
+			}
 		}
+		return controlConfig;
 	}
 
 	if (args._.length === 0) {
@@ -239,9 +242,10 @@ async function startControl() {
 
 	// Handle the control-config command before trying to connect.
 	if (args._[0] === "control-config") {
-		await lib.handleConfigCommand(args, controlConfig, args.config);
+		await lib.handleConfigCommand(args, controlConfigLoader, args.config);
 		return;
 	}
+	let controlConfig = await controlConfigLoader();
 
 	// Determine which command is being executed.
 	let commandPath = [...args._] as string[];

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -216,22 +216,10 @@ async function startControl() {
 		.parse() as CtlArguments
 	;
 
-	let controlConfigLoader = async () => {
-		logger.verbose(`Loading config from ${args.config}`);
-		let controlConfig;
-		try {
-			const jsonConfig = JSON.parse(await fs.readFile(args.config, "utf8"));
-			controlConfig = lib.ControlConfig.fromJSON(jsonConfig, "control");
-
-		} catch (err: any) {
-			if (err.code === "ENOENT") {
-				throw new lib.StartupError(`Control config "${args.config}" not found.`);
-			} else {
-				throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
-			}
-		}
-		return controlConfig;
-	};
+	let controlConfigLoader = async () => lib.loadConfig(
+		args.config,
+		(json) => lib.ControlConfig.fromJSON(json, "control")
+	);
 
 	if (args._.length === 0) {
 		yargs.showHelp();

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -182,7 +182,7 @@ async function startHost() {
 			}
 		}
 		return hostConfig;
-	}
+	};
 
 	if (command === "config") {
 		await lib.handleConfigCommand(args, hostConfigLoader, args.config, () => new lib.HostConfig("host"));

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -167,26 +167,30 @@ async function startHost() {
 	lib.registerPluginMessages(pluginInfos);
 	lib.addPluginConfigFields(pluginInfos);
 
-	logger.info(`Loading config from ${args.config}`);
-	let hostConfig;
-	try {
-		const jsonConfig = JSON.parse(await fs.readFile(args.config, "utf8"));
-		hostConfig = lib.HostConfig.fromJSON(jsonConfig, "host");
+	let hostConfigLoader = async () => {
+		logger.info(`Loading config from ${args.config}`);
+		let hostConfig;
+		try {
+			const jsonConfig = JSON.parse(await fs.readFile(args.config, "utf8"));
+			hostConfig = lib.HostConfig.fromJSON(jsonConfig, "host");
 
-	} catch (err: any) {
-		if (err.code === "ENOENT") {
-			logger.info("Config not found, initializing new config");
-			hostConfig = new lib.HostConfig("host");
-
-		} else {
-			throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
+		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				logger.info("Config not found, initializing new config");
+				hostConfig = new lib.HostConfig("host");
+			} else {
+				throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
+			}
 		}
+		return hostConfig;
 	}
 
 	if (command === "config") {
-		await lib.handleConfigCommand(args, hostConfig, args.config);
+		await lib.handleConfigCommand(args, hostConfigLoader, args.config);
 		return;
 	}
+	let hostConfig = await hostConfigLoader();
+
 
 	// If we get here the command was run
 

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -176,8 +176,7 @@ async function startHost() {
 
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				logger.info("Config not found, initializing new config");
-				hostConfig = new lib.HostConfig("host");
+				throw new lib.StartupError(`Host config "${args.config}" not found.`);
 			} else {
 				throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
 			}
@@ -186,7 +185,7 @@ async function startHost() {
 	}
 
 	if (command === "config") {
-		await lib.handleConfigCommand(args, hostConfigLoader, args.config);
+		await lib.handleConfigCommand(args, hostConfigLoader, args.config, () => new lib.HostConfig("host"));
 		return;
 	}
 	let hostConfig = await hostConfigLoader();

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -167,22 +167,10 @@ async function startHost() {
 	lib.registerPluginMessages(pluginInfos);
 	lib.addPluginConfigFields(pluginInfos);
 
-	let hostConfigLoader = async () => {
-		logger.info(`Loading config from ${args.config}`);
-		let hostConfig;
-		try {
-			const jsonConfig = JSON.parse(await fs.readFile(args.config, "utf8"));
-			hostConfig = lib.HostConfig.fromJSON(jsonConfig, "host");
-
-		} catch (err: any) {
-			if (err.code === "ENOENT") {
-				throw new lib.StartupError(`Host config "${args.config}" not found.`);
-			} else {
-				throw new lib.StartupError(`Failed to load ${args.config}: ${err.message}`);
-			}
-		}
-		return hostConfig;
-	};
+	let hostConfigLoader = () => lib.loadConfig(
+		args.config,
+		(json) => lib.HostConfig.fromJSON(json, "host")
+	);
 
 	if (command === "config") {
 		await lib.handleConfigCommand(args, hostConfigLoader, args.config, () => new lib.HostConfig("host"));

--- a/packages/lib/src/shared_commands.ts
+++ b/packages/lib/src/shared_commands.ts
@@ -129,15 +129,17 @@ export function configCommand(yargs: any) {
  * Handle the actions that are made available by configCommand.
  *
  * @param args - yargs args object.
- * @param instance - Config instance.
+ * @param instanceLoader - Function that loads the config instance.
  * @param configPath - Path to configuration file.
  */
 export async function handleConfigCommand(
 	args: Record<string, unknown>,
-	instance: libConfig.Config<any>,
+	instanceLoader: () => Promise<libConfig.Config<any>>,
 	configPath: string
 ) {
 	let command = (args._ as string[])[1];
+
+	let instance = await instanceLoader();
 
 	if (command === "list") {
 		for (const name of Object.keys(instance.constructor.fieldDefinitions)) {

--- a/packages/lib/src/shared_commands.ts
+++ b/packages/lib/src/shared_commands.ts
@@ -133,6 +133,8 @@ export function configCommand(yargs: any) {
  * @param args - yargs args object.
  * @param instanceLoader - Function that loads the config instance.
  * @param configPath - Path to configuration file.
+ * @param emptyConfigSupplier - Function supplying a default config for
+ *   the create command.
  */
 export async function handleConfigCommand(
 	args: Record<string, unknown>,
@@ -142,9 +144,9 @@ export async function handleConfigCommand(
 ) {
 	let command = (args._ as string[])[1];
 
-	if (command == "create") {
+	if (command === "create") {
 		if (await fs.exists(configPath)) {
-			logger.error(`Config "${configPath}" already exists`)
+			logger.error(`Config "${configPath}" already exists`);
 			return;
 		}
 		await libFileOps.safeOutputFile(configPath, JSON.stringify(emptyConfigSupplier(), null, "\t"));

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -226,6 +226,7 @@ before(async function() {
 	}
 	await fs.copyFile(`mods/${ssZip}`, `${modsDir}/${ssZip}`);
 
+	await exec("node ../../packages/controller config create");
 	await exec("node ../../packages/controller config set controller.auth_secret TestSecretDoNotUse");
 	await exec("node ../../packages/controller config set controller.http_port 8880");
 	await exec("node ../../packages/controller config set controller.https_port 4443");


### PR DESCRIPTION
This changes the behaviour when starting a controller, host or ctl when the config file can not be found. The intention (according to the backlog) is to prevent accidentally starting in the wrong directory.

Specifically it adds the following
- Starting without a config gives an error (not starting)
- A generic `config create` command is added to create configs. This fails if the config file already exists.

### Thoughts
The create-config command creates a basic config for all three types (controller, host and ctl). There are already two commands to create configs,  `ctl create-host` for creating host configs and `controller bootstrap create-ctl-config` for ctl configs. This duplication seems rather suspect.

### Todo
- [x] Update ChangeLog
- [x] Update docs/contributing.md (checked, no references to creating configs, everything is done through the create script.)
- [x] Update README.md (checked, no references to creating configs. Everything is done through the create script.)
- [ ] Write explicit tests
- [x] Update create.js