### PR TITLE
Fix instance update

### DIFF
--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -924,9 +924,7 @@ export default class Controller {
 	addInstanceHooks(instance: InstanceInfo) {
 		instance.config.on("fieldChanged", (field: string, curr: any, prev: any) => {
 			instance.updatedAtMs = Date.now();
-			if (field === "instance.name") {
-				this.instances.set(instance); // Trigger updated logic
-			}
+			this.instances.set(instance); // Trigger update logic
 
 			lib.invokeHook(this.plugins, "onInstanceConfigFieldChanged", instance, field, curr, prev);
 		});

--- a/packages/lib/src/datastore.ts
+++ b/packages/lib/src/datastore.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 
 import { safeOutputFile } from "./file_ops";
 import { SubscribableValue } from "./subscriptions";
+import { logger } from "./logging";
 import { EventEmitter } from "stream";
 import { ControllerConfig } from "./config";
 import path from "path";
@@ -60,6 +61,7 @@ export class JsonDatastoreProvider<
 
 	// Save the data to the json file
 	async save(data: Map<K, V>) {
+		logger.verbose(`Saving ${this.filePath}`);
 		await safeOutputFile(this.filePath, JSON.stringify(Object.fromEntries(data), null, "\t"));
 	}
 
@@ -68,6 +70,7 @@ export class JsonDatastoreProvider<
 		// Read the raw json from the file
 		let rawJson;
 		try {
+			logger.verbose(`Loading ${this.filePath}`);
 			rawJson = JSON.parse(await fs.readFile(this.filePath, { encoding: "utf8" }));
 		} catch (err: any) {
 			if (err.code !== "ENOENT") {
@@ -101,6 +104,7 @@ export class JsonIdDatastoreProvider<
 
 	// Save the data to the json file
 	async save(data: Map<K, V>) {
+		logger.verbose(`Saving ${this.filePath}`);
 		await safeOutputFile(this.filePath, JSON.stringify([...data.values()], null, "\t"));
 	}
 
@@ -109,6 +113,7 @@ export class JsonIdDatastoreProvider<
 		// Read the raw json from the file
 		let rawJson;
 		try {
+			logger.verbose(`Loading ${this.filePath}`);
 			rawJson = JSON.parse(await fs.readFile(this.filePath, { encoding: "utf8" }));
 		} catch (err: any) {
 			if (err.code !== "ENOENT") {

--- a/test/controller/Controller.js
+++ b/test/controller/Controller.js
@@ -17,7 +17,9 @@ class MockInstanceConfig extends EventEmitter {
 	}
 
 	set(field, value) {
-		return this._data.set(field, value);
+		const prev = this.get(field);
+		this._data.set(field, value);
+		this.emit("fieldChanged", field, value, prev);
 	}
 }
 
@@ -177,6 +179,14 @@ describe("controller/src/Controller", function() {
 					() => controller.sendEvent(new MockEvent(), new Address(99, 99)),
 					new Error("Unknown address type 99")
 				);
+			});
+		});
+
+		describe(".instances", function() {
+			it("should set the dirty flag if the config is updated", function() {
+				controller.instances.dirty = false;
+				mockInstanceConfig.set("instance.assigned_host", null);
+				assert(controller.instances.dirty === true, "dirty flag was not set");
 			});
 		});
 	});


### PR DESCRIPTION
If only the config of an instance is updated the dirty flag of the instance is not set, which results in changes being discarded when the controller shuts down afterwards.

Fix by always triggering the update logic when an instance field is changed.