### PR TITLE
Rework Factorio server stop logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Many thanks to the following for contributing to this release:
 - Fixed numeric admin name breaking login [#536](https://github.com/clusterio/clusterio/issues/536)
 - Added factorio.executable_path option which allows overriding the default path to the Factorio executable run.
 - Added instance version display [#573](https://github.com/clusterio/clusterio/pull/573)
+- Added `factorio.shutdown_timeout` config to set the time the host will wait for a Factorio server to shut down befor killing it.
+- Changed shutdown logic to prefer sending a /quit command via RCON instead of using diverging logic on Windows and Linux.
 
 ### Breaking Changes
 

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -153,7 +153,9 @@ export default class Instance extends lib.Link {
 		this._configFieldChanged = (field: string, curr: unknown, prev: unknown) => {
 			let hook = () => lib.invokeHook(this.plugins, "onInstanceConfigFieldChanged", field, curr, prev);
 
-			if (field === "factorio.settings") {
+			if (field === "factorio.shutdown_timeout") {
+				this.server.shutdownTimeoutMs = curr as number * 1000;
+			} else if (field === "factorio.settings") {
 				this.updateFactorioSettings(curr as any, prev as any).finally(hook);
 			} else if (field === "factorio.enable_whitelist") {
 				this.updateFactorioWhitelist(curr as any).finally(hook);
@@ -178,6 +180,7 @@ export default class Instance extends lib.Link {
 			verboseLogging: this.config.get("factorio.verbose_logging"),
 			stripPaths: this.config.get("factorio.strip_paths"),
 			maxConcurrentCommands: this.config.get("factorio.max_concurrent_commands"),
+			shutdownTimeoutMs: this.config.get("factorio.shutdown_timeout") * 1000,
 		};
 
 		this.server = new FactorioServer(

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -781,6 +781,7 @@ export class FactorioServer extends events.EventEmitter {
 		this._rconReady = false;
 		this._gameReady = false;
 		this._unexpected = [];
+		this._killed = false;
 		this._runningAutosave = null;
 	}
 

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -262,6 +262,7 @@ export interface InstanceConfigFields {
 
 	"factorio.version": string;
 	"factorio.executable_path": string | null;
+	"factorio.shutdown_timeout": number;
 	"factorio.game_port": number | null;
 	"factorio.host_assigned_game_port": number | null;
 	"factorio.rcon_port": number | null;
@@ -318,6 +319,14 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 				"Defaults to auto detect the path, only needed in special setups.",
 			restartRequired: true,
 			type: "string",
+			optional: true,
+		},
+		"factorio.shutdown_timeout": {
+			description:
+				"Timeout in seconds to wait after requesting the server to stop before killing " +
+				"the process. Set to 0 to disable.",
+			type: "number",
+			initialValue: 300,
 			optional: true,
 		},
 		"factorio.game_port": {

--- a/test/host/server.js
+++ b/test/host/server.js
@@ -211,9 +211,6 @@ describe("host/server", function() {
 
 		describe(".stop()", function() {
 			it("should handle server quitting on its own during stop", async function() {
-				if (process.platform === "win32") {
-					this.skip();
-				}
 				server.hangTimeoutMs = 20;
 				server._server = new events.EventEmitter();
 				server._server.kill = () => true;

--- a/test/host/server.js
+++ b/test/host/server.js
@@ -211,24 +211,28 @@ describe("host/server", function() {
 
 		describe(".stop()", function() {
 			it("should handle server quitting on its own during stop", async function() {
-				server.hangTimeoutMs = 20;
+				server.shutdownTimeoutMs = 20;
 				server._server = new events.EventEmitter();
 				server._server.kill = () => true;
 				server._state = "running";
-				server._rconReady = true;
+				server._rconReady = false;
 				server._rconClient = {
+					async sendRcon() { },
 					async end() {
 						server._rconClient = null;
-						process.nextTick(() => {
-							server.emit("_quitting");
-							server._server.emit("exit");
-						});
 					},
 				};
 				server._watchExit();
 
-				await server.stop();
-				await wait(21); // Wait until after hang timeout
+				const stop = server.stop();
+				stop.catch(() => {});
+				process.nextTick(() => {
+					server.emit("rcon-ready");
+					server._server.emit("exit");
+				});
+
+				await stop;
+				await wait(21); // Wait until after shutdown timeout
 			});
 		});
 	});

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -48,8 +48,21 @@ async function startAltHost() {
 
 async function stopAltHost(hostProcess) {
 	if (hostProcess && hostProcess.exitCode === null) {
-		hostProcess.kill("SIGINT");
-		await events.once(hostProcess, "exit");
+		const waitForExit = lib.timeout(
+			events.once(hostProcess, "exit"),
+			10e3,
+			"timeout"
+		).catch(() => {});
+		try {
+			await execCtl("host stop 5");
+		} catch (err) {
+			// Some tests cause the host to stop
+		}
+		if (await waitForExit === "timeout" && hostProcess.exitCode === null) {
+			// eslint-disable-next-line no-console
+			console.warn("Stopping alt-host failed. Killing.");
+			hostProcess.kill("SIGINT");
+		}
 	}
 }
 
@@ -148,12 +161,6 @@ describe("Integration of Clusterio", function() {
 	describe("clusteriohost", function() {
 		describe("hostUpdateEventHandler()", function() {
 			it("should trigger when a new host is added", async function() {
-				// On windows there's currently no way to automate graceful shutdown of the host
-				// process as CTRL+C is some weird terminal thing and SIGINT isn't a thing.
-				if (process.platform === "win32") {
-					this.skip();
-				}
-
 				slowTest(this);
 				getControl().hostUpdates = [];
 
@@ -189,12 +196,6 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 		it("should download mods from controller", async function() {
-			// On windows there's currently no way to automate graceful shutdown of the host
-			// process as CTRL+C is some weird terminal thing and SIGINT isn't a thing.
-			if (process.platform === "win32") {
-				this.skip();
-			}
-
 			slowTest(this);
 			await runWithAltHost(async () => {
 				const clusterioLib = path.join("temp", "test", "alt-mods", "clusterio_lib_0.1.2.zip");
@@ -206,12 +207,6 @@ describe("Integration of Clusterio", function() {
 			});
 		});
 		it("should auto start instances with auto_start enabled", async function() {
-			// On windows there's currently no way to automate graceful shutdown of the host
-			// process as CTRL+C is some weird terminal thing and SIGINT isn't a thing.
-			if (process.platform === "win32") {
-				this.skip();
-			}
-
 			slowTest(this);
 
 			let hostProcess;
@@ -310,12 +305,6 @@ describe("Integration of Clusterio", function() {
 		});
 		describe("host revoke-token", async function() {
 			it("should disconnect existing host", async function() {
-				// On windows there's currently no way to automate graceful shutdown of the host
-				// process as CTRL+C is some weird terminal thing and SIGINT isn't a thing.
-				if (process.platform === "win32") {
-					this.skip();
-				}
-
 				slowTest(this);
 				let sawDisconnected;
 				await runWithAltHost(async () => {
@@ -774,11 +763,6 @@ describe("Integration of Clusterio", function() {
 					if (remote) {
 						let hostProcess;
 						before(async function() {
-							// On windows there's currently no way to automate graceful shutdown of the host
-							// process as CTRL+C is some weird terminal thing and SIGINT isn't a thing.
-							if (process.platform === "win32") {
-								this.skip();
-							}
 							slowTest(this);
 
 							hostProcess = await startAltHost();
@@ -907,12 +891,8 @@ describe("Integration of Clusterio", function() {
 				slowTest(this);
 				let statusesToCheck = new Set([
 					"unassigned", "stopped", "creating_save", "exporting_data",
-					"starting", "running", "stopping", "deleted",
+					"starting", "running", "stopping", "deleted", "unknown",
 				]);
-				// Windows does not see the unknown status because alt-host is not spawned.
-				if (process.platform !== "win32") {
-					statusesToCheck.add("unknown");
-				}
 				let statusesNotSeen = new Set(statusesToCheck);
 
 				for (let update of getControl().instanceUpdates) {

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -13,7 +13,7 @@ const { wait } = lib;
 const testStrings = require("../lib/factorio/test_strings");
 const {
 	TestControl, TestControlConnector, url, controlToken, slowTest,
-	get, exec, execCtl, sendRcon, getControl, spawn, instancesDir,
+	exec, execCtl, sendRcon, getControl, spawn, instancesDir, factorioDir,
 } = require("./index");
 
 
@@ -41,7 +41,8 @@ async function startAltHost() {
 	await execCtl(`host create-config --id 5 --name alt-host --generate-token --output ${config}`);
 	await exec(`node ../../packages/host --config ${config} config set host.tls_ca ../../test/file/tls/cert.pem`);
 	await exec(`node ../../packages/host --config ${config} config set host.instances_directory alt-instances`);
-	await exec(`node ../../packages/host --config ${config} config set host.factorio_directory ../../factorio`);
+	const dir = path.isAbsolute(factorioDir) ? factorioDir : path.join("..", "..", factorioDir);
+	await exec(`node ../../packages/host --config ${config} config set host.factorio_directory ${dir}`);
 	await exec(`node ../../packages/host --config ${config} config set host.mods_directory alt-mods`);
 	return await spawnAltHost(config);
 }

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -14,9 +14,25 @@ const { slowTest, factorioDir } = require("./index");
 describe("Integration of host/src/server", function() {
 	describe("_getVersion()", function() {
 		it("should get a version from factorio's changelog.txt", async function() {
+			function checkVersion(version) {
+				if (!/^\d+\.\d+\.\d+$/.test(version)) {
+					assert.fail(`Detected version '${version}' does not followed the format x.y.z`);
+				}
+			}
+
 			let version = await _getVersion(path.join(factorioDir, "data", "changelog.txt"));
-			if (!/^\d+\.\d+\.\d+$/.test(version)) {
-				assert.fail(`Detected version '${version}' does not followed the format x.y.z`);
+			if (version !== null) {
+				checkVersion(version);
+			} else {
+				for (let entry of await fs.readdir(factorioDir, { withFileTypes: true })) {
+					if (!entry.isDirectory()) {
+						continue;
+					}
+
+					checkVersion(
+						await _getVersion(path.join(factorioDir, entry.name, "data", "changelog.txt"))
+					);
+				}
 			}
 		});
 	});

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -219,10 +219,6 @@ describe("Integration of host/src/server", function() {
 
 		describe(".start() termination detection", function() {
 			it("should tell if Factorio got killed", async function() {
-				// This does not work on Windows
-				if (process.platform === "win32") {
-					this.skip();
-				}
 				slowTest(this);
 				log(".start() for kill detection");
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -109,7 +109,7 @@ describe("Integration of host/src/server", function() {
 				let mapPath = server.writePath("saves", "test.zip");
 				assert(!await fs.exists(mapPath), "save exist before test");
 
-				await server.create("test.zip");
+				await server.create("test.zip", undefined, { width: 50, height: 50 });
 				assert(await fs.exists(mapPath), "test did not create save");
 			});
 		});


### PR DESCRIPTION
Reworks the logic for stopping Factorio servers to send `/quit` via RCON. This is done to make the logic essentially the same on all supported platforms, instead of having a stop function with two different code paths merged into it depending on whether it's running on Windows or not.

This also fixes most the skipped tests to run on Windows, and the Factorio directory not being correctly handled in all cases in the tests.