### PR TITLE
Fix missing codecov upload token

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,9 +34,10 @@ jobs:
       run: pnpm run ci-cover
     - name : Upload coverage to Codecov
       if: ${{ matrix.node-version == '18.x' }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage/lcov.info
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As title says. Repo admin will be required to add the token to secrets.