### PR TITLE
Use a relative path for commands in create

### DIFF
--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -113,21 +113,21 @@ async function execFile(cmd, args) {
 
 async function execController(args) {
 	if (dev) {
-		return await execFile("node", [path.join("packages", "controller"), ...args]);
+		return await execFile("node", [path.join(__dirname, "..", "controller"), ...args]);
 	}
 	return await execFile(path.join("node_modules", ".bin", `clusteriocontroller${scriptExt}`), args);
 }
 
 async function execHost(args) {
 	if (dev) {
-		return await execFile("node", [path.join("packages", "host"), ...args]);
+		return await execFile("node", [path.join(__dirname, "..", "host"), ...args]);
 	}
 	return await execFile(path.join("node_modules", ".bin", `clusteriohost${scriptExt}`), args);
 }
 
 async function execCtl(args) {
 	if (dev) {
-		return await execFile("node", [path.join("packages", "ctl"), ...args]);
+		return await execFile("node", [path.join(__dirname, "..", "ctl"), ...args]);
 	}
 	return await execFile(path.join("node_modules", ".bin", `clusterioctl${scriptExt}`), args);
 }


### PR DESCRIPTION
The create.js script in development mode used to use hard coded paths to the other cluster commands (ctl, controller etc.). This means that in dev mode a cluster could only be created from the root directory of the project.

By using relative paths one can also create a cluster in a subdirectory. For example by using the following:

mkdir test-cluster
cd test-cluster
node ../packages/create --dev

This is for example useful for testing the create.js in a separate directory.