### PR TITLE
Add pagination to saves list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.0.0-alpha.17
 
+### Features
+
+- Added pagination to the saves list.
+
 ### Changes
 
 - Fixed an unhandled error in Subspace Storage crashing the host.

--- a/packages/web_ui/src/components/SavesList.tsx
+++ b/packages/web_ui/src/components/SavesList.tsx
@@ -207,6 +207,7 @@ export default function SavesList(props: { instance: lib.InstanceDetails }) {
 
 	let hostOffline = ["unassigned", "unknown"].includes(props.instance.status!);
 	const saveTable = <Table
+		className="save-list-table"
 		size="small"
 		columns={[
 			{
@@ -236,7 +237,6 @@ export default function SavesList(props: { instance: lib.InstanceDetails }) {
 		]}
 		dataSource={[...saves.values()]}
 		rowKey={save => save.name}
-		pagination={false}
 		expandable={{
 			columnWidth: 33,
 			expandRowByClick: true,

--- a/packages/web_ui/src/style.css
+++ b/packages/web_ui/src/style.css
@@ -182,8 +182,17 @@ body {
 	white-space: pre-wrap;
 }
 
+.save-list-dragger .ant-upload.ant-upload-drag {
+	border: none;
+	background: none;
+}
+
 .save-list-dragger .ant-upload.ant-upload-btn {
 	padding: 0;
+}
+
+.save-list-table .ant-table-pagination.ant-pagination {
+	margin-bottom: 0;
 }
 
 .rcon-result code {


### PR DESCRIPTION
Prevent the saves list from pushing the console and config off the screen by turning on the pagination for it.