### PR TITLE
Fix host being unable to sync user state to instances after controller connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Many thanks to the following for contributing to this release:
 - Added `host.factorio_username` and `host.factorio_token` config to set Factorio credentials used on a given host.
 - Fixed 2.0 version extraction from linux headless downloaded during installation of clusterio. [#671](https://github.com/clusterio/clusterio/pull/671)
 - Updated display name and description of `controller.external_address` to avoid confusion. [#674](https://github.com/clusterio/clusterio/pull/674)
+- Fixed host user sync to instances after reconnecting to the controller. [#678](https://github.com/clusterio/clusterio/pull/678)
 
 ### Breaking Changes
 

--- a/packages/lib/src/data/messages_instance.ts
+++ b/packages/lib/src/data/messages_instance.ts
@@ -864,7 +864,7 @@ export class InstanceDetailsChangedEvent {
 export class InstanceBanlistUpdateEvent {
 	declare ["constructor"]: typeof InstanceBanlistUpdateEvent;
 	static type = "event" as const;
-	static src = "controller" as const;
+	static src = ["controller", "host"] as const;
 	static dst = "instance" as const;
 
 	constructor(
@@ -887,7 +887,7 @@ export class InstanceBanlistUpdateEvent {
 export class InstanceAdminlistUpdateEvent {
 	declare ["constructor"]: typeof InstanceAdminlistUpdateEvent;
 	static type = "event" as const;
-	static src = "controller" as const;
+	static src = ["controller", "host"] as const;
 	static dst = "instance" as const;
 
 	constructor(
@@ -908,7 +908,7 @@ export class InstanceAdminlistUpdateEvent {
 export class InstanceWhitelistUpdateEvent {
 	declare ["constructor"]: typeof InstanceWhitelistUpdateEvent;
 	static type = "event" as const;
-	static src = "controller" as const;
+	static src = ["controller", "host"] as const;
 	static dst = "instance" as const;
 
 	constructor(


### PR DESCRIPTION
Updated the tests for host.handleSyncUserListsEvent to include message validation.
Fixed the sync events missing host as a possible source which would raise an error if a user was banned while the host was disconnected from the controller and the host reconnected while instances were running.