### PR TITLE
Fix message seq reuse on forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 2.0.0-alpha.16
+
+## Changes
+
+- Fixed message sequences not being renumbered when forwarded between links causing reconnects to send duplicated messages.
+
+
 ## Version 2.0.0-alpha.15
 
 ### Features

--- a/packages/controller/src/ControllerRouter.ts
+++ b/packages/controller/src/ControllerRouter.ts
@@ -84,7 +84,7 @@ export default class ControllerRouter {
 			if (message.type === "request") {
 				nextHop.forwardRequest(message as lib.MessageRequest, origin);
 			} else {
-				nextHop.connector.send(message);
+				nextHop.connector.forward(message);
 			}
 		} else {
 			this.warnUnrouted(message, msg);
@@ -107,13 +107,13 @@ export default class ControllerRouter {
 		if (dst.id === lib.Address.host || dst.id === lib.Address.instance) {
 			for (let hostConnection of this.controller.wsServer.hostConnections.values()) {
 				if (hostConnection !== origin && (!plugin || hostConnection.plugins.has(plugin))) {
-					hostConnection.connector.send(message);
+					hostConnection.connector.forward(message);
 				}
 			}
 		} else if (dst.id === lib.Address.control) {
 			for (let controlConnection of this.controller.wsServer.controlConnections.values()) {
 				if (controlConnection !== origin) {
-					controlConnection.connector.send(message);
+					controlConnection.connector.forward(message);
 				}
 			}
 		} else {

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -173,16 +173,16 @@ export class HostRouter {
 		if (dst.id === lib.Address.instance) {
 			for (let instanceConnection of this.host.instanceConnections.values()) {
 				if (instanceConnection !== origin && (!plugin || instanceConnection.plugins.has(plugin))) {
-					instanceConnection.connector.send(message);
+					instanceConnection.connector.forward(message);
 				}
 			}
 			if (this.host !== origin && (!plugin || this.host.serverPlugins.has(plugin))) {
-				this.host.connector.send(message);
+				this.host.connector.forward(message);
 			}
 		} else if (dst.id === lib.Address.control) {
 			if (this.host !== origin) {
 				if (!plugin || this.host.serverPlugins.has(plugin)) {
-					this.host.connector.send(message);
+					this.host.connector.forward(message);
 				}
 			} else {
 				logger.warn(`Received control broadcast of ${(message as lib.MessageEvent).name} from controller.`);
@@ -208,7 +208,7 @@ export class HostRouter {
 		}
 
 		this.host._connectInstance(dst.id).then(instanceConnection => {
-			instanceConnection.connector.send(message);
+			instanceConnection.connector.forward(message);
 		}).catch(err => {
 			logger.error(`Error starting instance:\n${err.stack}`, this.host.instanceLogMeta(dst.id));
 			origin.connector.sendResponseError(
@@ -222,7 +222,7 @@ export class HostRouter {
 			if (message.type === "request") {
 				nextHop.forwardRequest(message as lib.MessageRequest, origin);
 			} else {
-				nextHop.connector.send(message);
+				nextHop.connector.forward(message);
 			}
 		} catch (err: any) {
 			if (message.type === "request") {

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -132,7 +132,8 @@ export class Link {
 				}
 			).finally(
 				() => {
-					this.connector.send(new libData.MessageDisconnect("ready"));
+					// Only WebSocket connectors issue disconnection events.
+					(this.connector as WebSocketBaseConnector).sendDisconnectReady();
 				},
 			);
 		});
@@ -561,7 +562,7 @@ export class Link {
 			dst: message.dst,
 		};
 		this._forwardedRequests.set(message.src.index(), pending);
-		this.connector.send(message);
+		this.connector.forward(message);
 	}
 
 	sendEvent<T>(event: Event<T>, dst: libData.Address) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -80,6 +80,10 @@ class MockConnector extends lib.BaseConnector {
 		this.sentMessages.push(message);
 		setImmediate(() => this.emit("send", message));
 	}
+
+	sendDisconnectReady() {
+		this.send(new lib.MessageDisconnect("ready"));
+	}
 }
 
 class MockServer extends events.EventEmitter {


### PR DESCRIPTION
When messages were forwarded they were sent using the low level connector .send method which accepts a message and sends it over the link.  This method sends the message as is with no modification which means that at no point during the forwarding logic was the message sequence number that originated from Link A renumbered to the correct sequence number to send out on Link B which it was forwarded on.

This in turn caused the logic which drops acked messages from the send buffer to break which in turn meant the resume could cause duplication of message and/or messages to be lost.  With enough duplicated messages the resume of one connection could cause other connections to drop and also initiate resume.

Fix by renumbering the sequence on forwarded messages.  In the future the sequences sent and received should also be checked to make sure this kind of problem does not happen again, this is not done here because partially updating a running cluster with sequence problems to one that checks and enforces sequences numbers will be problematic.