### PR TITLE
Fix build pipeline under typescript 5.5 and make use of new configDir option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Many thanks to the following for contributing to this release:
 
 - Fixed IPC errors reporting undefined when no stack trace was present [#624](https://github.com/clusterio/clusterio/pull/624).
 - Fixed loopback routing for instances reporting the wrong error message [#625](https://github.com/clusterio/clusterio/pull/625).
+- Bumped Typescript version to 5.5 and implemented `${configDir}` in base configs for "outDir" [#648](https://github.com/clusterio/clusterio/pull/648).
 
 ### Breaking Changes
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
 		"@clusterio/controller": "workspace:*",
 		"@clusterio/ctl": "workspace:*",
 		"@clusterio/host": "workspace:*",
-		"@clusterio/web_ui": "workspace:*",
 		"@clusterio/lib": "workspace:*",
+		"@clusterio/web_ui": "workspace:*",
 		"@swc/core": "^1.4.0",
 		"@typescript-eslint/eslint-plugin": "^6.4.1",
 		"@typescript-eslint/parser": "^6.4.1",
@@ -51,8 +51,8 @@
 		"mocha": "^10.2.0",
 		"nyc": "^15.1.0",
 		"phin": "^3.7.0",
-		"typedoc": "^0.24.8",
-		"typescript": "^5.1.6",
+		"typedoc": "^0.26.3",
+		"typescript": "^5.5.3",
 		"yargs": "^17.7.2"
 	}
 }

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -29,7 +29,6 @@
 		"jsonwebtoken": "^9.0.1",
 		"jszip": "^3.10.1",
 		"set-blocking": "^2.0.0",
-		"webpack-cli": "^5.1.4",
 		"winston": "^3.10.0",
 		"winston-daily-rotate-file": "^4.7.1",
 		"ws": "^8.13.0",
@@ -54,7 +53,8 @@
 		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-dev-middleware": "^6.1.1",
-		"webpack-merge": "^5.9.0"
+		"webpack-merge": "^5.9.0",
+		"webpack-cli": "^5.1.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -51,7 +51,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.4.14",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-dev-middleware": "^6.1.1",
 		"webpack-merge": "^5.9.0"

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -95,7 +95,7 @@ export default class Controller {
 	public shouldRestart: boolean = false;
 	_fallbackedRequests: Map<lib.RequestClass<unknown, unknown>, lib.RequestHandler<unknown, unknown>> = new Map();
 	_registeredRequests: Map<lib.RequestClass<unknown, unknown>, lib.RequestHandler<unknown, unknown>> = new Map();
-	_registeredEvents = new Map();
+	_registeredEvents = new Map<lib.EventClass<unknown>, lib.EventHandler<unknown>>();
 	_snoopedEvents = new Map();
 
 	devMiddleware: any | null = null;

--- a/packages/controller/tsconfig.browser.json
+++ b/packages/controller/tsconfig.browser.json
@@ -7,6 +7,5 @@
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "package.json" ],
 	"compilerOptions": {
 		"rootDir": "..",
-		"outDir": "dist/browser",
 	}
 }

--- a/packages/controller/tsconfig.node.json
+++ b/packages/controller/tsconfig.node.json
@@ -4,7 +4,4 @@
 		{ "path": "../lib/tsconfig.node.json" },
 	],
 	"include": ["index.ts", "controller.ts", "package.json", "src/**/*.ts"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/packages/create/templates/common/package.json
+++ b/packages/create/templates/common/package.json
@@ -20,7 +20,7 @@
 	"devDependencies": {
 //%// Typescript and type declarations
 //%if typescript
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"@types/node": "^20.4.5",
 //%endif
 //%if typescript & web

--- a/packages/create/templates/plugin-ts/tsconfig.browser.json
+++ b/packages/create/templates/plugin-ts/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/packages/create/templates/plugin-ts/tsconfig.node.json
+++ b/packages/create/templates/plugin-ts/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/packages/ctl/package.json
+++ b/packages/ctl/package.json
@@ -35,6 +35,6 @@
 		"@types/node": "^20.4.5",
 		"@types/set-blocking": "^2.0.0",
 		"@types/yargs": "^17.0.24",
-		"typescript": "^5.1.6"
+		"typescript": "^5.5.3"
 	}
 }

--- a/packages/ctl/tsconfig.node.json
+++ b/packages/ctl/tsconfig.node.json
@@ -4,7 +4,4 @@
 		{ "path": "../lib/tsconfig.node.json" },
 	],
 	"include": ["index.ts", "package.json", "ctl.ts", "src/**/*.ts"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -43,6 +43,6 @@
 		"@types/semver": "^7.5.0",
 		"@types/set-blocking": "^2.0.0",
 		"@types/yargs": "^17.0.24",
-		"typescript": "^5.1.6"
+		"typescript": "^5.5.3"
 	}
 }

