### PR TITLE
Use sync file writes and catch errors to reset state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Many thanks to the following for contributing to this release:
 - Added `host.factorio_username` and `host.factorio_token` config to set Factorio credentials used on a given host.
 - Fixed 2.0 version extraction from linux headless downloaded during installation of clusterio. [#671](https://github.com/clusterio/clusterio/pull/671)
 - Updated display name and description of `controller.external_address` to avoid confusion. [#674](https://github.com/clusterio/clusterio/pull/674)
+- Fixed invalid transient state during server start. [#676](https://github.com/clusterio/clusterio/issues/676)
 
 ### Breaking Changes
 


### PR DESCRIPTION
By using sync file writes it prevents interrupts between the state change and the server process starting. Also adding error catching to reset the state following an error writing to the files. Fixes: #676