### PR TITLE
A number of small changes with minimal impact.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        node-version: [18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         factorio-version: [1.1.110]
         # Supported versions are latest stable/experimental and one minor version before stable (even if from a previous major) 
-        node-version: [18.x, 20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v4
@@ -26,7 +26,8 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: pnpm i --no-frozen-lockfile
+    - name: Prepare and install
+      run: pnpm i --no-frozen-lockfile
     - name: Use Factorio ${{ matrix.factorio-version }}
       run: wget -q -O factorio.tar.gz https://www.factorio.com/get-download/${{ matrix.factorio-version }}/headless/linux64 && tar -xf factorio.tar.gz && rm factorio.tar.gz
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Many thanks to the following for contributing to this release:
 - Changed default role selection to be a dropdown menu rather than id [#664](https://github.com/clusterio/clusterio/pull/664).
 - Added credential option to config entries to allow writing sensitive data that can't be read back remotely.
 - Allow hidden and readonly graphical representations of config values. [#665](https://github.com/clusterio/clusterio/pull/665).
+- Added option for silent testing which only shows the results, can be ran using `pnpm silent-test` [#655](https://github.com/clusterio/clusterio/pull/655).
 
 ### Changes
 
@@ -58,10 +59,11 @@ Many thanks to the following for contributing to this release:
 - Changed shutdown logic to prefer sending a /quit command via RCON instead of using diverging logic on Windows and Linux.
 - Fixed issues with subscriptions which prevented them from working on instances or generic events [#655](https://github.com/clusterio/clusterio/pull/655).
 - Fixed unreliable datastore tests [#662](https://github.com/clusterio/clusterio/pull/662).
-- Added option for silent tests.
 - Added `controller.factorio_username` and `controller.factorio_token` config to set Factorio credentials used for the whole cluster.
 - Added `controller.share_factorio_credential_with_hosts` config to optionally require hosts to provide their own credentials.
 - Added `host.factorio_username` and `host.factorio_token` config to set Factorio credentials used on a given host.
+- Changed `instance.rcon_password` config to be a credential field that can not be read by the control interface.
+- Changed `host.id` `instance.id` and `instance.assign_host` config to be hidden fields that can not be seen on the web ui.
 - Fixed 2.0 version extraction from linux headless downloaded during installation of clusterio. [#671](https://github.com/clusterio/clusterio/pull/671)
 - Updated display name and description of `controller.external_address` to avoid confusion. [#674](https://github.com/clusterio/clusterio/pull/674)
 - Fixed invalid transient state during server start. [#676](https://github.com/clusterio/clusterio/issues/676)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"build": "tsc --build",
 		"watch": "tsc --build --watch",
 		"test": "pnpm run build && mocha --check-leaks -R spec --recursive test \"plugins/*/test/**\" --exclude \"test/manual/**\"",
+		"silent-test": "SILENT_TEST=y pnpm test",
 		"fast-test": "FAST_TEST=y pnpm test",
 		"cover": "nyc pnpm test",
 		"fast-cover": "FAST_TEST=y nyc pnpm test",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "tsc --build",
 		"watch": "tsc --build --watch",
-		"test": "pnpm run build && mocha --check-leaks -R spec --recursive test \"plugins/*/test/**\" --exclude \"test/manual/**\"",
+		"test": "pnpm run build && mocha --enable-source-maps --check-leaks -R spec --recursive test \"plugins/*/test/**\" --exclude \"test/manual/**\"",
 		"silent-test": "SILENT_TEST=y pnpm test",
 		"fast-test": "FAST_TEST=y pnpm test",
 		"cover": "nyc pnpm test",

--- a/packages/web_ui/src/components/BaseConfigTree.tsx
+++ b/packages/web_ui/src/components/BaseConfigTree.tsx
@@ -44,7 +44,7 @@ function renderInput(inputComponents: Record<string, InputComponent>, def: lib.F
 	}
 	if (def.type === "string") {
 		if (def.credential) {
-			return <Input.Password autoComplete={def.autoComplete} disabled={readonly} />;
+			return <Input.Password autoComplete={def.autoComplete ?? "new-password"} disabled={readonly} />;
 		}
 		return <Input autoComplete={def.autoComplete} disabled={readonly} />;
 	}

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -13,7 +13,7 @@ const { wait } = lib;
 const testStrings = require("../lib/factorio/test_strings");
 const {
 	TestControl, TestControlConnector, url, controlToken, slowTest,
-	exec, execCtl, sendRcon, getControl, spawn, instancesDir, factorioDir,
+	exec, execCtl, sendRcon, getControl, spawnNode, instancesDir, factorioDir,
 } = require("./index");
 
 
@@ -29,7 +29,7 @@ async function checkInstanceStatus(id, status) {
 }
 
 async function spawnAltHost(config = "alt-host-config.json") {
-	return await spawn("alt-host:", `node ../../packages/host run --config ${config}`, /Started host/);
+	return await spawnNode("alt-host:", `../../packages/host run --config ${config}`, /Started host/);
 }
 
 async function startAltHost() {

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -179,7 +179,7 @@ async function exec(command, options = {}) {
 }
 
 async function execCtl(...args) {
-	args[0] = `node ../../packages/ctl ${args[0]}`;
+	args[0] = `node --enable-source-maps ../../packages/ctl ${args[0]}`;
 	return await exec(...args);
 }
 
@@ -219,6 +219,10 @@ function spawn(name, cmd, waitFor) {
 		process.stdout.pipe(stdout);
 		process.stderr.pipe(stderr);
 	});
+}
+
+async function spawnNode(name, cmd, waitFor) {
+	return await spawn(name, `node --enable-source-maps ${cmd}`, waitFor);
 }
 
 before(async function() {
@@ -302,7 +306,7 @@ before(async function() {
 	await exec("node ../../packages/controller bootstrap create-ctl-config test");
 	await exec("node ../../packages/ctl control-config set control.tls_ca ../../test/file/tls/cert.pem");
 
-	controllerProcess = await spawn("controller:", "node ../../packages/controller run", /Started controller/);
+	controllerProcess = await spawnNode("controller:", "../../packages/controller run", /Started controller/);
 
 	await execCtl("host create-config --id 4 --name host --generate-token");
 
@@ -310,7 +314,7 @@ before(async function() {
 	await exec(`node ../../packages/host config set host.factorio_directory ${relativeFactorioDir}`);
 	await exec("node ../../packages/host config set host.tls_ca ../../test/file/tls/cert.pem");
 
-	hostProcess = await spawn("host:", "node ../../packages/host run", /Started host/);
+	hostProcess = await spawnNode("host:", "../../packages/host run", /Started host/);
 
 	let tlsCa = await fs.readFile("test/file/tls/cert.pem");
 	let controlConnector = new TestControlConnector(url, 2, tlsCa);
@@ -366,6 +370,7 @@ module.exports = {
 	sendRcon,
 	getControl,
 	spawn,
+	spawnNode,
 
 	url,
 	controlToken,


### PR DESCRIPTION
Changes:
- Make silent testing accessible via `pnpm silent-test` similar to fast testing.
- Enable source maps during testing, this includes for spawns processes like host and controller.
- Add the new node LTS version to our test matrix, 18.x will continue to be supported until EoL.
- Add a default autoComplete for credential fields to fix issues with password autofill.
- Added missing items to the change log.

A single PR is justified by the minimal impact of all these changes. All changes have previously been discussed without objection and no new functionally has been added. The change to credential behaviour is not breaking because it was introduced in alpha 19 which has not been published.