### PR TITLE
Bump winston and resolve type error

### DIFF
--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -29,7 +29,7 @@
 		"jsonwebtoken": "^9.0.1",
 		"jszip": "^3.10.1",
 		"set-blocking": "^2.0.0",
-		"winston": "^3.10.0",
+		"winston": "^3.17.0",
 		"winston-daily-rotate-file": "^4.7.1",
 		"ws": "^8.13.0",
 		"yargs": "^17.7.2"
@@ -52,9 +52,9 @@
 		"react-router-dom": "^6.4.14",
 		"typescript": "^5.5.3",
 		"webpack": "^5.88.2",
+		"webpack-cli": "^5.1.4",
 		"webpack-dev-middleware": "^6.1.1",
-		"webpack-merge": "^5.9.0",
-		"webpack-cli": "^5.1.4"
+		"webpack-merge": "^5.9.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/ctl/package.json
+++ b/packages/ctl/package.json
@@ -24,7 +24,7 @@
 		"fs-extra": "^11.1.1",
 		"phin": "^3.7.0",
 		"set-blocking": "^2.0.0",
-		"winston": "^3.10.0",
+		"winston": "^3.17.0",
 		"yargs": "^17.7.2"
 	},
 	"publishConfig": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -29,7 +29,7 @@
 		"rcon-client": "^4.2.3",
 		"semver": "^7.5.4",
 		"set-blocking": "^2.0.0",
-		"winston": "^3.10.0",
+		"winston": "^3.17.0",
 		"winston-daily-rotate-file": "^4.7.1",
 		"yargs": "^17.7.2"
 	},

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -27,7 +27,7 @@
 		"set-blocking": "^2.0.0",
 		"triple-beam": "^1.4.1",
 		"winston": "^3.17.0",
-		"winston-transport": "^4.5.0",
+		"winston-transport": "^4.9.0",
 		"ws": "^8.13.0",
 		"yargs": "^17.7.2"
 	},

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -26,7 +26,7 @@
 		"klaw": "^4.1.0",
 		"set-blocking": "^2.0.0",
 		"triple-beam": "^1.4.1",
-		"winston": "^3.10.0",
+		"winston": "^3.17.0",
 		"winston-transport": "^4.5.0",
 		"ws": "^8.13.0",
 		"yargs": "^17.7.2"

--- a/packages/lib/src/logging.ts
+++ b/packages/lib/src/logging.ts
@@ -72,7 +72,7 @@ export class WebConsoleFormat {
 		public options = {}
 	) { }
 
-	transform(info: any, _options: object) {
+	transform(info: any, _options: unknown) {
 		let src = " ";
 		if (info.host_id !== undefined) {
 			src += `h:${info.host_name} - `;

--- a/packages/lib/src/logging_utils.ts
+++ b/packages/lib/src/logging_utils.ts
@@ -139,6 +139,10 @@ function formatServerOutput(parsed: ParsedFactorioOutput) {
 // These are defined here to avoid circular dependencies and pulling them
 // into the web interface code.
 
+export interface TerminalFormatOptions extends winston.Logform.ColorizeOptions {
+	showTimestamp?: boolean
+}
+
 /**
  * Formats winston log messages for a character terminal.
  */
@@ -146,12 +150,13 @@ export class TerminalFormat {
 	colorize: winston.Logform.Colorizer;
 
 	constructor(
-		public options: object = {}
+		public options: TerminalFormatOptions = {}
 	) {
 		this.colorize = winston.format.colorize(options);
 	}
 
-	transform(info: any, options: { showTimestamp: boolean }) {
+	transform(info: any, opts: unknown) {
+		const options = opts as TerminalFormatOptions;
 		info = this.colorize.transform(info, this.colorize.options);
 		let ts = "";
 		if (options.showTimestamp && info.timestamp) {


### PR DESCRIPTION
CI was broken by this [commit](https://github.com/winstonjs/logform/commit/55f3d8cf5df54faf881fa5270384c0c28a6bc2f2) to winston logform merged into v3.17 via this [PR](https://github.com/winstonjs/logform/pull/325).

This PR resolves the breaking change.