### PR TITLE
Fix bootstrap command missing type declaration for admin name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Many thanks to the following for contributing to this release:
 - Fixed log events being sent from a host over an invalid websocket [#639](https://github.com/clusterio/clusterio/pull/639).
 - Bumped Typescript version to 5.5 and implemented `${configDir}` in base configs for "outDir" [#648](https://github.com/clusterio/clusterio/pull/648).
 - Fixed spaces passed in arguments to the installer causing it to break [#620](https://github.com/clusterio/clusterio/issues/620)
+- Fixed numeric admin name breaking login [#536](https://github.com/clusterio/clusterio/issues/536)
 
 ### Breaking Changes
 
@@ -53,6 +54,7 @@ Many thanks to the following for contributing to this release:
 [@Danielv123](https://github.com/Danielv123)
 [@Hornwitser](https://github.com/Hornwitser)
 [@Laar](https://github.com/Laar)
+[@psihius](https://github.com/psihius)
 
 ## Version 2.0.0-alpha.18
 

--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -248,8 +248,12 @@ async function initialize(): Promise<InitializeParameters> {
 		.command("config", "Manage Controller config", lib.configCommand)
 		.command("bootstrap", "Bootstrap access to cluster", yargs => {
 			yargs
-				.command("create-admin <name>", "Create a cluster admin")
-				.command("generate-user-token <name>", "Generate authentication token for the given user")
+				.command("create-admin <name>", "Create a cluster admin", yargs => {
+					yargs.positional("name", { describe: "Name of the admin user", type: "string" });
+				})
+				.command("generate-user-token <name>", "Generate authentication token for the given user", yargs => {
+					yargs.positional("name", { describe: "Name of the user", type: "string" });
+				})
 				.command("generate-host-token <id>", "Generate authentication token for the given host", yargs => {
 					yargs.positional("id", { describe: "ID of the host", type: "number" });
 				})


### PR DESCRIPTION
Lack of typing was resulting in admin name being serialized to storage as a number and breaking websocket communications protocol due to type mismatch: expected string, got number.

Fixes #536