### PR TITLE
Add config value to prevent use of script commands over rcon.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Many thanks to the following for contributing to this release:
 - Previously silent errors for controller.sendEvent now throw exceptions [#625](https://github.com/clusterio/clusterio/pull/625).
 - @clusterio/controller export InstanceInfo has added factorioVersion parameter.
 - Argument order for `Config.canAccess` changed to require an access mode passed as the second argument.
+- Instances can now have `factorio.enable_script_commands` disabled which will throw an error when any script command is used over rcon. [#681](https://github.com/clusterio/clusterio/pull/681).
 
 Many thanks to the following for contributing to this release:  
 [@CCpersonguy](https://github.com/CCpersonguy)

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -18,7 +18,7 @@ const scriptCommands = [
 	"/cheat", "/editor",
 	"/command", "/c",
 	"/measured-command", "/mc",
-	"/silent-command", "/sc"
+	"/silent-command", "/sc",
 ];
 
 const instanceRconCommandDuration = new lib.Histogram(
@@ -876,7 +876,7 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 		this._loadedSave = saveName;
 		await this.server.start(saveName);
 
-		if (this.config.get("factorio.enable_save_patching")) {
+		if (this.config.get("factorio.enable_save_patching") && this.config.get("factorio.enable_script_commands")) {
 			await this.server.disableAchievements();
 			await this.updateInstanceData();
 		} else {

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -14,6 +14,12 @@ import { exportData } from "./export";
 import type Host from "./Host";
 import BaseInstancePlugin from "./BaseInstancePlugin";
 
+const scriptCommands = [
+	"/cheat", "/editor",
+	"/command", "/c",
+	"/measured-command", "/mc",
+	"/silent-command", "/sc"
+];
 
 const instanceRconCommandDuration = new lib.Histogram(
 	"clusterio_instance_rcon_command_duration_seconds",
@@ -371,6 +377,16 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 	}
 
 	async sendRcon(message: string, expectEmpty = false, plugin = "") {
+		if (
+			!this.config.get("factorio.enable_script_commands")
+			&& scriptCommands.find(cmd => message.startsWith(cmd))
+		) {
+			throw new Error(
+				"Attempted to use script command while disabled. See config factorio.enable_script_commands.\n" +
+				`Command: ${message}`
+			);
+		}
+
 		let instanceId = String(this.id);
 		let observeDuration = instanceRconCommandDuration.labels(instanceId).startTimer();
 		try {

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -319,6 +319,7 @@ export interface InstanceConfigFields {
 	"factorio.player_online_autosave_slots": number;
 	"factorio.mod_pack_id": number | null;
 	"factorio.enable_save_patching": boolean;
+	"factorio.enable_script_commands": boolean;
 	"factorio.enable_whitelist": boolean;
 	"factorio.enable_authserver_bans": boolean;
 	"factorio.settings": Record<string, unknown>;
@@ -423,6 +424,15 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 		"factorio.enable_save_patching": {
 			description:
 				"Patch saves with Lua code. Required for Clusterio integrations, lua modules, and most plugins.",
+			restartRequired: true,
+			type: "boolean",
+			initialValue: true,
+		},
+		"factorio.enable_script_commands": {
+			description:
+				"Allows achievement breaking commands to be executed over rcon. " +
+				"Required for Clusterio integrations and most plugins. " +
+				"This does not prevent players using script commands.",
 			restartRequired: true,
 			type: "boolean",
 			initialValue: true,

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -433,7 +433,6 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 				"Allows achievement breaking commands to be executed over rcon. " +
 				"Required for Clusterio integrations and most plugins. " +
 				"This does not prevent players using script commands.",
-			restartRequired: true,
 			type: "boolean",
 			initialValue: true,
 		},

--- a/plugins/global_chat/instance.ts
+++ b/plugins/global_chat/instance.ts
@@ -16,6 +16,10 @@ export class InstancePlugin extends BaseInstancePlugin {
 	messageQueue: string[] = [];
 
 	async init() {
+		if (!this.instance.config.get("factorio.enable_script_commands")) {
+			throw new Error("global_chat plugin requires script commands.");
+		}
+
 		this.instance.handle(ChatEvent, this.handleChatEvent.bind(this));
 	}
 

--- a/plugins/inventory_sync/instance.ts
+++ b/plugins/inventory_sync/instance.ts
@@ -31,6 +31,12 @@ export class InstancePlugin extends BaseInstancePlugin {
 	disconnecting!: boolean;
 
 	async init() {
+		if (!this.instance.config.get("factorio.enable_save_patching")) {
+			throw new Error("inventory_sync plugin requires save patching.");
+		}
+		if (!this.instance.config.get("factorio.enable_script_commands")) {
+			throw new Error("inventory_sync plugin requires script commands.");
+		}
 		this.playersToRelease = new Set();
 		this.disconnecting = false;
 

--- a/plugins/research_sync/instance.ts
+++ b/plugins/research_sync/instance.ts
@@ -30,6 +30,9 @@ export class InstancePlugin extends BaseInstancePlugin {
 		if (!this.instance.config.get("factorio.enable_save_patching")) {
 			throw new Error("research_sync plugin requires save patching.");
 		}
+		if (!this.instance.config.get("factorio.enable_script_commands")) {
+			throw new Error("research_sync plugin requires script commands.");
+		}
 
 		this.instance.server.on("ipc-research_sync:contribution", (tech: IpcContribution) => {
 			this.researchContribution(tech).catch(err => this.unexpectedError(err));

--- a/plugins/statistics_exporter/instance.ts
+++ b/plugins/statistics_exporter/instance.ts
@@ -66,6 +66,9 @@ export class InstancePlugin extends BaseInstancePlugin {
 		if (!this.instance.config.get("factorio.enable_save_patching")) {
 			throw new Error("statistics_exporter plugin requires save patching.");
 		}
+		if (!this.instance.config.get("factorio.enable_script_commands")) {
+			throw new Error("statistics_exporter plugin requires script commands.");
+		}
 	}
 
 	async gatherMetrics() {

--- a/plugins/subspace_storage/instance.ts
+++ b/plugins/subspace_storage/instance.ts
@@ -20,6 +20,10 @@ export class InstancePlugin extends BaseInstancePlugin {
 	}
 
 	async init() {
+		if (!this.instance.config.get("factorio.enable_script_commands")) {
+			throw new Error("subspace_storage plugin requires script commands.");
+		}
+
 		this.pendingTasks = new Set();
 		this.instance.server.on("ipc-subspace_storage:output", (output: IpcItems) => {
 			this.provideItems(output).catch(err => this.unexpectedError(err));

--- a/test/mock.js
+++ b/test/mock.js
@@ -129,6 +129,7 @@ class MockInstance extends lib.Link {
 		this.mockConfigEntries = new Map([
 			["instance.id", 7357],
 			["factorio.enable_save_patching", true],
+			["factorio.enable_script_commands", true],
 		]);
 		this.config = {
 			get: (name) => {


### PR DESCRIPTION
The new config value, when disabled, will prevent the use of any script command over rcon, including `/sc`. This is designed to protect against the accidental disabling of achievements. This is a breaking change for most plugins as it will throw an error when a script command is used, although this only impacts the user experience of your plugin.

If your plugin uses any script command, then for the best user experience include the following within `async init` on your `InstancePlugin` class. (This is the same test you would perform for `factorio.enable_save_patching`)
```ts
if (!this.instance.config.get("factorio.enable_script_commands")) {
    throw new Error("plugin_name plugin requires script commands.");
}
```