### PR TITLE
Include mono repo plugins in build

### DIFF
--- a/clean.js
+++ b/clean.js
@@ -12,7 +12,9 @@ const fs = require("fs-extra");
 const yargs = require("yargs");
 
 const npmPackage = require("./package.json");
-const workspaces = npmPackage.workspaces.map(p => p.slice(0, -2));
+const workspaces = npmPackage.workspaces
+	.map(p => p.slice(0, -2))
+	.filter(p => !p.includes("external_plugins"));
 
 let DRY = false;
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	"workspaces": [
 		"packages/*",
 		"plugins/*",
-		"external_plugins/*"
+		"external_plugins/*",
+		"external_plugins/*/*"
 	],
 	"devDependencies": {
 		"@clusterio/controller": "workspace:*",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - "packages/*"
   - "plugins/*"
   - "external_plugins/*"
+  - "external_plugins/*/*"
   - "test/"


### PR DESCRIPTION
Allows for mono repos to be used for plugins. This means that following the same steps for isntalling the dev version of a single plugin also works for a repo containing many plugins. That is `cd external_plugins`  `git clone <url>`. This also changes it so the clean script does not touch external plugins at all which could contain tracked files in their dist folder.