### PR TITLE
Add option to set path to server executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Many thanks to the following for contributing to this release:
 - Bumped Typescript version to 5.5 and implemented `${configDir}` in base configs for "outDir" [#648](https://github.com/clusterio/clusterio/pull/648).
 - Fixed spaces passed in arguments to the installer causing it to break [#620](https://github.com/clusterio/clusterio/issues/620)
 - Fixed numeric admin name breaking login [#536](https://github.com/clusterio/clusterio/issues/536)
+- Added factorio.executable_path option which allows overriding the default path to the Factorio executable run.
 
 ### Breaking Changes
 

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -169,6 +169,7 @@ export default class Instance extends lib.Link {
 		let serverOptions = {
 			logger: this.logger,
 			version: this.config.get("factorio.version"),
+			executablePath: this.config.get("factorio.executable_path") ?? undefined,
 			gamePort: this.config.get("factorio.game_port") ?? host.assignGamePort(this.id),
 			rconPort: this.config.get("factorio.rcon_port") ?? undefined,
 			rconPassword: this.config.get("factorio.rcon_password") ?? undefined,

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -407,6 +407,8 @@ export interface FactorioServerOptions {
 	 * the latest version found in `factorioDir`.
 	 */
 	version?: string,
+	/** Path to executable to invoke when starting the server */
+	executablePath?: string;
 	/** UDP port to host game on. */
 	gamePort?: number,
 	/** TCP port to use for RCON. */
@@ -450,6 +452,8 @@ export interface FactorioServerOptions {
  * @extends events.EventEmitter
  */
 export class FactorioServer extends events.EventEmitter {
+	/** Path to executable to invoke when starting the server */
+	executablePath?: string;
 	/** UDP port used for hosting the Factorio game server on */
 	gamePort: number;
 	/** TCP port used for RCON on the Factorio game server */
@@ -504,6 +508,7 @@ export class FactorioServer extends events.EventEmitter {
 
 		this._logger = options.logger || lib.logger;
 		this._targetVersion = options.version || "latest";
+		this.executablePath = options.executablePath;
 		/** UDP port used for hosting the Factorio game server on */
 		this.gamePort = options.gamePort || randomDynamicPort();
 		/** TCP port used for RCON on the Factorio game server */
@@ -1155,11 +1160,15 @@ export class FactorioServer extends events.EventEmitter {
 	/**
 	 * Get Factorio binary path
 	 *
-	 * Get the path to the factorio binary depending on the platform (MacOS support)
+	 * Get the path to the factorio binary depending on the configuration
+	 * and or the platform (MacOS support)
 	 *
 	 * @returns Path to factorio binary
 	 */
 	binaryPath() {
+		if (this.executablePath) {
+			return this.dataPath("..", this.executablePath);
+		}
 		if (process.platform === "darwin") {
 			return this.dataPath("..", "MacOS", "factorio");
 		}

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -261,6 +261,7 @@ export interface InstanceConfigFields {
 	"instance.auto_start": boolean;
 
 	"factorio.version": string;
+	"factorio.executable_path": string | null;
 	"factorio.game_port": number | null;
 	"factorio.host_assigned_game_port": number | null;
 	"factorio.rcon_port": number | null;
@@ -310,6 +311,14 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			restartRequired: true,
 			type: "string",
 			initialValue: "latest",
+		},
+		"factorio.executable_path": {
+			description:
+				"Relative path from the Factorio installation directory to the executable to run. " +
+				"Defaults to auto detect the path, only needed in special setups.",
+			restartRequired: true,
+			type: "string",
+			optional: true,
 		},
 		"factorio.game_port": {
 			description: "UDP port to run game on, uses a port in host.factorio_port_range if null",


### PR DESCRIPTION
Allow overriding the logic selecting the path to the Factorio executable.  This is mainly useful when working with development versions of the game.