### PR TITLE
Add useInstanceConfig hook

### DIFF
--- a/packages/web_ui/package.json
+++ b/packages/web_ui/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@ant-design/icons": "^5.1.4",
 		"@clusterio/lib": "workspace:*",
+		"@sinclair/typebox": "^0.30.4",
 		"@swc/core": "^1.4.0",
 		"antd": "^5.13.0",
 		"assert": "^2.0.0",

--- a/packages/web_ui/src/model/instance.ts
+++ b/packages/web_ui/src/model/instance.ts
@@ -1,4 +1,6 @@
-import { useCallback, useContext, useSyncExternalStore } from "react";
+import { useCallback, useContext, useEffect, useState, useSyncExternalStore } from "react";
+import { Static } from "@sinclair/typebox";
+import { Config, InstanceConfigGetRequest } from "@clusterio/lib";
 import ControlContext from "../components/ControlContext";
 
 export function useInstance(id?: number) {
@@ -11,3 +13,17 @@ export function useInstances() {
 	const subscribe = useCallback((callback: () => void) => control.instances.subscribe(callback), [control]);
 	return useSyncExternalStore(subscribe, () => control.instances.getSnapshot());
 }
+
+export function useInstanceConfig(id?: number) {
+	let control = useContext(ControlContext);
+	const [config, setConfig] = useState(undefined as undefined | Static<typeof Config.jsonSchema>);
+
+	useEffect(() => {
+		if (id) {
+			control.send(new InstanceConfigGetRequest(id))
+				.then(conf => setConfig(conf));
+		}
+	}, [id]);
+
+	return config;
+};


### PR DESCRIPTION
Currently the web interface implements configs by pulling the state directly in the components where they are used. I need to access the instance config for a plugin, which would require me to duplicate parts of the instance config retrival code. Instead, I implement it here under lib. This allows 3rd party consumers to get immediate access if we decide to implement a subscription model for configs in the future.