### PR TITLE
Fix possible undefined title error

### DIFF
--- a/packages/web_ui/src/components/SavesList.tsx
+++ b/packages/web_ui/src/components/SavesList.tsx
@@ -150,7 +150,7 @@ function TransferModal(props: ModalProps) {
 						autoFocus
 						showSearch
 						filterOption={(input, option) => (
-							(option?.title.toLowerCase().indexOf(input.toLowerCase())??-1) >= 0
+							(option?.title!.toLowerCase().indexOf(input.toLowerCase())??-1) >= 0
 						)}
 					>
 						{[...instances.values()].filter(


### PR DESCRIPTION
When building a clean dev install, including during CI, there is the following error:

`plugins/global_chat prepare: ../../packages/web_ui/src/components/SavesList.tsx(153,9): error TS18048: 'option.title' is possibly 'undefined'.`

There is a race condition for which plugin will error first but all of them can throw this error.
I do not know what has changed in the last week to cause this error to appear but it is preventing all CI pipelines.

The fix is an assertion that the value is defined, it is not clear why an `any` type requires this assertion but it works.