### PR TITLE
Escape arguments when installer invokes commands

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: pnpm i --no-optional --no-frozen-lockfile
+    - run: pnpm i --no-frozen-lockfile
     - run: wget -q -O factorio.tar.gz https://www.factorio.com/get-download/latest/headless/linux64 && tar -xf factorio.tar.gz && rm factorio.tar.gz
     - name: Run tests
       if: ${{ matrix.node-version != '18.x' }}
@@ -49,5 +49,5 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 18.x
-    - run: pnpm i --no-optional --no-frozen-lockfile
+    - run: pnpm i --no-frozen-lockfile
     - run: pnpm run lint

--- a/packages/create/escape_arg.js
+++ b/packages/create/escape_arg.js
@@ -1,0 +1,62 @@
+"use strict";
+
+function escapeArg(arg) {
+	// When shell: true is used execFile does not escaping of arguments, they are
+	// simply joined by space and then passed to the shell.
+
+	// For Windows the command is cmd.exe /d /s /c "command arg arg ..."
+	// The parsing and escaping on windows is cursed. The following references are not for mortals:
+	// https://daviddeley.com/autohotkey/parameters/parameters.htm#WIN
+	// https://stackoverflow.com/a/4095133
+	// https://ss64.com/nt/syntax-esc.html
+	if (process.platform === "win32") {
+		if (!/[\t "%&<>\\^|]/.test(arg)) {
+			return arg;
+		}
+
+		const escaped = [];
+		let pos = 0;
+		while (pos < arg.length) {
+			if (arg[pos] === "\\") {
+				// If a backslash is followed by a quote or the end of the string, then
+				// double the number of backslashes because why not!
+				let peek = pos + 1;
+				while (peek !== arg.length && arg[peek] === "\\") {
+					peek += 1;
+				}
+				if (peek === arg.length || arg[peek] === '"') {
+					const count = peek - pos;
+					escaped.push("\\".repeat(count * 2));
+					pos = peek;
+					continue;
+				} else {
+					escaped.push("\\");
+				}
+			} else if (arg[pos] === '"') {
+				escaped.push('""');
+			} else if (arg[pos] === "%") {
+				// Expect a pct environment variable to contain %, because cmd does variable substitutions
+				// before parsing string quotes, and there's no mechanism for escaping % symbols, and this
+				// is a half sane workaround. The less sane workaround is to replace % with %%cd:~,%.
+				escaped.push("%pct%");
+			} else {
+				escaped.push(arg[pos]);
+			}
+			pos += 1;
+		}
+		return `"${escaped.join("")}"`;
+	}
+
+	// For all other platforms the command is /bin/sh -c <command arg arg ...>
+	// The command and its arguments are passed as a single argument to the shell.
+	// See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_02
+	// eslint-disable-next-line no-lonely-if
+	if (!/[|&;<>()$`\\"' \t*?\[#~=%]/.test(arg)) {
+		return arg;
+	}
+	return `"${arg.replace(/[$`"\\]/g, "\\$&")}"`;
+}
+
+module.exports = {
+	escapeArg,
+};

--- a/test/create/echo_args.js
+++ b/test/create/echo_args.js
@@ -1,0 +1,4 @@
+"use strict";
+if (module === require.main) {
+	process.stdout.write(JSON.stringify(process.argv.slice(2)));
+}

--- a/test/create/escape_arg.js
+++ b/test/create/escape_arg.js
@@ -1,0 +1,71 @@
+"use strict";
+const child_process = require("child_process");
+const util = require("util");
+const assert = require("assert").strict;
+const path = require("path");
+
+const { escapeArg } = require("../../packages/create/escape_arg");
+const execFile = util.promisify(child_process.execFile);
+
+async function exec(file, args) {
+	const { stdout, stderr } = await execFile(
+		file,
+		args.map(escapeArg),
+		// eslint-disable-next-line node/no-process-env
+		{ shell: true, cwd: __dirname, env: { ...process.env, pct: "%"} }
+	);
+	return { stdout: JSON.parse(stdout), stderr };
+}
+
+const strings = [
+	'"a"',
+	"a sentence of text.",
+	" irregular  \tspaces   ",
+	'"C:\\path\\"',
+	"C:\\path\\",
+	'\\ "\\" \\\\ "\\\\" \\\\\\ "\\\\\\" \\\\\\\\ "\\\\\\\\" \\\\\\\\\\ "\\\\\\\\\\" \\\\\\\\\\\ "\\\\\\\\\\\\"',
+	'"C:\\path"',
+	"C:\\path",
+	"%OS%",
+	"!OS!",
+	"😮",
+];
+for (let i=1; i < 128; i++) {
+	const char = String.fromCodePoint(i);
+	// Skip newline and carriage return because those are difficult to escape
+	// Skip most alphanumeric characters as they don't behave differently to each other.
+	if (/[\n\r1-9B-Zb-z]/.test(char)) {
+		continue;
+	}
+	strings.push(char, `${char}${char}`, `${char}"`);
+}
+
+// Test 100 strings at a time.
+const tests = [[]];
+for (const string of strings) {
+	if (tests[tests.length - 1].length >= 100) {
+		tests.push([]);
+	}
+	tests[tests.length - 1].push(string);
+}
+
+
+describe("create/escape_arg", function() {
+	it("should correctly escape strings when args are forwarded", async function() {
+		const ext = process.platform === "win32" ? ".cmd" : ".sh";
+		for (const args of tests) {
+			assert.deepEqual(
+				await exec(`.${path.sep}forward_args${ext}`, ["echo_args.js", ...args]),
+				{ stdout: args, stderr: "" }
+			);
+		}
+	});
+	it("should correctly escape strings when invoking node directly", async function() {
+		for (const args of tests) {
+			assert.deepEqual(
+				await exec("node", ["echo_args.js", ...args]),
+				{ stdout: args, stderr: "" }
+			);
+		}
+	});
+});

--- a/test/create/forward_args.cmd
+++ b/test/create/forward_args.cmd
@@ -1,0 +1,3 @@
+@ECHO off
+REM this is how npm and package.json bin entries forwards arguments on Windows
+node.exe %*

--- a/test/create/forward_args.sh
+++ b/test/create/forward_args.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# this is how package.json bin entries forwards arguments on Linux
+exec node "$@"


### PR DESCRIPTION
The usage of shell: true means that no escaping is done on the arguments passed to the commands invoked by the installer. This leads to the installation failing if the user for example puts a space in the username for the admin account.

Fix by escaping the arguments passed on command lines. This is unreasonably complicated on Windows 😡.

Resolves #620.