### PR TITLE
Add non_blocking_saving to instance defaults

### DIFF
--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -804,6 +804,7 @@ export default class Controller {
 			"auto_pause": false,
 			"only_admins_can_pause_the_game": true,
 			"autosave_only_on_server": true,
+			"non_blocking_saving": false,
 
 			...instanceConfig.get("factorio.settings"),
 		};


### PR DESCRIPTION
This option was originally left out because it has caused a lot of issues in the past when used with Clusterio. A better solution than hard coding the defaults to newly created instances should implemented, but for now this will have to do as I don't have a good idea of how to implement that.