### PR TITLE
Add first join at player statistic

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -301,6 +301,9 @@ export default class Instance extends lib.Link {
 			this.playerStats.set(name, stats);
 		}
 		stats.lastJoinAt = new Date();
+		if (!stats.firstJoinAt) {
+			stats.firstJoinAt = stats.lastJoinAt;
+		}
 		stats.joinCount += 1;
 
 		let event: lib.PlayerEvent = {

--- a/packages/lib/src/data/PlayerStats.ts
+++ b/packages/lib/src/data/PlayerStats.ts
@@ -15,6 +15,11 @@ export default class PlayerStats {
 	onlineTimeMs = 0;
 
 	/**
+	 * Timestapm the player was first seen joining.
+	 */
+	firstJoinAt?: Date;
+
+	/**
 	 * Timestamp the player was last seen joining.
 	 */
 	lastJoinAt?: Date;
@@ -32,6 +37,7 @@ export default class PlayerStats {
 	static jsonSchema = Type.Object({
 		"join_count": Type.Optional(Type.Integer()),
 		"online_time_ms": Type.Optional(Type.Number()),
+		"first_join_at": Type.Optional(Type.Number()),
 		"last_join_at": Type.Optional(Type.Number()),
 		"last_leave_at": Type.Optional(Type.Number()),
 		"last_leave_reason": Type.Optional(Type.String()),
@@ -41,11 +47,17 @@ export default class PlayerStats {
 		if (json["join_count"]) {
 			this.joinCount = json["join_count"];
 		}
+		if (json["first_join_at"]) {
+			this.firstJoinAt = new Date(json["first_join_at"]);
+		}
 		if (json["online_time_ms"]) {
 			this.onlineTimeMs = json["online_time_ms"];
 		}
 		if (json["last_join_at"]) {
 			this.lastJoinAt = new Date(json["last_join_at"]);
+			if (!this.firstJoinAt) { // migrate: pre-alpha 14 did not have this field.
+				this.firstJoinAt = this.lastJoinAt;
+			}
 		}
 		if (json["last_leave_at"]) {
 			this.lastLeaveAt = new Date(json["last_leave_at"]);
@@ -64,6 +76,9 @@ export default class PlayerStats {
 		}
 		if (this.onlineTimeMs) {
 			json["online_time_ms"] = this.onlineTimeMs;
+		}
+		if (this.firstJoinAt) {
+			json["first_join_at"] = this.firstJoinAt.getTime();
 		}
 		if (this.lastJoinAt) {
 			json["last_join_at"] = this.lastJoinAt.getTime();

--- a/packages/lib/src/data/User.ts
+++ b/packages/lib/src/data/User.ts
@@ -126,6 +126,12 @@ export default class User {
 		let playerStats = new PlayerStats();
 		for (let instanceStats of instanceStatsMap.values()) {
 			if (
+				instanceStats.firstJoinAt
+				&& (!playerStats.firstJoinAt || instanceStats.firstJoinAt < playerStats.firstJoinAt)
+			) {
+				playerStats.firstJoinAt = instanceStats.firstJoinAt;
+			}
+			if (
 				instanceStats.lastJoinAt
 				&& (!playerStats.lastJoinAt || instanceStats.lastJoinAt > playerStats.lastJoinAt)
 			) {

--- a/packages/web_ui/src/components/UserViewPage.tsx
+++ b/packages/web_ui/src/components/UserViewPage.tsx
@@ -17,7 +17,7 @@ import PluginExtra from "./PluginExtra";
 import SectionHeader from "./SectionHeader";
 import notify, { notifyErrorHandler } from "../util/notify";
 import { formatDuration } from "../util/time_format";
-import { formatLastSeen, sortLastSeen, useUser } from "../model/user";
+import { formatFirstSeen, formatLastSeen, sortFirstSeen, sortLastSeen, useUser } from "../model/user";
 
 const strcmp = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }).compare;
 
@@ -286,12 +286,15 @@ export default function UserViewPage() {
 			}
 		</Form>
 		<SectionHeader title="Player stats" />
-		<Descriptions size="small" bordered column={{ xs: 1, sm: 2, lg: 3 }}>
+		<Descriptions size="small" bordered column={{ xs: 1, sm: 2, md: 2, lg: 2, xl: 2, xxl: 2 }}>
 			<Descriptions.Item label="Total online time">
 				{formatDuration(user.playerStats?.onlineTimeMs ?? 0)}
 			</Descriptions.Item>
 			<Descriptions.Item label="Total join count">
 				{user.playerStats?.joinCount ?? 0}
+			</Descriptions.Item>
+			<Descriptions.Item label="First seen">
+				{formatFirstSeen(user) || " "}
 			</Descriptions.Item>
 			<Descriptions.Item label="Last seen">
 				{formatLastSeen(user) || " "}
@@ -320,6 +323,12 @@ export default function UserViewPage() {
 					render: (_, [, stats]) => stats.joinCount || 0,
 					sorter: (a, b) => (a[1].joinCount || 0) - (b[1].joinCount || 0),
 					responsive: ["sm"],
+				},
+				{
+					title: "First seen",
+					key: "firstSeen",
+					render: (_, [id]) => formatFirstSeen(user, id),
+					sorter: (a, b) => sortFirstSeen(user, user, a[0], b[0]),
 				},
 				{
 					title: "Last seen",

--- a/packages/web_ui/src/components/UsersPage.tsx
+++ b/packages/web_ui/src/components/UsersPage.tsx
@@ -11,7 +11,7 @@ import { formatDuration } from "../util/time_format";
 import PageHeader from "./PageHeader";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
-import { formatLastSeen, sortLastSeen, useUsers } from "../model/user";
+import { formatFirstSeen, formatLastSeen, sortFirstSeen, sortLastSeen, useUsers } from "../model/user";
 
 const strcmp = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }).compare;
 
@@ -108,6 +108,12 @@ export default function UsersPage() {
 					sorter: (a, b) => (a.playerStats?.onlineTimeMs ?? 0) -
 						(b.playerStats?.onlineTimeMs ?? 0),
 					responsive: ["lg"],
+				},
+				{
+					title: "First seen",
+					key: "firstSeen",
+					render: (_, user) => formatFirstSeen(user),
+					sorter: (a, b) => sortFirstSeen(a, b),
 				},
 				{
 					title: "Last seen",

--- a/test/lib/data/User.js
+++ b/test/lib/data/User.js
@@ -35,12 +35,14 @@ describe("lib/data/User", function() {
 				[2, {
 					join_count: 1,
 					online_time_ms: 0,
+					first_join_at: new Date("2020-05T12:00Z").getTime(),
 					last_join_at: new Date("2020-05T12:02Z").getTime(),
 				}],
 			]});
 
 			assert.equal(user.playerStats.onlineTimeMs, 60e3);
 			assert.equal(user.playerStats.joinCount, 2);
+			assert.deepEqual(user.playerStats.firstJoinAt, new Date("2020-05T12:00Z"));
 			assert.deepEqual(user.playerStats.lastJoinAt, new Date("2020-05T12:02Z"));
 			assert.deepEqual(user.playerStats.lastLeaveAt, new Date("2020-05T12:01Z"));
 			assert.equal(user.playerStats.lastLeaveReason, "quit");
@@ -50,6 +52,7 @@ describe("lib/data/User", function() {
 				lib.PlayerStats.fromJSON({
 					join_count: 2,
 					online_time_ms: 120e3,
+					first_join_at: new Date("2020-05T11:00Z").getTime(),
 					last_join_at: new Date("2020-05T13:00Z").getTime(),
 					last_leave_at: new Date("2020-05T13:02Z").getTime(),
 					last_leave_reason: "afk",
@@ -59,6 +62,7 @@ describe("lib/data/User", function() {
 			user.recalculatePlayerStats();
 			assert.equal(user.playerStats.onlineTimeMs, 180e3);
 			assert.equal(user.playerStats.joinCount, 4);
+			assert.deepEqual(user.playerStats.firstJoinAt, new Date("2020-05T11:00Z"));
 			assert.deepEqual(user.playerStats.lastJoinAt, new Date("2020-05T13:00Z"));
 			assert.deepEqual(user.playerStats.lastLeaveAt, new Date("2020-05T13:02Z"));
 			assert.equal(user.playerStats.lastLeaveReason, "afk");


### PR DESCRIPTION
Record the time a player was first seen joining an instance in PlayerStats.  For existing stats this value is set to the last joined time when it is first loaded.

Resolves #550 