### PR TITLE
Update CI to support testing of multiple factorio versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        factorio-version: [1.1.110]
+        # Supported versions are latest stable/experimental and one minor version before stable (even if from a previous major) 
         node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
@@ -25,15 +27,16 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: pnpm i --no-frozen-lockfile
-    - run: wget -q -O factorio.tar.gz https://www.factorio.com/get-download/latest/headless/linux64 && tar -xf factorio.tar.gz && rm factorio.tar.gz
+    - name: Use Factorio ${{ matrix.factorio-version }}
+      run: wget -q -O factorio.tar.gz https://www.factorio.com/get-download/${{ matrix.factorio-version }}/headless/linux64 && tar -xf factorio.tar.gz && rm factorio.tar.gz
     - name: Run tests
-      if: ${{ matrix.node-version != '18.x' }}
+      if: ${{ matrix.node-version != '18.x' || matrix.factorio-version != '1.1.110' }}
       run: pnpm test
     - name: Run coverage
-      if: ${{ matrix.node-version == '18.x' }}
+      if: ${{ matrix.node-version == '18.x' && matrix.factorio-version == '1.1.110' }}
       run: pnpm run ci-cover
     - name : Upload coverage to Codecov
-      if: ${{ matrix.node-version == '18.x' }}
+      if: ${{ matrix.node-version == '18.x' && matrix.factorio-version == '1.1.110' }}
       uses: codecov/codecov-action@v4
       with:
         files: ./coverage/lcov.info


### PR DESCRIPTION
We have plans to support the latest version and one minor previous. 2.0 will be added as `latest` to CI once enough changes have been made to support it.