### PR TITLE
Implement stop and restart of controller/hosts

### DIFF
--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -244,6 +244,10 @@ async function initialize(): Promise<InitializeParameters> {
 				.demandCommand(1, "You need to specify a command to run");
 		})
 		.command("run", "Run controller", yargs => {
+			yargs.option("can-restart", {
+				type: "boolean", nargs: 0, default: false,
+				describe: "Indicate that a process monitor will restart the controller on failure",
+			});
 			yargs.option("dev", { hidden: true, type: "boolean", nargs: 0 });
 			yargs.option("dev-plugin", { hidden: true, type: "array" });
 		})
@@ -386,6 +390,7 @@ async function startup() {
 		pluginInfos,
 		controllerConfigPath,
 		controllerConfig,
+		Boolean(args.canRestart),
 		...await Controller.bootstrap(controllerConfig)
 	);
 

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -68,6 +68,8 @@ export default class ControlConnection extends BaseConnection {
 			});
 		}
 
+		this.handle(lib.ControllerStopRequest, this.handleControllerStopRequest.bind(this));
+		this.handle(lib.ControllerRestartRequest, this.handleControllerRestartRequest.bind(this));
 		this.handle(lib.ControllerConfigGetRequest, this.handleControllerConfigGetRequest.bind(this));
 		this.handle(lib.ControllerConfigSetFieldRequest, this.handleControllerConfigSetFieldRequest.bind(this));
 		this.handle(lib.ControllerConfigSetPropRequest, this.handleControllerConfigSetPropRequest.bind(this));
@@ -165,6 +167,18 @@ export default class ControlConnection extends BaseConnection {
 		}
 
 		throw new Error("Should be unreachable");
