### PR TITLE
Add error tests for sendEvent and sendRequest

### DIFF
--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, useContext, useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
 import { Dropdown, Layout, Menu, MenuProps } from "antd";
-import { ItemType, MenuItemType } from "antd/es/menu/interface";
 import UserOutlined from "@ant-design/icons/UserOutlined";
 import webUiPackage from "../../package.json";
 


### PR DESCRIPTION
As title says, adds tests for the error cases within sendEvent and sendRequent on the controller.
Also fixes a broken import.