### PR TITLE
Add devcontainer configuration file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"image":"mcr.microsoft.com/devcontainers/universal:2",
+	"postCreateCommand": "wget https://factorio.com/get-download/1.1.107/headless/linux64 && tar -xf linux64 && pnpm install",
+}


### PR DESCRIPTION
When I am on the go with shitty wifi it is very difficult to install npm modules locally for PR reviews etc. Codespaces is great in that it fixes most of the issues with a high latency connection like that. This devcontainer file provides enough setup that `pnpm test` passes when ran without having to look up factorio download urls etc.