### PR TITLE
Add bun compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
 	"engines": {
 		"node": ">=18"
 	},
+	"workspaces": [
+		"packages/*",
+		"plugins/*",
+		"external_plugins/*"
+	],
 	"devDependencies": {
 		"@clusterio/controller": "workspace:*",
 		"@clusterio/ctl": "workspace:*",

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Alert, Button, Descriptions, Dropdown, MenuProps, Modal, Space, Spin, Typography } from "antd";
-import { ItemType } from "antd/es/menu/interface";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import DownOutlined from "@ant-design/icons/DownOutlined";
 
@@ -25,6 +24,7 @@ import { useHost } from "../model/host";
 import InstanceStatusTag from "./InstanceStatusTag";
 import Link from "./Link";
 
+type MenuItem = Required<MenuProps>["items"][number];
 const { Title } = Typography;
 
 type InstanceDescriptionProps = {
@@ -71,7 +71,7 @@ function InstanceButtons(props: { instance: lib.InstanceDetails }) {
 	let instance = props.instance;
 	let instanceId = instance.id!;
 
-	let instanceButtonMenuItems: ItemType[] = [];
+	let instanceButtonMenuItems: MenuItem[] = [];
 	if (account.hasPermission("core.instance.export_data")) {
 		instanceButtonMenuItems.push({
 			disabled: exportingData || instance.status !== "stopped",

--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -12,6 +12,8 @@ import ControlContext from "./ControlContext";
 import { pages } from "../pages";
 import { DraggingContext } from "../model/is_dragging";
 
+type MenuItem = Required<MenuProps>["items"][number];
+
 const { Header, Sider } = Layout;
 
 function isActiveDropzone(element: HTMLElement | null): boolean {
@@ -64,7 +66,7 @@ export default function SiteLayout() {
 		combinedPages.push(...plugin.pages);
 	}
 
-	let menuItems: ItemType<MenuItemType>[] = [];
+	let menuItems: MenuItem[] = [];
 	let menuGroups = new Map();
 	for (let { sidebarName, sidebarGroup, permission, path } of combinedPages) {
 		if (


### PR DESCRIPTION
When doing development on terrible networks pnpm installs usually fail. Bun is an alternative nodejs runtime and package manager which seems to be a whole lot more resilient.

Bun requires using the npm workspace location specification rather than the pnpm yaml file. This does not conflict, pnpm will continue to operate undisturbed.

It also complained about my earlier type fix. This time I changed it to use the same type declaration as in the antd documentation.