### PR TITLE
Extend PageHeader for plugins

### DIFF
--- a/packages/web_ui/src/components/PageHeader.tsx
+++ b/packages/web_ui/src/components/PageHeader.tsx
@@ -1,13 +1,19 @@
 import React from "react";
+import { Space, Typography } from "antd";
+const { Text } = Typography;
 
 type PageHeaderProps = {
-	title: string|React.ReactElement;
+	title: string | React.ReactElement;
+	subTitle?: string | React.ReactElement;
 	extra?: React.JSX.Element;
 };
 
 export default function PageHeader(props: PageHeaderProps): React.JSX.Element {
 	return <div className="page-header">
-		<h2 className="page-header-title">{props.title}</h2>
+		<Space>
+			<h2 className="page-header-title">{props.title}</h2>
+			{props.subTitle && <Text type="secondary">{props.subTitle}</Text>}
+		</Space>
 		{props.extra && <div className="page-header-extra">{props.extra}</div>}
 	</div>;
 }


### PR DESCRIPTION
My plugins used the antd pageheader more than base did. I did not notice that these features dissappeared when we migrated from antd to our own implementation - this brings them back