+	}
+
+	async handleControllerStopRequest() {
+		this._controller.stop();
+	}
+
+	async handleControllerRestartRequest() {
+		if (!this._controller.canRestart) {
+			throw new lib.RequestError("Cannot restart, controller does not have a process monitor to restart it.");
+		}
+		this._controller.shouldRestart = true;
+		this._controller.stop();
 	}
 
 	async handleControllerConfigGetRequest() {

--- a/packages/ctl/src/commands.ts
+++ b/packages/ctl/src/commands.ts
@@ -82,6 +82,20 @@ function serializedConfigToString(
 }
 
 const controllerCommands = new lib.CommandTree({ name: "controller", description: "Controller management" });
+controllerCommands.add(new lib.Command({
+	definition: ["stop", "Stop controller"],
+	handler: async function(_args: object, control: Control) {
+		await control.send(new lib.ControllerStopRequest());
+	},
+}));
+
+controllerCommands.add(new lib.Command({
+	definition: ["restart", "Restart controller"],
+	handler: async function(_args: object, control: Control) {
+		await control.send(new lib.ControllerRestartRequest());
+	},
+}));
+
 const controllerConfigCommands = new lib.CommandTree({
 	name: "config", alias: ["c"], description: "controller config management",
 });
@@ -224,6 +238,26 @@ controllerCommands.add(controllerPluginCommands);
 
 
 const hostCommands = new lib.CommandTree({ name: "host", description: "Host management" });
+hostCommands.add(new lib.Command({
+	definition: ["stop <host>", "Stop the given host", (yargs) => {
+		yargs.positional("host", { describe: "Host to stop", type: "string" });
+	}],
+	handler: async function(args: { host: string }, control: Control) {
+		let hostId = await lib.resolveHost(control, args.host);
+		await control.sendTo({ hostId }, new lib.HostStopRequest());
+	},
+}));
+
+hostCommands.add(new lib.Command({
+	definition: ["restart <host>", "Restart the given host", (yargs) => {
+		yargs.positional("host", { describe: "Host to restart", type: "string" });
+	}],
+	handler: async function(args: { host: string }, control: Control) {
+		let hostId = await lib.resolveHost(control, args.host);
+		await control.sendTo({ hostId }, new lib.HostRestartRequest());
+	},
+}));
+
 hostCommands.add(new lib.Command({
 	definition: [["list", "l"], "List hosts connected to the controller"],
 	handler: async function(args: object, control: Control) {

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -94,7 +94,12 @@ async function startHost() {
 		})
 		.command("plugin", "Manage available plugins", lib.pluginCommand)
 		.command("config", "Manage Host config", lib.configCommand)
-		.command("run", "Run host")
+		.command("run", "Run host", yargs => {
+			yargs.option("can-restart", {
+				type: "boolean", nargs: 0, default: false,
+				describe: "Indicate that a process monitor will restart this host on failure",
+			});
+		})
 		.demandCommand(1, "You need to specify a command to run")
 		.strict()
 		.parseSync()
@@ -206,6 +211,7 @@ async function startHost() {
 		hostConfig,
 		tlsCa,
 		pluginInfos,
+		Boolean(args.canRestart),
 		...await Host.bootstrap(hostConfig)
 	);
 
@@ -295,7 +301,11 @@ ${err.stack}`
 			);
 		}
 
-		process.exitCode = 1;
+		if (err instanceof lib.AuthenticationFailed) {
+			process.exitCode = 8;
+		} else {
+			process.exitCode = 1;
+		}
 	});
 }
 

--- a/packages/lib/src/data/messages_controller.ts
+++ b/packages/lib/src/data/messages_controller.ts
@@ -3,6 +3,22 @@ import { JsonString, StringEnum, plainJson } from "./composites";
 import { levels } from "../logging";
 import { ControllerConfig, HostConfig } from "../config";
 
+export class ControllerStopRequest {
+	declare ["constructor"]: typeof ControllerStopRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static permission = "core.controller.stop" as const;
+}
+
+export class ControllerRestartRequest {
+	declare ["constructor"]: typeof ControllerRestartRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static permission = "core.controller.restart" as const;
+}
+
 export class ControllerConfigGetRequest {
 	declare ["constructor"]: typeof ControllerConfigGetRequest;
 	static type = "request" as const;
@@ -221,6 +237,7 @@ export class SystemInfo {
 		public memoryAvailable: number,
 		public diskCapacity: number,
 		public diskAvailable: number,
+		public canRestart: boolean,
 		/** Millisecond Unix timestamp this entry was last updated at */
 		public updatedAt: number,
 		public isDeleted: boolean,
@@ -238,6 +255,7 @@ export class SystemInfo {
 		"memoryAvailable": Type.Number(),
 		"diskCapacity": Type.Number(),
 		"diskAvailable": Type.Number(),
+		"canRestart": Type.Boolean(),
 		"updatedAt": Type.Number(),
 		"isDeleted": Type.Boolean(),
 	});
@@ -255,6 +273,7 @@ export class SystemInfo {
 			json.memoryAvailable,
 			json.diskCapacity,
 			json.diskAvailable,
+			json.canRestart,
 			json.updatedAt,
 			json.isDeleted,
 		);

--- a/packages/lib/src/data/messages_host.ts
+++ b/packages/lib/src/data/messages_host.ts
@@ -3,6 +3,22 @@ import { jsonArray, plainJson, StringEnum } from "./composites";
 import { CollectorResultSerialized } from "../prometheus";
 import { HostConfig } from "../config/definitions";
 
+export class HostStopRequest {
+	declare ["constructor"]: typeof HostStopRequest;
+	static type = "request" as const;
+	static src = ["control", "controller"] as const;
+	static dst = "host" as const;
+	static permission = "core.host.stop" as const;
+}
+
+export class HostRestartRequest {
+	declare ["constructor"]: typeof HostRestartRequest;
+	static type = "request" as const;
+	static src = ["control", "controller"] as const;
+	static dst = "host" as const;
+	static permission = "core.host.restart" as const;
+}
+
 export class HostConfigGetRequest {
 	declare ["constructor"]: typeof HostConfigGetRequest;
 	static type = "request" as const;

--- a/packages/lib/src/link/messages.ts
+++ b/packages/lib/src/link/messages.ts
@@ -17,6 +17,8 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	core.PingRequest,
 	core.AccountUpdateEvent,
 
+	controller.ControllerStopRequest,
+	controller.ControllerRestartRequest,
 	controller.ControllerConfigGetRequest,
 	controller.ControllerConfigSetFieldRequest,
 	controller.ControllerConfigSetPropRequest,
@@ -32,6 +34,8 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 
 	subscriptions.SubscriptionRequest,
 
+	host.HostStopRequest,
+	host.HostRestartRequest,
 	host.HostConfigGetRequest,
 	host.HostConfigSetFieldRequest,
 	host.HostConfigSetPropRequest,

--- a/packages/lib/src/permissions.ts
+++ b/packages/lib/src/permissions.ts
@@ -120,6 +120,18 @@ definePermission({
 });
 
 definePermission({
+	name: "core.controller.stop",
+	title: "Stop controller",
+	description:
+		"Stop the Node.js controller process making the cluster inoperable until someone with access to the system " +
+		"it runs on manually starts it again.",
+});
+definePermission({
+	name: "core.controller.restart",
+	title: "Restart controller",
+	description: "Restart the Node.js controller process if the system is set up for restarting.",
+});
+definePermission({
 	name: "core.controller.get_config",
 	title: "Get controller config",
 	description: "Get the config of controller.",
@@ -135,6 +147,18 @@ definePermission({
 	description:
 		"Subscribe to be notified when the system info detailing system specific information along with metrics " +
 		"such as cpu, memory and disk usage for the controller and hosts are updated.",
+});
+definePermission({
+	name: "core.host.stop",
+	title: "Stop Hosts",
+	description:
+		"Stop Node.js host processes making the host inaccessible until someone with access to the system " +
+		"it runs on manually starts it again.",
+});
+definePermission({
+	name: "core.host.restart",
+	title: "Restart Hosts",
+	description: "Restart Node.js host processes if the system they run on are set up for restarting.",
 });
 definePermission({
 	name: "core.host.get_config",

--- a/packages/lib/src/system_collectors.ts
+++ b/packages/lib/src/system_collectors.ts
@@ -134,7 +134,7 @@ function minZip<T>(a: T[], b: T[]): [T, T][] {
 
 let previousTotalCpuMs: number[] = [];
 let previousIdleCpuMs: number[] = [];
-export async function gatherSystemInfo(id: SystemInfo["id"]) {
+export async function gatherSystemInfo(id: SystemInfo["id"], canRestart: boolean) {
 	const cpus = os.cpus();
 	const currentTotalCpuMs = cpus.map(({ times }) => times.user + times.idle + times.irq + times.nice + times.sys);
 	const currentIdleCpuMs = cpus.map(({ times }) => times.idle);
@@ -164,6 +164,7 @@ export async function gatherSystemInfo(id: SystemInfo["id"]) {
 		os.freemem(),
 		diskCapacity,
 		diskAvailable,
+		canRestart,
 		Date.now(),
 		false,
 	);

--- a/packages/web_ui/src/components/ControllerPage.tsx
+++ b/packages/web_ui/src/components/ControllerPage.tsx
@@ -1,5 +1,7 @@
-import React from "react";
-import { Descriptions, Typography } from "antd";
+import React, {useContext} from "react";
+import { Button, Descriptions, Popconfirm, Space, Typography } from "antd";
+
+import * as lib from "@clusterio/lib";
 
 import PluginExtra from "./PluginExtra";
 import LogConsole from "./LogConsole";
@@ -9,8 +11,11 @@ import {
 } from "./system_metrics";
 import { useAccount } from "../model/account";
 import { useSystems } from "../model/system";
+import ControlContext from "./ControlContext";
 import ControllerConfigTree from "./ControllerConfigTree";
+import PageHeader from "./PageHeader";
 import PageLayout from "./PageLayout";
+import { notifyErrorHandler } from "../util/notify";
 import webUiPackage from "../../package.json";
 
 const { Title } = Typography;
@@ -18,11 +23,50 @@ const { Title } = Typography;
 
 export default function ControllerPage() {
 	let account = useAccount();
+	const control = useContext(ControlContext);
 	const [systems] = useSystems();
 	const system = systems.get("controller");
 
 	return <PageLayout nav={[{ name: "Controller" }]}>
-		<h2>Controller</h2>
+		<PageHeader
+			title="Controller"
+			extra={<Space>
+				{
+					account.hasPermission("core.controller.stop")
+					&& <Popconfirm
+						title={<>
+							Stopping the controller will leave the cluster inoperable until someone with
+							access to the system it runs on manually starts it again.<br />
+							Are you sure you want to stop the controller?
+						</>}
+						placement="bottomRight"
+						okText="Stop"
+						okButtonProps={{ danger: true }}
+						onConfirm={() => {
+							control.send(
+								new lib.ControllerStopRequest()
+							).catch(notifyErrorHandler("Error stopping controller"));
+						}}
+					>
+						<Button danger>Stop</Button>
+					</Popconfirm>
+				}
+				{
+					account.hasPermission("core.controller.restart")
+					&& <Button
+						disabled={system?.canRestart === false}
+						onClick={() => {
+							control.send(
+								new lib.ControllerRestartRequest()
+							).catch(notifyErrorHandler("Error restarting controller"));
+						}}
+					>
+						Restart
+					</Button>
+				}
+			</Space>}
+		/>
+
 		<Descriptions bordered size="small" column={{ xs: 1, md: 2, lg: 2, xl: 2, xxl: 2 }}>
 			<Descriptions.Item label="Version">{webUiPackage.version}</Descriptions.Item>
 			<Descriptions.Item label="Node.js">{system?.node}</Descriptions.Item>

--- a/packages/web_ui/src/components/HostViewPage.tsx
+++ b/packages/web_ui/src/components/HostViewPage.tsx
@@ -46,8 +46,9 @@ export default function HostViewPage() {
 		</PageLayout>;
 	}
 
-	let hostButtons = <Space> {
-		account.hasPermission("core.host.revoke_access")
+	let hostButtons = <Space>
+		{
+			account.hasPermission("core.host.revoke_access")
 			&& <Popconfirm
 				title={`Revoke tokens of ${host.name}?`}
 				placement="bottomRight"
@@ -63,7 +64,42 @@ export default function HostViewPage() {
 					Revoke tokens
 				</Button>
 			</Popconfirm>
-	}
+		}
+		{
+			account.hasPermission("core.host.stop")
+			&& <Popconfirm
+				title={<>
+					Stopping this host will leave it inaccessible until someone with
+					access to the system it runs on manually starts it again.<br />
+					Are you sure you want to stop the host?
+				</>}
+				placement="bottomRight"
+				okText="Stop"
+				okButtonProps={{ danger: true }}
+				onConfirm={() => {
+					control.sendTo(
+						{ hostId },
+						new lib.HostStopRequest()
+					).catch(notifyErrorHandler("Error stopping host"));
+				}}
+			>
+				<Button danger>Stop</Button>
+			</Popconfirm>
+		}
+		{
+			account.hasPermission("core.host.restart")
+			&& <Button
+				disabled={system?.canRestart === false}
+				onClick={() => {
+					control.sendTo(
+						{ hostId },
+						new lib.HostRestartRequest()
+					).catch(notifyErrorHandler("Error restarting host"));
+				}}
+			>
+				Restart
+			</Button>
+		}
 	</Space>;
 
 	return <PageLayout nav={nav}>

--- a/test/lib/data/SystemInfo.js
+++ b/test/lib/data/SystemInfo.js
@@ -20,6 +20,7 @@ describe("lib/data/SystemInfo", function() {
 				768,
 				2048,
 				512,
+				false,
 				0,
 				false
 			);


### PR DESCRIPTION
Implement remotely initiated stopping and restarting of the controller and hosts.  Restarting is implemented by exiting with a non-zero exit code and relying on a process manager to start the procress again.  To prevent accidentally trying to restart on a system that doesn't have a process manager present the `--can-restart` command line option needs to be passed to enable the restart operation.

Resolves #549 