### PR TITLE
Fix loopback routing message and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ Many thanks to the following for contributing to this release:
 [@username](https://github.com/username)
 -->
 
+## Version 2.0.0-alpha.19
+
+### Changes
+
+- Fixed IPC errors reporting undefined when no stack trace was present [#624](https://github.com/clusterio/clusterio/pull/624).
+- Fixed loopback routing for instances reporting the wrong error message [#625](https://github.com/clusterio/clusterio/pull/625).
+
+### Breaking Changes
+
+- Previously silent errors for controller.sendEvent now throw exceptions [#625](https://github.com/clusterio/clusterio/pull/625).
+
+Many thanks to the following for contributing to this release:  
+[@Cooldude2606](https://github.com/Cooldude2606)
+
 ## Version 2.0.0-alpha.18
 
 ### Features

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -140,7 +140,7 @@ export class HostRouter {
 						return false;
 					}
 					origin.connector.sendResponseError(
-						new lib.ResponseError("Instance is not running."), message.src
+						new lib.ResponseError(msg || "Instance is not running."), message.src
 					);
 				}
 				return true;

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -538,6 +538,9 @@ export class Link {
 		if (!entry) {
 			throw new Error(`Attempt to send unregistered Request ${request.constructor.name}`);
 		}
+		if (this.connector.src.equals(dst)) {
+			throw new Error(`Message would return back to sender ${dst}.`);
+		}
 		if (this.validateSent) {
 			entry.requestFromJSON(JSON.parse(JSON.stringify(request)));
 		}
@@ -571,6 +574,9 @@ export class Link {
 		let entry = Link._eventsByClass.get(event.constructor as EventClass<unknown>);
 		if (!entry) {
 			throw new Error(`Attempt to send unregistered Event ${event.constructor.name}`);
+		}
+		if (this.connector.src.equals(dst)) {
+			throw new Error(`Message would return back to sender ${dst}.`);
 		}
 		if (this.validateSent) {
 			entry.eventFromJSON(JSON.parse(JSON.stringify(event)));

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -189,6 +189,12 @@ before(async function() {
 		format: new lib.TerminalFormat(),
 	}));
 
+	// If fast test is enabled then output that it is
+	// eslint-disable-next-line node/no-process-env
+	if (process.env.FAST_TEST) {
+		console.log("FAST_TEST is present in env, slow tests will be skipped.");
+	}
+
 	await fs.remove(instancesDir);
 	await fs.remove(modsDir);
 	await fs.remove(databaseDir);

--- a/test/integration/routing.js
+++ b/test/integration/routing.js
@@ -424,18 +424,10 @@ describe("Integration of link routing", function() {
 	});
 
 	describe("event should not be routable on loopback", function() {
-		it("should not loopback on controller", async function() {
-			// Sending an event never returns a promise, so it throws rather than rejects like a request
-			assert.throws(
-				() => send(get("controller"), addr("controller"), new TestEvent()),
-				new Error("controller as dst is not supported.")
-			);
-		});
-
-		for (const srcName of ["hostA", "instanceA1", "controlA"]) {
+		for (const srcName of ["controller", "hostA", "instanceA1", "controlA"]) {
 			it(`should not loopback on ${srcName}`, async function() {
 				const src = get(srcName);
-				const dstAddr = src.connector.src;
+				const dstAddr = src instanceof Controller ? addr("controller") : src.connector.src;
 				assert.throws(
 					() => send(src, dstAddr, new TestEvent()),
 					new Error(`Message would return back to sender ${dstAddr}.`)
@@ -445,18 +437,11 @@ describe("Integration of link routing", function() {
 	});
 
 	describe("request should not be routable on loopback", function() {
-		it("should not loopback on controller", async function() {
-			await assert.rejects(
-				() => send(get("controller"), addr("controller"), new TestRequest()),
-				new Error("controller as dst is not supported.")
-			);
-		});
-
-		for (const srcName of ["hostA", "instanceA1", "controlA"]) {
+		for (const srcName of ["controller", "hostA", "instanceA1", "controlA"]) {
 			it(`should not loopback on ${srcName}`, async function() {
 				const src = get(srcName);
-				const dstAddr = src.connector.src;
-				await assert.rejects(
+				const dstAddr = src instanceof Controller ? addr("controller") : src.connector.src;
+				assert.throws(
 					() => send(src, dstAddr, new TestRequest()),
 					new Error(`Message would return back to sender ${dstAddr}.`)
 				);


### PR DESCRIPTION
Fixes the incorrect error message when an instance attempts to make a request to itself.
Also adds test cases to prevent regression in this area.

~~Draft: It is noted that events log a warning rather than error, intended behaviour needs to be discussed.~~
Events have been changed to throw an error before being sent over a connector if it would loopback. If the event has already been sent and a loopback is discovered then it will be dropped and a warning emited.

Sending events on the controller to invalid addresses now throws an error rather than silently returning. This is to match the new behaviour of events throwing an error before being sent and the existing behaviour of requests.
