### PR TITLE
Fix 634 - Fatel error when shutting down host from webui

### DIFF
--- a/packages/lib/src/link/connectors.ts
+++ b/packages/lib/src/link/connectors.ts
@@ -34,6 +34,7 @@ export abstract class BaseConnector extends events.EventEmitter {
 	}
 
 	protected abstract send(message: libData.MessageRoutable): void;
+	abstract get valid(): boolean;
 
 	forward(message: libData.MessageRoutable) {
 		const seq = this._seq;
@@ -345,6 +346,14 @@ export abstract class WebSocketBaseConnector extends BaseConnector {
 	 */
 	get hasSession() {
 		return ["connected", "resuming"].includes(this._state);
+	}
+
+	/**
+	 * True if the connector is valid and can accept new messages,
+	 * only needs to be checked on fringe cases during setup and tear down.
+	 */
+	get valid() {
+		return this.hasSession;
 	}
 }
 
@@ -722,5 +731,15 @@ export class VirtualConnector extends BaseConnector {
 	 */
 	send(message: libData.Message) {
 		this.other.emit("message", message);
+	}
+
+	/**
+	 * True if the connector is valid and can accept new messages,
+	 * only needs to be checked on fringe cases during setup and tear down.
+	 *
+	 * For a virtual connector this is always true.
+	 */
+	get valid() {
+		return true;
 	}
 }

--- a/packages/lib/src/logging_utils.ts
+++ b/packages/lib/src/logging_utils.ts
@@ -207,7 +207,9 @@ export class LinkTransport extends Transport {
 		}
 
 		try {
-			this.link.send(new libData.LogMessageEvent(info));
+			if (this.link.connector.valid) {
+				this.link.send(new libData.LogMessageEvent(info));
+			}
 		} catch (err) {
 			// Ignore session lost errors.
 			if (!(err instanceof libErrors.SessionLost)) {


### PR DESCRIPTION
Depends on #638 for webpack build fix. Fixes #634 

Fixes the fatel error on the host when shutdown from the webui. Achieved by adding `abstract get valid` to BaseConnector which indicates when it is safe to send messages on a link. This property only needs to be checked on fringe cases during setup and tear down contexts such as attempting to send logs after disconnection.