### PR TITLE
Fix Subscription Issues

### DIFF
--- a/packages/controller/src/BaseConnection.ts
+++ b/packages/controller/src/BaseConnection.ts
@@ -35,7 +35,7 @@ export default class BaseConnection extends lib.Link {
 
 		this.handle(lib.SubscriptionRequest, this.handleSubscriptionRequest.bind(this));
 		this.connector.on("close", () => {
-			this._controller.subscriptions.unsubscribe(this);
+			this._controller.subscriptions.unsubscribeLink(this);
 		});
 	}
 

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -1043,6 +1043,11 @@ export default class Controller {
 	}
 
 	instanceDetailsUpdated(instances: InstanceInfo[]) {
+		for (const instance of instances) {
+			if (instance.status === "stopped") {
+				this.subscriptions.unsubscribeAddress(lib.Address.fromShorthand({instanceId: instance.id}));
+			}
+		}
 		const updates = instances.map(instance => instance.toInstanceDetails());
 		this.subscriptions.broadcast(new lib.InstanceDetailsUpdatesEvent(updates));
 	}

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -469,6 +469,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 	notifyExit() {
 		this._loadedSave = null;
 		this.notifyStatus("stopped");
+		this.connector.emit("close");
 
 		this.config.off("fieldChanged", this._configFieldChanged);
 		clearTimeout(this._playerCheckInterval);

--- a/test/mock.js
+++ b/test/mock.js
@@ -72,6 +72,7 @@ class MockConnector extends lib.BaseConnector {
 	constructor(src, dst) {
 		super(src, dst);
 
+		this.valid = true;
 		this.connected = true;
 		this.hasSession = true;
 		this.sentMessages = [];


### PR DESCRIPTION
Two major changes here:
1) Removed some assumptions that were made that prevented subscription listeners from working on an instance.
This meant allowing the host to forward the event from the instance to the controller; correctly storing subscription listeners by address rather than by connection; and a bunch of network and event stuff to correctly clean up a listener.
2) Removed the assumption that all subscriptions events contained the `updates` property.
This meant fixing inconsistent types; always checking if the property existed; fixing lots of the tests that made incorrect assumptions.

Minior Features:
- There is output made during the start of tests to indicate something is happening when start up is slow.
- Allow for silent testing to reduce the amount of text output to the console.
- Fixed double firing of listener callbacks on first connection.
- Fixed synced being set to true too early on first connection.
- Fixed edge case interaction between last response and last snapshot for values with updated at as 0.