### PR TITLE
Mark RCON password as a credential

### DIFF
--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -398,8 +398,8 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			optional: true,
 		},
 		"factorio.rcon_password": {
-			credential: ["instance"],
-			description: "Password for RCON, randomly generated if null",
+			credential: ["host"],
+			description: "Password for RCON, randomly generated if null. Does not persist between host transfers.",
 			restartRequired: true,
 			type: "string",
 			optional: true,

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -398,6 +398,7 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			optional: true,
 		},
 		"factorio.rcon_password": {
+			credential: ["instance"],
 			description: "Password for RCON, randomly generated if null",
 			restartRequired: true,
 			type: "string",

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -398,8 +398,8 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			optional: true,
 		},
 		"factorio.rcon_password": {
-			credential: ["host"],
-			description: "Password for RCON, randomly generated if null. Does not persist between host transfers.",
+			credential: ["host", "controller"],
+			description: "Password for RCON, randomly generated if null.",
 			restartRequired: true,
 			type: "string",
 			optional: true,


### PR DESCRIPTION
Makes RCON password a credential field which can only be read by the instance.