### PR TITLE
Implement shared Factorio credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Many thanks to the following for contributing to this release:
 - Added instance version display [#573](https://github.com/clusterio/clusterio/pull/573)
 - Added `factorio.shutdown_timeout` config to set the time the host will wait for a Factorio server to shut down befor killing it.
 - Changed shutdown logic to prefer sending a /quit command via RCON instead of using diverging logic on Windows and Linux.
+- Added `controller.factorio_username` and `controller.factorio_token` config to set Factorio credentials used for the whole cluster.
+- Added `controller.share_factorio_credential_with_hosts` config to optionally require hosts to provide their own credentials.
+- Added `host.factorio_username` and `host.factorio_token` config to set Factorio credentials used on a given host.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Many thanks to the following for contributing to this release:
 - Added clean script to speed up publishing and debugging of build steps [#640](https://github.com/clusterio/clusterio/pull/640).
 - Added sub-tile option on plugin page headers [#642](https://github.com/clusterio/clusterio/pull/642).
 - Greatly improved plugin and module template generation [#641](https://github.com/clusterio/clusterio/pull/641).
+- Added credential option to config entries to allow writing sensitive data that can't be read back remotely.
 
 ### Changes
 
@@ -55,6 +56,7 @@ Many thanks to the following for contributing to this release:
 
 - Previously silent errors for controller.sendEvent now throw exceptions [#625](https://github.com/clusterio/clusterio/pull/625).
 - @clusterio/controller export InstanceInfo has added factorioVersion parameter.
+- Argument order for `Config.canAccess` changed to require an access mode passed as the second argument.
 
 Many thanks to the following for contributing to this release:  
 [@CCpersonguy](https://github.com/CCpersonguy)

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -788,8 +788,6 @@ export default class Controller {
 			"tags": ["clusterio"],
 			"max_players": 0,
 			"visibility": { "public": true, "lan": true },
-			"username": "",
-			"token": "",
 			"game_password": "",
 			"require_user_verification": true,
 			"max_upload_in_kilobytes_per_second": 0,

--- a/packages/controller/src/HostConnection.ts
+++ b/packages/controller/src/HostConnection.ts
@@ -74,6 +74,7 @@ export default class HostConnection extends BaseConnection {
 			this._controller.hosts.set(this.info);
 		});
 
+		this.handle(lib.GetFactorioCredentialsRequest, this.handleGetFactorioCredentialsRequest.bind(this));
 		this.handle(lib.HostInfoUpdateEvent, this.handleHostInfoUpdateEvent.bind(this));
 		this.handle(lib.InstanceStatusChangedEvent, this.handleInstanceStatusChangedEvent.bind(this));
 		this.handle(lib.InstancesUpdateRequest, this.handleInstancesUpdateRequest.bind(this));
@@ -159,6 +160,16 @@ export default class HostConnection extends BaseConnection {
 	 */
 	get remoteAddress() {
 		return this.info.remoteAddress;
+	}
+
+	async handleGetFactorioCredentialsRequest() {
+		if (this._controller.config.get("controller.share_factorio_credentials_with_hosts")) {
+			return {
+				username: this._controller.config.get("controller.factorio_username") ?? undefined,
+				token: this._controller.config.get("controller.factorio_token") ?? undefined,
+			};
+		}
+		return {};
 	}
 
 	async handleHostInfoUpdateEvent(event: lib.HostInfoUpdateEvent) {

--- a/packages/lib/src/config/classes.ts
+++ b/packages/lib/src/config/classes.ts
@@ -78,6 +78,12 @@ export interface FieldDefinition {
 	 */
 	description?: string;
 	/**
+	 * Value to use for the autocomplete attribute in the Web UI's input element.
+	 * Useful for making browsers behave properly with credential inputs.
+	 * Only used for string and number fields.
+	 */
+	autoComplete?: string;
+	/**
 	 * Web UI component to use for rending this input. Can be extended by
 	 * @{link "@clusterio/web_ui".BaseWebPlugin.inputComponents}
 	 */

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -153,12 +153,14 @@ export class ControllerConfig extends classes.Config<ControllerConfigFields> {
 		"controller.factorio_username": {
 			title: "Factorio Username",
 			description: "Username to authenticate with Factorio API with.",
+			autoComplete: "section-factorio username",
 			type: "string",
 			optional: true,
 		},
 		"controller.factorio_token": {
 			title: "Factorio Token",
 			description: "Token to authenticate with Factorio API with.",
+			autoComplete: "section-factorio new-password",
 			type: "string",
 			credential: ["controller"],
 			optional: true,
@@ -276,6 +278,7 @@ export class HostConfig extends classes.Config<HostConfigFields> {
 			description:
 				"Username to authenticate with Factorio API with. If set this will be used in the server settings " +
 				"of all instances on this host.",
+			autoComplete: "section-factorio username",
 			type: "string",
 			optional: true,
 		},
@@ -284,6 +287,7 @@ export class HostConfig extends classes.Config<HostConfigFields> {
 			description:
 				"Token to authenticate with Factorio API with. If set this will be used in the server settings " +
 				"of all instances on this host.",
+			autoComplete: "section-factorio new-password",
 			type: "string",
 			credential: ["host"],
 			optional: true,

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -20,6 +20,9 @@ export interface ControllerConfigFields {
 	"controller.metrics_timeout": number;
 	"controller.system_metrics_interval": number;
 	"controller.proxy_stream_timeout": number;
+	"controller.factorio_username": string | null;
+	"controller.factorio_token": string | null;
+	"controller.share_factorio_credentials_with_hosts": boolean;
 	"controller.default_mod_pack_id": number | null;
 	"controller.default_role_id": number | null;
 	"controller.autosave_interval": number;
@@ -147,6 +150,27 @@ export class ControllerConfig extends classes.Config<ControllerConfigFields> {
 			type: "number",
 			initialValue: 15,
 		},
+		"controller.factorio_username": {
+			title: "Factorio Username",
+			description: "Username to authenticate with Factorio API with.",
+			type: "string",
+			optional: true,
+		},
+		"controller.factorio_token": {
+			title: "Factorio Token",
+			description: "Token to authenticate with Factorio API with.",
+			type: "string",
+			credential: ["controller"],
+			optional: true,
+		},
+		"controller.share_factorio_credentials_with_hosts": {
+			title: "Share Factorio credentials with Hosts",
+			description:
+				"If enabled, the Factorio Username and Token will be shared with hosts and " +
+				"used in the server settings of instances in this cluster.",
+			type: "boolean",
+			initialValue: true,
+		},
 		"controller.default_mod_pack_id": {
 			title: "Default Mod Pack",
 			description: "Mod pack used by default for instances.",
@@ -175,6 +199,8 @@ export interface HostConfigFields {
 	"host.tls_ca": string | null;
 	"host.public_address": string;
 	"host.factorio_port_range": string;
+	"host.factorio_username": string | null,
+	"host.factorio_token": string | null,
 	"host.max_reconnect_delay": number;
 }
 
@@ -244,6 +270,23 @@ export class HostConfig extends classes.Config<HostConfigFields> {
 				"ranges separated with a dash.",
 			type: "string",
 			initialValue: "34100-34199",
+		},
+		"host.factorio_username": {
+			title: "Factorio Username",
+			description:
+				"Username to authenticate with Factorio API with. If set this will be used in the server settings " +
+				"of all instances on this host.",
+			type: "string",
+			optional: true,
+		},
+		"host.factorio_token": {
+			title: "Factorio Token",
+			description:
+				"Token to authenticate with Factorio API with. If set this will be used in the server settings " +
+				"of all instances on this host.",
+			type: "string",
+			credential: ["host"],
+			optional: true,
 		},
 		"host.max_reconnect_delay": {
 			title: "Max Reconnect Delay",

--- a/packages/lib/src/data/messages_controller.ts
+++ b/packages/lib/src/data/messages_controller.ts
@@ -122,6 +122,18 @@ export class HostConfigCreateRequest {
 	static Response = plainJson(HostConfig.jsonSchema);
 }
 
+export class GetFactorioCredentialsRequest {
+	declare ["constructor"]: typeof GetFactorioCredentialsRequest;
+	static type = "request" as const;
+	static src = ["host", "instance"] as const;
+	static dst = "controller" as const;
+
+	static Response = plainJson(Type.Object({
+		"username": Type.Optional(Type.String()),
+		"token": Type.Optional(Type.String()),
+	}));
+}
+
 export class LogSetSubscriptionsRequest {
 	declare ["constructor"]: typeof LogSetSubscriptionsRequest;
 	static type = "request" as const;

--- a/packages/lib/src/link/messages.ts
+++ b/packages/lib/src/link/messages.ts
@@ -24,6 +24,7 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	controller.ControllerConfigSetPropRequest,
 	controller.HostGenerateTokenRequest,
 	controller.HostConfigCreateRequest,
+	controller.GetFactorioCredentialsRequest,
 	controller.LogSetSubscriptionsRequest,
 	controller.LogQueryRequest,
 	controller.LogMessageEvent,

--- a/packages/web_ui/src/components/BaseConfigTree.tsx
+++ b/packages/web_ui/src/components/BaseConfigTree.tsx
@@ -44,12 +44,12 @@ function renderInput(inputComponents: Record<string, InputComponent>, def: lib.F
 	}
 	if (def.type === "string") {
 		if (def.credential) {
-			return <Input.Password/>;
+			return <Input.Password autoComplete={def.autoComplete} />;
 		}
-		return <Input/>;
+		return <Input autoComplete={def.autoComplete} />;
 	}
 	if (def.type === "number") {
-		return <InputNumber/>;
+		return <InputNumber autoComplete={def.autoComplete} />;
 	}
 
 	return `Unknown type ${def.type}`;

--- a/packages/web_ui/src/components/BaseConfigTree.tsx
+++ b/packages/web_ui/src/components/BaseConfigTree.tsx
@@ -16,13 +16,13 @@ const { Title } = Typography;
 function getInitialValues(config: lib.Config<any>, props: BaseConfigTreeProps) {
 	let initialValues: any = {};
 	for (let [name, def] of Object.entries(config.constructor.fieldDefinitions)) {
-		if (!config.canAccess(name)) {
+		if (!config.canAccess(name, lib.ConfigAccess.read)) {
 			continue;
 		}
 
 		let value = config.get(name) as any;
 		if (def.type === "object") {
-			for (let prop of Object.keys(value)) {
+			for (let prop of Object.keys(value ?? {})) {
 				initialValues[`${name}.${prop}`] = JSON.stringify(value[prop]);
 			}
 		} else {
@@ -43,6 +43,9 @@ function renderInput(inputComponents: Record<string, InputComponent>, def: lib.F
 		return <Checkbox/>;
 	}
 	if (def.type === "string") {
+		if (def.credential) {
+			return <Input.Password/>;
+		}
 		return <Input/>;
 	}
 	if (def.type === "number") {
@@ -110,7 +113,8 @@ export default function BaseConfigTree(props: BaseConfigTreeProps) {
 			if (key.endsWith(":add.name") || key.endsWith(":add.value")) {
 				continue;
 			}
-			if (initialValues[key] === value) {
+			const def = config?.constructor.fieldDefinitions[key];
+			if (!def?.credential && initialValues[key] === value) {
 				changed = newChangedFields.delete(key) || changed;
 			} else {
 				changed = !newChangedFields.has(key) || changed;
@@ -213,6 +217,7 @@ export default function BaseConfigTree(props: BaseConfigTreeProps) {
 	</>;
 }
 
+// eslint-disable-next-line complexity
 function computeTreeData(
 	control: Control,
 	form: FormInstance<any>,
@@ -259,7 +264,9 @@ function computeTreeData(
 		};
 
 		for (let [field, def] of Object.entries(groupDefs)) {
-			if (!config.canAccess(`${groupName}.${field}`)) {
+			const canWrite = config.canAccess(`${groupName}.${field}`, lib.ConfigAccess.write);
+			const canRead = config.canAccess(`${groupName}.${field}`, lib.ConfigAccess.read);
+			if (!canWrite && !canRead) {
 				continue;
 			}
 
@@ -279,7 +286,7 @@ function computeTreeData(
 					</>}
 					tooltip={def.description}
 				/>;
-				for (let prop of Object.keys(value)) {
+				for (let prop of Object.keys(value ?? {})) {
 					let propPath = `${groupName}.${field}.${prop}`;
 					let restart = Boolean(
 						def.restartRequiredProps && Number(def.restartRequired) ^ Number(restartRequiredProps.has(prop))
@@ -333,7 +340,7 @@ function computeTreeData(
 							onClick={() => {
 								let propName = form.getFieldValue(`${newPropPath}.name`);
 								let propValue = form.getFieldValue(`${newPropPath}.value`);
-								if (!Object.prototype.hasOwnProperty.call(value, propName)) {
+								if (!value || !Object.prototype.hasOwnProperty.call(value, propName)) {
 									let newConfig = ConfigClass.fromJSON(config!.toJSON(), "control");
 									(newConfig as lib.Config<any>).setProp(fieldName, propName, null);
 									setConfig(newConfig);


### PR DESCRIPTION
Adds a new credential option to config entries and uses it to add a Factorio username and token config option to the controller and hosts. The purpose of this is to allow setting the Factorio username and token once in the controller config and have the hosts fetch it from the controller when they need it to start instances published on the server list.

Because we sometimes have large clusters with dozens of people donating hardware there's also an option for the controller to not share the token with hosts. In this case the token can be configured on each host, and instances assigned to a given host will use that token.

Since tokens are sensitive and more open sharing of config access has been something that hasn't been done solely because "it contains tokens" credential options function as write only configs that can't be read back remotely (unless configured so, which the factorio_token config is not configured to do). This doesn't really pose a problem because you rarely if ever need to read back the token once you've set it. I couldn't find any simple way to implement knowing if an optional credential is set or not, so there's no way to tell in the UI or API if a credential has been set remotely. Another consideration done is that the credentials are removed from server-settings.json after the Factorio server has started up, this is because copy and paste of whole instance folders is an expected use case for moving instances between hosts and even clusters, and the credentials shouldn't accidentally come along in this case.

Note that there's one caveat when using the Factorio username and token configs and that is if "username" and "token" is set in factorio.settings even if it's to empty strings they will take precedence and override the controller/host credentials.