### PR TITLE
Fix test starting alt host under windows

### DIFF
--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -206,6 +206,12 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 		it("should auto start instances with auto_start enabled", async function() {
+			// On windows there's currently no way to automate graceful shutdown of the host
+			// process as CTRL+C is some weird terminal thing and SIGINT isn't a thing.
+			if (process.platform === "win32") {
+				this.skip();
+			}
+
 			slowTest(this);
 
 			let hostProcess;


### PR DESCRIPTION
One of the tests which uses the alt host was mistakening not skipped on windows causing another test to fail.
However, it was found that all tests which skip on windows pass without leaving any child processes behind, this needs further investigation.