--- a/packages/host/tsconfig.node.json
+++ b/packages/host/tsconfig.node.json
@@ -4,7 +4,4 @@
 		{ "path": "../lib/tsconfig.node.json" },
 	],
 	"include": ["index.ts", "host.ts", "package.json", "src/**/*.ts", "src/**/*.js"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -41,6 +41,6 @@
 		"@types/triple-beam": "^1.3.2",
 		"@types/ws": "^8.5.5",
 		"@types/yargs": "^17.0.24",
-		"typescript": "^5.1.6"
+		"typescript": "^5.5.3"
 	}
 }

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -538,7 +538,7 @@ export class Link {
 		if (!entry) {
 			throw new Error(`Attempt to send unregistered Request ${request.constructor.name}`);
 		}
-		if (this.connector.src.equals(dst)) {
+		if (this.connector.src.addressedTo(dst)) {
 			throw new Error(`Message would return back to sender ${dst}.`);
 		}
 		if (this.validateSent) {
@@ -575,7 +575,7 @@ export class Link {
 		if (!entry) {
 			throw new Error(`Attempt to send unregistered Event ${event.constructor.name}`);
 		}
-		if (this.connector.src.equals(dst)) {
+		if (this.connector.src.addressedTo(dst)) {
 			throw new Error(`Message would return back to sender ${dst}.`);
 		}
 		if (this.validateSent) {

--- a/packages/lib/tsconfig.browser.json
+++ b/packages/lib/tsconfig.browser.json
@@ -26,6 +26,5 @@
 	],
 	"compilerOptions": {
 		"rootDir": ".",
-		"outDir": "dist/browser",
 	}
 }

--- a/packages/lib/tsconfig.node.json
+++ b/packages/lib/tsconfig.node.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.node.json",
 	"include": ["index.ts", "browser.ts", "build_mod.js", "src/**/*.ts", "src/**/*.js"],
 	"compilerOptions": {
-		"outDir": "dist/node",
 		"allowJs": true,
 	},
 }

--- a/packages/web_ui/package.json
+++ b/packages/web_ui/package.json
@@ -40,7 +40,7 @@
 		"style-loader": "^3.3.3",
 		"swc-loader": "^0.2.6",
 		"terser-webpack-plugin": "^5.3.9",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"util": "^0.12.5",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",

--- a/packages/web_ui/src/index.ts
+++ b/packages/web_ui/src/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="../global.d.ts" />
+/// <reference path="../global.d.ts" preserve="true" />
 export { default as bootstrap } from "./bootstrap";
 export { default as notify, notifyErrorHandler } from "./util/notify";
 export { default as BaseWebPlugin } from "./BaseWebPlugin";

--- a/packages/web_ui/tsconfig.browser.json
+++ b/packages/web_ui/tsconfig.browser.json
@@ -4,7 +4,4 @@
 		{ "path": "../lib/tsconfig.browser.json" },
 	],
 	"include": [ "src/**/*.tsx", "src/**/*.ts", "package.json", "global.d.ts" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -25,7 +25,7 @@
 		"@clusterio/web_ui": "workspace:*",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0"

--- a/plugins/global_chat/tsconfig.browser.json
+++ b/plugins/global_chat/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/global_chat/tsconfig.node.json
+++ b/plugins/global_chat/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -33,7 +33,7 @@
 		"antd": "^5.13.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0"

--- a/plugins/inventory_sync/tsconfig.browser.json
+++ b/plugins/inventory_sync/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/inventory_sync/tsconfig.node.json
+++ b/plugins/inventory_sync/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -36,7 +36,7 @@
 		"phin": "^3.7.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0"

--- a/plugins/player_auth/tsconfig.browser.json
+++ b/plugins/player_auth/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/player_auth/tsconfig.node.json
+++ b/plugins/player_auth/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -30,7 +30,7 @@
 		"@types/fs-extra": "^11.0.1",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0"

--- a/plugins/research_sync/tsconfig.browser.json
+++ b/plugins/research_sync/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/research_sync/tsconfig.node.json
+++ b/plugins/research_sync/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -25,7 +25,7 @@
 		"@clusterio/web_ui": "workspace:*",
 		"@types/node": "^20.4.5",
 		"@types/react": "^18.2.21",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0"

--- a/plugins/statistics_exporter/tsconfig.browser.json
+++ b/plugins/statistics_exporter/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/statistics_exporter/tsconfig.node.json
+++ b/plugins/statistics_exporter/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -34,7 +34,7 @@
 		"antd": "^5.13.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"typescript": "^5.1.6",
+		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
 		"webpack-cli": "^5.1.4",
 		"webpack-merge": "^5.9.0"

--- a/plugins/subspace_storage/tsconfig.browser.json
+++ b/plugins/subspace_storage/tsconfig.browser.json
@@ -5,7 +5,4 @@
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
 	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
-	"compilerOptions": {
-		"outDir": "dist/browser",
-	}
 }

--- a/plugins/subspace_storage/tsconfig.node.json
+++ b/plugins/subspace_storage/tsconfig.node.json
@@ -5,7 +5,4 @@
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],
-	"compilerOptions": {
-		"outDir": "dist/node",
-	},
 }

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -7,5 +7,6 @@
 		"target": "es2022",
 		"jsx": "react-jsx",
 		"noEmitOnError": true,
+		"outDir": "${configDir}/dist/browser",
 	},
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,5 +6,6 @@
 		"moduleResolution": "node16",
 		"target": "es2022",
 		"forceConsistentCasingInFileNames": true,
+		"outDir": "${configDir}/dist/node",
 	},
 }


### PR DESCRIPTION
Build would fail when using typescript 5.5, after much investigation the cause was identified as the behaviour changes to [reference emiting](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#simplified-reference-directive-declaration-emit). This has been fixed in this PR.

Additionally this PR bumps the minimum version of typescript to 5.5 to make use of the new [configDir](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-configdir-template-variable-for-configuration-files) template variable for outDir.
This also required a bump of version for typedoc due to its peer dependency on typescript 5.1

Other Fixes:
- Link using `Address.equals` rather than `Address.addressedTo` for loopback checks.
- A missing type defiantion for a controller property.
- Inclusion of `webpack-cli` as a production dependency of controller.