### PR TITLE
Added 2.0 zip file name to version matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Many thanks to the following for contributing to this release:
 - Added `controller.factorio_username` and `controller.factorio_token` config to set Factorio credentials used for the whole cluster.
 - Added `controller.share_factorio_credential_with_hosts` config to optionally require hosts to provide their own credentials.
 - Added `host.factorio_username` and `host.factorio_token` config to set Factorio credentials used on a given host.
+- Fixed 2.0 version extraction from linux headless downloaded during installation of clusterio. [#671](https://github.com/clusterio/clusterio/pull/671)
 
 ### Breaking Changes
 

--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -746,7 +746,11 @@ async function downloadLinuxServer() {
 	const url = new URL(res.headers.location);
 	// get the filename of the latest factorio archive from redirected url
 	const filename = path.posix.basename(url.pathname);
-	const version = filename.match(/(?<=factorio_headless_x64_).*(?=\.tar\.xz)/)[0];
+	const match = filename.match(/(?<=factorio_headless_x64_|factorio-headless_linux_)\d+\.\d+\.\d+(?=\.tar\.xz)/);
+	if (!match || !match.length) {
+		throw Error(`Unable to extract version from filename: ${filename}`);
+	}
+	const version = match[0];
 
 	const tmpDir = "temp/create-temp/";
 	const archivePath = tmpDir + filename;


### PR DESCRIPTION
Adds support for the new zip file name used in 2.0. e.g. `factorio-headless_linux_2.0.10.tar.xz` vs the previous `factorio_headless_x64_1.1.110.tar.xz`

Also raises a more clear error message should there be another change in the future.

Fixes: Install problem ? #668