### PR TITLE
Fix instance auto start

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
 			"rules": {
 				"prefer-arrow-callback": "off",
 				"no-invalid-this": "off",
+				"valid-jsdoc": "off",
 				"node/no-unpublished-import": "off",
 				"node/no-unpublished-require": "off",
 			},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed a memory leak on every request sent over the WebSocket.
 - Fixed assertion error on closing or invalidating a link with messages forwarded from a virtual link.
 - Fixed host hanging if stopped while an instance is in the process of creating a save during startup.
+- Fixed `instance.auto_start` option.
 
 
 ## Version 2.0.0-alpha.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed installer incorrectly claiming the options --factorio-dir and --no-download-headless conflicts with each other.
 - Fixed a memory leak on every request sent over the WebSocket.
 - Fixed assertion error on closing or invalidating a link with messages forwarded from a virtual link.
+- Fixed host hanging if stopped while an instance is in the process of creating a save during startup.
 
 
 ## Version 2.0.0-alpha.14

--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ If you want to use a different user for the command line interface, you can gene
 
 ## Known Issues
 
-- The `instance.auto_start` option is currently is broken and will not work, turn it off and do not use it for now.
 - When the `server_select` plugin is installed you may see `[error] Unhandled event server_select:UpdateInstancesEvent` logged when starting an instance.
   This should be ignored as it does not indicate an error occured.
 - After migrating from Alpha 13 to Alpha 14 running an instance data export fails with the error `Upload failed: 401 Unauthorized` due to the host token being issued to a slave.

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -1056,7 +1056,7 @@ export default class Host extends lib.Link {
 				if (instanceInfo.config.get("instance.auto_start")) {
 					try {
 						let instanceConnection = await this._connectInstance(instanceId);
-						await instanceConnection.send(new lib.InstanceStartRequest());
+						await instanceConnection.instance.handleInstanceStartRequest(new lib.InstanceStartRequest());
 					} catch (err: any) {
 						logger.error(
 							`Error during auto startup for ${instanceInfo.config.get("instance.name")}:\n${err.stack}`,

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -955,6 +955,11 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 			await lib.invokeHook(this.plugins, "onStop");
 			await this.server.stop();
 			await this.sendSaveListUpdate();
+		} else if (
+			this.server._state === "stopping"
+			|| this.server._state === "create"
+		) {
+			await this.server.kill();
 		}
 	}
 

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -865,7 +865,9 @@ export class FactorioServer extends events.EventEmitter {
 
 		try {
 			let [code, signal] = await events.once(this._server, "exit");
-			void signal;
+			if (signal) {
+				throw new Error(`Factorio exited with signal ${signal}`);
+			}
 			if (code !== 0) {
 				throw new Error(`Factorio exited with status ${code}`);
 			}
@@ -1092,7 +1094,7 @@ export class FactorioServer extends events.EventEmitter {
 	 *     process.
 	 */
 	async kill(unexpected = false) {
-		this._check(["running", "stopping"]);
+		this._check(["running", "stopping", "create"]);
 		this._killed = true;
 		if (!unexpected) {
 			this._state = "stopping";

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -17,6 +17,7 @@ const {
 } = require("./index");
 
 
+/** @returns {Promise<Map<number, lib.InstanceDetails>>} */
 async function getInstances() {
 	let instances = await getControl().send(new lib.InstanceDetailsListRequest());
 	return new Map(instances.map(instance => [instance.id, instance]));
@@ -25,6 +26,10 @@ async function getInstances() {
 async function checkInstanceStatus(id, status) {
 	let instances = await getInstances();
 	assert.equal(instances.get(44).status, status, "incorrect instance status");
+}
+
+async function spawnAltHost(config = "alt-host-config.json") {
+	return await spawn("alt-host:", `node ../../packages/host run --config ${config}`, /Started host/);
 }
 
 async function startAltHost() {
@@ -38,7 +43,7 @@ async function startAltHost() {
 	await exec(`node ../../packages/host --config ${config} config set host.instances_directory alt-instances`);
 	await exec(`node ../../packages/host --config ${config} config set host.factorio_directory ../../factorio`);
 	await exec(`node ../../packages/host --config ${config} config set host.mods_directory alt-mods`);
-	return await spawn("alt-host:", `node ../../packages/host run --config ${config}`, /Started host/);
+	return await spawnAltHost(config);
 }
 
 async function stopAltHost(hostProcess) {
@@ -199,6 +204,38 @@ describe("Integration of Clusterio", function() {
 				await execCtl("instance save create alt-mod");
 				assert(await fs.pathExists(clusterioLib), "mod was not downloaded by the test");
 			});
+		});
+		it("should auto start instances with auto_start enabled", async function() {
+			slowTest(this);
+
+			let hostProcess;
+			try {
+				hostProcess = await startAltHost();
+				await execCtl("instance create alt-start --id 97");
+				await execCtl("instance assign alt-start 5");
+				await execCtl("instance config set alt-start instance.auto_start true");
+				await stopAltHost(hostProcess);
+				hostProcess = await spawnAltHost();
+				// Stop the host immediatly to test the handling of stopping
+				// instances while automatically started and a save is being created
+				await stopAltHost(hostProcess);
+				hostProcess = await spawnAltHost();
+				let status;
+				// Wait for instance status to become running.
+				for (let i = 0; i < 100; i++) {
+					const instances = await getInstances();
+					status = instances.get(97)?.status ?? "not_present";
+					if (status === "running") {
+						break;
+					}
+					await wait(100); // Try again 10 times per second.
+				}
+				assert.equal(status, "running");
+				await execCtl("instance stop alt-start");
+				await execCtl("instance delete alt-start");
+			} finally {
+				await stopAltHost(hostProcess);
+			}
 		});
 	});
 


### PR DESCRIPTION
Fix and add test for the `instance.auto_start` option working as intended. During the development of this fix I found another issue with the host hanging when stopped while an instance is creating a save as part of the startup sequence.

Fixes #563 