### PR TITLE
Increase libLink event emitter leak warning limit

### DIFF
--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -107,6 +107,9 @@ export class Link {
 	) {
 		this.handle(libData.PingRequest, async () => {});
 
+		// Prevent warnings about possible memory leak due to large number of event listeners
+		connector.setMaxListeners(20);
+
 		// Process messages received by the connector
 		connector.on("message", payload => {
 			try {


### PR DESCRIPTION
The browser console has a warning about 11 event emitters possibly being an event listener leak. It is not.

I suggest increasing the limit to 20. We could also set it to 0 to disable the warning entirely, but I suppose it could be nice to be warned if we actually have a leak.