### PR TITLE
Fix broken types

### DIFF
--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Alert, Button, Descriptions, Dropdown, Menu, MenuProps, Modal, Space, Spin, Typography } from "antd";
-import type { ItemType } from "antd/es/menu/hooks/useItems";
+import { Alert, Button, Descriptions, Dropdown, MenuProps, Modal, Space, Spin, Typography } from "antd";
+import { ItemType } from "antd/es/menu/interface";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import DownOutlined from "@ant-design/icons/DownOutlined";
 

--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useContext, useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
 import { Dropdown, Layout, Menu, MenuProps } from "antd";
+import { ItemType, MenuItemType } from "antd/es/menu/interface";
 import UserOutlined from "@ant-design/icons/UserOutlined";
 import webUiPackage from "../../package.json";
 
@@ -63,7 +64,7 @@ export default function SiteLayout() {
 		combinedPages.push(...plugin.pages);
 	}
 
-	let menuItems = [];
+	let menuItems: ItemType<MenuItemType>[] = [];
 	let menuGroups = new Map();
 	for (let { sidebarName, sidebarGroup, permission, path } of combinedPages) {
 		if (


### PR DESCRIPTION
Some time between antd 5.15.0 and 5.17.3 they moved around some types, which caused our builds to break. This fixes the issue.