### PR TITLE
Implement custom input for mod pack config

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -638,7 +638,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 	 */
 	async syncMods() {
 		this.logger.info("Syncing mods");
-		const modPackId = this.config.get("factorio.mod_pack");
+		const modPackId = this.config.get("factorio.mod_pack_id");
 		let modPack;
 		if (modPackId === null) {
 			modPack = await this.sendTo("controller", new lib.ModPackGetDefaultRequest());

--- a/packages/lib/src/config/classes.ts
+++ b/packages/lib/src/config/classes.ts
@@ -78,6 +78,11 @@ export interface FieldDefinition {
 	 */
 	description?: string;
 	/**
+	 * Web UI component to use for rending this input. Can be extended by
+	 * @{link "@clusterio/web_ui".BaseWebPlugin.inputComponents}
+	 */
+	inputComponent?: string;
+	/**
 	 * True if this field can be set to null.  Defaults to false.
 	 */
 	optional?: boolean;

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -142,6 +142,7 @@ export class ControllerConfig extends classes.Config<ControllerConfigFields> {
 		"controller.default_mod_pack_id": {
 			title: "Default Mod Pack",
 			description: "Mod pack used by default for instances.",
+			inputComponent: "mod_pack",
 			type: "number",
 			optional: true,
 		},
@@ -257,7 +258,7 @@ export interface InstanceConfigFields {
 	"factorio.rcon_port": number | null;
 	"factorio.rcon_password": string | null;
 	"factorio.player_online_autosave_slots": number;
-	"factorio.mod_pack": number | null;
+	"factorio.mod_pack_id": number | null;
 	"factorio.enable_save_patching": boolean;
 	"factorio.enable_whitelist": boolean;
 	"factorio.enable_authserver_bans": boolean;
@@ -332,8 +333,11 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			type: "number",
 			initialValue: 5,
 		},
-		"factorio.mod_pack": {
-			description: "Mod pack to use on this server",
+		"factorio.mod_pack_id": {
+			title: "Mod Pack",
+			description:
+				"Mod pack to use on this server, if not set the default configured on the controller will be used",
+			inputComponent: "mod_pack",
 			restartRequired: true,
 			type: "number",
 			optional: true,

--- a/packages/web_ui/src/BaseWebPlugin.ts
+++ b/packages/web_ui/src/BaseWebPlugin.ts
@@ -1,5 +1,5 @@
 import type React from "react";
-import type { AccountRole, Logger, PluginWebpackEnvInfo } from "@clusterio/lib";
+import type { AccountRole, FieldDefinition, Logger, PluginWebpackEnvInfo } from "@clusterio/lib";
 import type { Control } from "./util/websocket";
 
 /**
@@ -21,7 +21,14 @@ export interface PluginLoginForm {
 	 * when an authentication token is aquired via this form.
 	 */
 	Component: React.ComponentType<{ setToken(token: string): void }>;
-};
+}
+
+export interface InputComponentProps {
+	fieldDefinition: FieldDefinition,
+	value: null | boolean | number | string,
+	onChange: (value: null | boolean | number | string) => void,
+}
+export type InputComponent = React.ComponentType<InputComponentProps>;
 
 export type UserAccount = {
 	/** Name of the currently logged in account. */
@@ -94,6 +101,11 @@ export default class BaseWebPlugin {
 	 * List of pages provided by this plugin
 	 */
 	pages: PluginPage[] = [];
+	/**
+	 * Additional Config inputComponent types available to render config
+	 * entries with.
+	 */
+	inputComponents: Record<string, InputComponent> = {};
 	/**
 	 * Extra react component to add to core components
 	 *

--- a/packages/web_ui/src/components/InputModPack.tsx
+++ b/packages/web_ui/src/components/InputModPack.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Select } from "antd";
+
+import { useModPacks } from "../model/mod_pack";
+import { InputComponentProps } from "../BaseWebPlugin";
+
+export default function InputModPack(props: InputComponentProps) {
+	const [modPacks] = useModPacks();
+	return <Select
+		style={{ minWidth: 175 }}
+		onChange={(value) => props.onChange(value ?? null)}
+		value={props.value}
+		options={[...modPacks.values()].map(modPack => ({
+			label: modPack.name,
+			value: modPack.id,
+		}))}
+		allowClear={props.fieldDefinition.optional}
+	/>;
+}
+

--- a/packages/web_ui/src/util/websocket.ts
+++ b/packages/web_ui/src/util/websocket.ts
@@ -1,6 +1,6 @@
 import * as lib from "@clusterio/lib";
 import packageJson from "../../package.json";
-import BaseWebPlugin from "../BaseWebPlugin";
+import BaseWebPlugin, { type InputComponent } from "../BaseWebPlugin";
 
 const { logFilter, logger } = lib;
 
@@ -53,6 +53,7 @@ export class Control extends lib.Link {
 
 	/** Plugins loaded in the web interface */
 	public plugins = new Map<string, BaseWebPlugin>();
+	public inputComponents: Record<string, InputComponent> = {};
 
 	/** Updates not handled by the subscription service */
 	accountUpdateHandlers: accountHandler[] = [];


### PR DESCRIPTION
Add custom input component support to the Web UI config in order to provide a user friendly dropdown selector for the Mod Pack that is configured as default on the controller and overridden instances.

![image](https://github.com/clusterio/clusterio/assets/14362102/9dfcee5e-c5ae-4ded-a8ce-90469d1b9e31)