### PR TITLE
Fix hard to reproduce crash on join

### DIFF
--- a/plugins/inventory_sync/module/inventory_sync.lua
+++ b/plugins/inventory_sync/module/inventory_sync.lua
@@ -357,8 +357,14 @@ end
 
 -- Download inventory from controller
 inventory_sync.events[defines.events.on_player_joined_game] = function(event)
-	-- Send acquire request even if an active download is currently in plogress
 	local player = game.get_player(event.player_index)
+
+	-- It's possible Factorio doesn't invoke the on_player_created event when loading a save in single player
+	if not global.inventory_sync.players[player.name] then
+		create_player(player, false)
+	end
+
+	-- Send acquire request even if an active download is currently in plogress
 	inventory_sync.acquire(player, false)
 
 	-- Clear active upload if it existsi


### PR DESCRIPTION
Apparently it is possible to run into a crash on join here

![image](https://github.com/clusterio/clusterio/assets/6792749/96e51cc5-086c-46e7-bf75-ee14779515a8)

Apparently its fixable through deleting this from the save:

![image](https://github.com/clusterio/clusterio/assets/6792749/56eb9230-5b19-44e3-baad-c7927088d7c6)

I assume the reason this works is because on being repatched it also reruns the code to update the globals with all players in the save.

Eternity cluster discord link: https://discord.com/channels/1193199619740540978/1193199620336144476/1239838359564582973

I don't have any way to reproduce, but I think this should fix it in the future - at the very least a nil check shouldn't do any harm.