### PR TITLE
Fix plugin hooks called before host removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Many thanks to the following for contributing to this release:
 ### Changes
 
 - Fixed Inventory Sync reporting a negative database size [¤598](https://github.com/clusterio/clusterio/pull/598).
+- Fixed plugin events being invoked while a host connection was in an invalid state.
 
 Many thanks to the following for contributing to this release:  
 [@Cooldude2606](https://github.com/Cooldude2606)


### PR DESCRIPTION
Due a bad order of operations when a host connection was closed the event handler listening on "close" to remove the host from the hostConnections mapping was added after the HostConnection's event handler listening on "close" and invoking plugin hooks in response to the host going offline.  This in turn causes plugins that send broadcasts in repsonse to thos hooks to throw an error due to the broadcast sending code assuming connections that exist are valid target to send messages to.

Fix by ordering the listener for the removal of the host connection before the listener invoking plugin events.