### PR TITLE
Fix Web UI not clearing config props

### DIFF
--- a/packages/web_ui/src/components/ControllerConfigTree.tsx
+++ b/packages/web_ui/src/components/ControllerConfigTree.tsx
@@ -27,6 +27,8 @@ export default function ControllerConfigTree() {
 			} catch (err) {
 				return;
 			}
+		} else {
+			value = undefined;
 		}
 		await control.send(new lib.ControllerConfigSetPropRequest(field, prop, value));
 	}

--- a/packages/web_ui/src/components/HostConfigTree.tsx
+++ b/packages/web_ui/src/components/HostConfigTree.tsx
@@ -24,6 +24,8 @@ export default function HostConfigTree(props: { id: number, available: boolean }
 			} catch (err) {
 				return;
 			}
+		} else {
+			value = undefined;
 		}
 		await control.sendTo({ hostId: props.id }, new lib.HostConfigSetPropRequest(field, prop, value));
 	}

--- a/packages/web_ui/src/components/InstanceConfigTree.tsx
+++ b/packages/web_ui/src/components/InstanceConfigTree.tsx
@@ -28,6 +28,8 @@ export default function InstanceConfigTree(props: InstanceConfigTreeProps) {
 			} catch (err) {
 				return;
 			}
+		} else {
+			value = undefined;
 		}
 		await control.send(new lib.InstanceConfigSetPropRequest(props.id, field, prop, value));
 	}


### PR DESCRIPTION
Turns out there was an additional problem with clearing properties in the Web UI.