### PR TITLE
Fix breaking change in pnpn v9 with workspace package linking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@clusterio/controller": "workspace:*",
 		"@clusterio/ctl": "workspace:*",
 		"@clusterio/host": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@clusterio/lib": "workspace:*",
 		"@swc/core": "^1.4.0",
 		"@typescript-eslint/eslint-plugin": "^6.4.1",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -19,7 +19,7 @@
 		"node": ">=18"
 	},
 	"dependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
 		"@sinclair/typebox": "^0.30.4",
 		"busboy": "^1.6.0",
 		"compression": "^1.7.4",
@@ -36,7 +36,7 @@
 		"yargs": "^17.7.2"
 	},
 	"devDependencies": {
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/web_ui": "workspace:*",
 		"@swc/core": "^1.4.0",
 		"@types/busboy": "^1.5.0",
 		"@types/compression": "^1.7.2",

--- a/packages/create/templates/common/package.json
+++ b/packages/create/templates/common/package.json
@@ -15,7 +15,7 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.17"
+		"@clusterio/lib": "workspace:*"
 	},
 	"devDependencies": {
 //%// Typescript and type declarations
@@ -36,9 +36,9 @@
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0",
-		"@clusterio/web_ui": "^2.0.0-alpha.17",
+		"@clusterio/web_ui": "workspace:*",
 //%endif
-		"@clusterio/lib": "^2.0.0-alpha.17"
+		"@clusterio/lib": "workspace:*"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "^0.30.4"

--- a/packages/ctl/package.json
+++ b/packages/ctl/package.json
@@ -19,7 +19,7 @@
 		"node": ">=18"
 	},
 	"dependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
 		"as-table": "^1.0.55",
 		"fs-extra": "^11.1.1",
 		"phin": "^3.7.0",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -19,7 +19,7 @@
 		"node": ">=18"
 	},
 	"dependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
 		"@sinclair/typebox": "^0.30.4",
 		"fs-extra": "^11.1.1",
 		"jimp": "^0.22.8",

--- a/packages/web_ui/package.json
+++ b/packages/web_ui/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"@ant-design/icons": "^5.1.4",
-		"@clusterio/lib": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
 		"@swc/core": "^1.4.0",
 		"antd": "^5.13.0",
 		"assert": "^2.0.0",

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -18,11 +18,11 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.0"
+		"@clusterio/lib": "workspace:*"
 	},
 	"devDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",
 		"typescript": "^5.1.6",

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -18,15 +18,15 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.0"
+		"@clusterio/lib": "workspace:*"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "^0.30.4",
 		"fs-extra": "^8.1.0"
 	},
 	"devDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -18,7 +18,7 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.0"
+		"@clusterio/lib": "workspace:*"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "^0.30.4",
@@ -26,8 +26,8 @@
 		"jsonwebtoken": "^9.0.1"
 	},
 	"devDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@types/express": "^4.17.17",
 		"@types/jsonwebtoken": "^9.0.2",
 		"@types/node": "^20.4.5",

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -18,15 +18,15 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.0"
+		"@clusterio/lib": "workspace:*"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "^0.30.4",
 		"fs-extra": "^8.1.0"
 	},
 	"devDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -18,11 +18,11 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.0"
+		"@clusterio/lib": "workspace:*"
 	},
 	"devDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",
 		"typescript": "^5.1.6",

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -18,15 +18,15 @@
 		"node": ">=18"
 	},
 	"peerDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.0"
+		"@clusterio/lib": "workspace:*"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "^0.30.4",
 		"fs-extra": "^8.1.0"
 	},
 	"devDependencies": {
-		"@clusterio/lib": "^2.0.0-alpha.18",
-		"@clusterio/web_ui": "^2.0.0-alpha.18",
+		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@types/express": "^4.17.17",
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.4.5",


### PR DESCRIPTION
As per the [pnpn v9 change log](https://github.com/pnpm/pnpm/releases/tag/v9.0.0):

> [link-workspace-packages](https://pnpm.io/npmrc#link-workspace-packages): disabled by default. This means that by default, dependencies will be linked from workspace packages only when they are specified using the [workspace protocol](https://pnpm.io/workspaces#workspace-protocol-workspace).

Previously the default was `true` which allowed packages to be linked within the workspace as long as the version was compatible. With the new value of `false` this no longer happens and you must be explicit in the package linking. This resulted in fresh dev installs failling at build and prepare stages. Thankfully, this is an easy change to make and pnpn will [update the version on publish](https://pnpm.io/workspaces#publishing-workspace-packages) to match the workspace versions.

The changes made:
- Add web ui as a dev dep at the root of the project.
- Change all workspace versions to `workspace:*` to allow linking.

Possible change:
- We could update the CI to use pnpn v9 in / after this PR.