### PR TITLE
Fix safeOutputFile writing to wrong directory

### DIFF
--- a/packages/lib/src/file_ops.ts
+++ b/packages/lib/src/file_ops.ts
@@ -142,7 +142,7 @@ export async function safeOutputFile(file: string, data: string | Buffer, option
 	if (dir && !await fs.pathExists(dir)) {
 		await fs.mkdirs(dir);
 	}
-	let temporary = `${dir}${name}.tmp${ext}`;
+	let temporary = path.join(dir, `${name}.tmp${ext}`);
 	let fd = await fs.open(temporary, "w");
 	try {
 		await fs.writeFile(fd, data, options);


### PR DESCRIPTION
When renaming a file over another file the operation is only atomic if both the source file and the target file is in the same directory.  Fix safeOutputFile writing the temporary file to a different directory than the target file due to the path separator not being included when creating the temporary file path.