### PR TITLE
Fix unhandled rejection on RCON lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 2.0.0-alpha.17
+
+## Changes
+
+- Fixed an unhandled error in Subspace Storage crashing the host.
+
+
 ## Version 2.0.0-alpha.16
 
 ## Changes

--- a/plugins/subspace_storage/instance.ts
+++ b/plugins/subspace_storage/instance.ts
@@ -116,7 +116,6 @@ export class InstancePlugin extends BaseInstancePlugin {
 		let itemsJson = lib.escapeString(JSON.stringify(items));
 		let task = this.sendRcon(`/sc __subspace_storage__ UpdateInvData("${itemsJson}")`, true);
 		this.pendingTasks.add(task);
-		task.finally(() => { this.pendingTasks.delete(task); });
-		await task;
+		await task.finally(() => { this.pendingTasks.delete(task); });
 	}
 }


### PR DESCRIPTION
When using .finally on a promise a new promise is created which calls the handler passed to it when the the original promise is resolved or rejected, and resolves or rejects with same value as the original promise.  This means if the rejection of the new promise that was created by finally is not handled then an unhandled promise rejection will be raised.

Fix by making sure the promise rejection from the finally promise created in subspace_storage's handleUpdateStorageEvent is properly handled.