### PR TITLE
Cache ModInfo to reduce startup time

### DIFF
--- a/packages/lib/src/data/ModInfo.ts
+++ b/packages/lib/src/data/ModInfo.ts
@@ -117,6 +117,11 @@ export default class ModInfo {
 	size = 0;
 
 	/**
+	 * Last modification time of the file.
+	 */
+	mtimeMs = 0;
+
+	/**
 	 * SHA1 hash of this mod
 	 */
 	sha1?: string;
@@ -147,6 +152,7 @@ export default class ModInfo {
 	static jsonSchema = Type.Object({
 		...this.infoJsonSchema.properties,
 		"size": Type.Optional(Type.Integer()),
+		"mtime_ms": Type.Optional(Type.Number()),
 		"sha1": Type.Optional(Type.String()),
 		"updated_at_ms": Type.Optional(Type.Number()),
 		"is_deleted": Type.Optional(Type.Boolean()),
@@ -170,6 +176,7 @@ export default class ModInfo {
 
 		// Additional data
 		if (json.size) { modInfo.size = json.size; }
+		if (json.mtime_ms) { modInfo.mtimeMs = json.mtime_ms; }
 		if (json.sha1) { modInfo.sha1 = json.sha1; }
 		if (json.updated_at_ms) { modInfo.updatedAtMs = json.updated_at_ms; }
 		if (json.is_deleted) { modInfo.isDeleted = json.is_deleted; }
@@ -192,6 +199,7 @@ export default class ModInfo {
 			json.dependencies = this.dependencies;
 		}
 		if (this.size) { json.size = this.size; }
+		if (this.mtimeMs) { json.mtime_ms = this.mtimeMs; }
 		if (this.sha1) { json.sha1 = this.sha1; }
 		if (this.updatedAtMs) { json.updated_at_ms = this.updatedAtMs; }
 		if (this.isDeleted) { json.is_deleted = this.isDeleted; }
@@ -229,6 +237,7 @@ export default class ModInfo {
 
 			size: stat.size,
 			sha1: await libHash.hashFile(modPath),
+			mtime_ms: stat.mtimeMs,
 			updated_at_ms: stat.mtimeMs,
 			is_deleted: false,
 		});

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -1054,6 +1054,7 @@ describe("Integration of Clusterio", function() {
 					"factorioVersion: 1.1\n" +
 					"dependencies:\n" +
 					`size: ${stat.size}\n` +
+					`mtimeMs: ${stat.mtimeMs}\n` +
 					`sha1: ${hash}\n` +
 					`updatedAtMs: ${stat.mtimeMs}\n` +
 					"isDeleted: false\n",

--- a/test/lib/data/ModInfo.js
+++ b/test/lib/data/ModInfo.js
@@ -33,6 +33,7 @@ describe("lib/data/ModInfo", function() {
 			check(ModInfo.fromJSON({ dependencies: ["UltraMod", "SuperLib >= 1.00", "! bad-mod"] }));
 			check(ModInfo.fromJSON({ filename: "MyMod_1.0.0.zip" }));
 			check(ModInfo.fromJSON({ size: 1024 }));
+			check(ModInfo.fromJSON({ mtime_ms: new Date(2024, 0, 1).getTime() }));
 			check(ModInfo.fromJSON({ sha1: "verified-as-MyMod" }));
 			check(ModInfo.fromJSON({ is_deleted: true }));
 
@@ -49,6 +50,7 @@ describe("lib/data/ModInfo", function() {
 				dependencies: ["UltraMod", "SuperLib >= 1.00", "! bad-mod"],
 				filename: "MyMod_1.0.0.zip",
 				size: 1024,
+				mtime_ms: new Date(2024, 0, 1).getTime(),
 				sha1: "verified-as-MyMod",
 				is_deleted: true,
 			}));
@@ -92,6 +94,7 @@ describe("lib/data/ModInfo", function() {
 					dependencies: [],
 					filename: "empty_mod_1.0.0.zip",
 					size: stat.size,
+					mtime_ms: stat.mtimeMs,
 					updated_at_ms: stat.mtimeMs,
 					sha1: hash,
 				})


### PR DESCRIPTION
Store and use a cache of the loaded ModInfo data to mod-info-cache.json in the mods directory during startup.  For simplicity this does not cache mods added to the controller or host after startup, these get added to the cache on the next startup.

_I've been trying to do reviews, but my local dev environment has become really slow to start up due to all the mods I have._