### PR TITLE
Fix unhandled rejection on disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Changes
 
 - Fixed an unhandled error in Subspace Storage crashing the host.
+- Fixed an unhandled rejection in disconnect logic crashing the host.
 
 
 ## Version 2.0.0-alpha.16

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -126,16 +126,15 @@ export class Link {
 		});
 
 		connector.on("disconnectPrepare", () => {
-			this.prepareDisconnect().catch(
-				err => {
-					logger.error(`Unexpected error preparing disconnect:\n${err.stack}`);
+			this.prepareDisconnect().finally(() => {
+				// Only WebSocket connectors issue disconnection events.
+				const webSocketConnector = this.connector as WebSocketBaseConnector;
+				if (webSocketConnector.hasSession) {
+					webSocketConnector.sendDisconnectReady();
 				}
-			).finally(
-				() => {
-					// Only WebSocket connectors issue disconnection events.
-					(this.connector as WebSocketBaseConnector).sendDisconnectReady();
-				},
-			);
+			}).catch(err => {
+				logger.error(`Unexpected error preparing disconnect:\n${err.stack}`);
+			});
 		});
 
 		connector.on("invalidate", () => {

--- a/test/mock.js
+++ b/test/mock.js
@@ -73,6 +73,7 @@ class MockConnector extends lib.BaseConnector {
 		super(src, dst);
 
 		this.connected = true;
+		this.hasSession = true;
 		this.sentMessages = [];
 	}
 


### PR DESCRIPTION
If a link is closed while the prepareDisconnect action is in progress the link will still try to signal the disconnect ready over the socket when the prepareDisconnect action completes, which throws due to the socket no longer being present.  This error is not caught due to the catch happening before the finally on the promise and triggers an unhandled rejection.

Fix by rearranging the finally to come before the catch on the promise so that errors are always handled, and checking that the link still has a session before attempting to send the disconnct ready signal.