### PR TITLE
Allow declaring custom config input components for objects

### DIFF
--- a/packages/web_ui/src/components/BaseConfigTree.tsx
+++ b/packages/web_ui/src/components/BaseConfigTree.tsx
@@ -270,7 +270,7 @@ function computeTreeData(
 				children: [],
 			};
 
-			if (def.type === "object") {
+			if (def.type === "object" && !Object.keys(control.inputComponents).includes(def.inputComponent!)) {
 				let restartRequiredProps = new Set(def.restartRequiredProps || []);
 				childNode.title = <Form.Item
 					label={<>


### PR DESCRIPTION
Input components allow us to customize the config field editing experience in plugins, but due to an oversight this did not include object definitions.

An alternative way of implementing this fix would be to define the default editor for objects as an inputComponent, but that doesn't quite fit with how inputComponents are explicitly selected and not based on the type in the definition properties.

Use of both inputcomponents and object config definitions are rare, so I expect this will be sufficient.