### PR TITLE
Add plugins automatically

### DIFF
--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -317,14 +317,7 @@ async function initialize(): Promise<InitializeParameters> {
 	}
 
 	logger.info(`Loading available plugins from ${args.pluginList}`);
-	let pluginList = new Map();
-	try {
-		pluginList = new Map(JSON.parse(await fs.readFile(args.pluginList, { encoding: "utf8" })));
-	} catch (err: any) {
-		if (err.code !== "ENOENT") {
-			throw err;
-		}
-	}
+	let pluginList = await lib.loadPluginList(args.pluginList);
 
 	// If the command is plugin management we don't try to load plugins
 	if (command === "plugin") {

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -13,6 +13,7 @@
 		"clusteriocontroller": "./dist/node/controller.js"
 	},
 	"keywords": [
+		"clusterio",
 		"factorio"
 	],
 	"engines": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -9,8 +9,8 @@
 		"clusteriocreate": "./create.js"
 	},
 	"keywords": [
-		"factorio",
-		"clusterio"
+		"clusterio",
+		"factorio"
 	],
 	"engines": {
 		"node": ">=18"

--- a/packages/create/templates/common/package.json
+++ b/packages/create/templates/common/package.json
@@ -8,6 +8,9 @@
 //%if !typescript
 	"main": "index.js",
 //%endif
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "__prepare__"
 	},

--- a/packages/create/templates/common/package.json
+++ b/packages/create/templates/common/package.json
@@ -8,9 +8,6 @@
 //%if !typescript
 	"main": "index.js",
 //%endif
-	"keywords": [
-		"clusterio-plugin"
-	],
 	"scripts": {
 		"prepare": "__prepare__"
 	},
@@ -51,6 +48,7 @@
 	},
 	"keywords": [
 		"clusterio",
+		"clusterio-plugin",
 		"factorio"
 	]
 }

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -188,14 +188,7 @@ async function startControl() {
 	lib.handleUnhandledErrors();
 
 	logger.verbose(`Loading available plugins from ${args.pluginList}`);
-	let pluginList = new Map();
-	try {
-		pluginList = new Map(JSON.parse(await fs.readFile(args.pluginList, "utf8")));
-	} catch (err: any) {
-		if (err.code !== "ENOENT") {
-			throw err;
-		}
-	}
+	let pluginList = await lib.loadPluginList(args.pluginList);
 
 	// If the command is plugin management we don't try to load plugins
 	if (args._[0] === "plugin") {

--- a/packages/ctl/package.json
+++ b/packages/ctl/package.json
@@ -13,6 +13,7 @@
 		"clusterioctl": "./dist/node/ctl.js"
 	},
 	"keywords": [
+		"clusterio",
 		"factorio"
 	],
 	"engines": {

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -147,14 +147,7 @@ async function startHost() {
 	}
 
 	logger.info(`Loading available plugins from ${args.pluginList}`);
-	let pluginList = new Map();
-	try {
-		pluginList = new Map(JSON.parse(await fs.readFile(args.pluginList, "utf8")));
-	} catch (err: any) {
-		if (err.code !== "ENOENT") {
-			throw err;
-		}
-	}
+	let pluginList = await lib.loadPluginList(args.pluginList);
 
 	// If the command is plugin management we don't try to load plugins
 	if (command === "plugin") {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -13,6 +13,7 @@
 		"clusteriohost": "./dist/node/host.js"
 	},
 	"keywords": [
+		"clusterio",
 		"factorio"
 	],
 	"engines": {

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -29,6 +29,7 @@ export * from "./src/system_collectors";
 export * from "./src/zip_ops";
 export * from "./src/subscriptions";
 export * from "./src/datastore";
+export * from "./src/load_plugin_list";
 
 export { default as ExponentialBackoff } from "./src/ExponentialBackoff";
 export { default as ModStore } from "./src/ModStore";

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -11,6 +11,7 @@
 	"main": "dist/node/index.js",
 	"browser": "browser.ts",
 	"keywords": [
+		"clusterio",
 		"factorio"
 	],
 	"engines": {

--- a/packages/lib/src/load_plugin_list.ts
+++ b/packages/lib/src/load_plugin_list.ts
@@ -96,17 +96,17 @@ async function findNpmPlugins(pluginList: Map<string, string>, pluginListPath: s
 		throw err;
 	}
 
+	if (!dependencies) {
+		return;
+	}
+
 	let changed = 0;
 	for (const [packageName, packageVersion] of Object.entries(dependencies)) {
 		if ([...pluginList.values()].includes(packageName)) {
 			continue; // This npm module is already in the plugin list
 		}
-		// Find the package in node_modules and read the package.json
-		const packageJsonPath = path.resolve("node_modules", packageName, "package.json");
-		const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: "utf8" }));
-		// Check if the package has the "clusterio-plugin" keyword
-		if (packageJson.keywords?.includes("clusterio-plugin")) {
-			// eslint-disable-next-line @typescript-eslint/no-var-requires
+		// Find the package in node_modules and read the package.json to check if it's a clusterio-plugin
+		if (await checkPackageJson(path.resolve("node_modules", packageName))) {
 			const pluginName = getPluginName(path.resolve("node_modules", packageName));
 			if (pluginList.has(pluginName)) {
 				logger.warn(

--- a/packages/lib/src/load_plugin_list.ts
+++ b/packages/lib/src/load_plugin_list.ts
@@ -74,8 +74,8 @@ async function findLocalPlugins(pluginList: Map<string, string>, pluginListPath:
 }
 
 function getPluginName(requireSpec: string) {
-	const context = vm.createContext({ require: require });
-	const code = `const pluginInfo = require(${JSON.stringify(requireSpec)}).plugin;`;
+	const context = vm.createContext({ require: require, pluginInfo: null });
+	const code = `pluginInfo = require(${JSON.stringify(requireSpec)}).plugin;`;
 	vm.runInContext(code, context);
 	return context.pluginInfo.name;
 }

--- a/packages/lib/src/load_plugin_list.ts
+++ b/packages/lib/src/load_plugin_list.ts
@@ -127,7 +127,7 @@ export async function loadPluginList(pluginListPath: string, findLocal = true): 
 		await findLocalPlugins(pluginList, pluginListPath);
 	}
 
-	// Optionally discover NPM plugins
+	// Discover NPM plugins
 	await findNpmPlugins(pluginList, pluginListPath);
 
 	return pluginList;

--- a/packages/lib/src/load_plugin_list.ts
+++ b/packages/lib/src/load_plugin_list.ts
@@ -1,0 +1,74 @@
+import fs from "fs-extra";
+import path from "path";
+import { logger } from "./logging";
+import * as libFileOps from "./file_ops";
+
+/**
+ * Find local plugins to add to the plugin list. This is primarily used during development.
+ */
+async function findLocalPlugins(pluginList: Map<string, string>, pluginListPath: string) {
+	// Check folders for plugins
+	const pluginFolders = [
+		path.join(process.cwd(), "plugins"),
+		path.join(process.cwd(), "external_plugins"),
+	];
+
+	let has_changed = 0;
+	for (const pluginFolder of pluginFolders) {
+		const pluginNames = await fs.readdir(pluginFolder);
+		for (const pluginName of pluginNames) {
+			if (pluginList.has(pluginName)) {
+				continue;
+			}
+			const pluginPath = path.resolve(pluginFolder, pluginName);
+			const stats = await fs.stat(pluginPath);
+			if (!stats.isDirectory()) {
+				continue;
+			}
+
+			// Check that the plugin has a package.json file
+			const packageJsonPath = path.resolve(pluginPath, "package.json");
+			if (!(await fs.exists(packageJsonPath))) {
+				continue;
+			}
+			console.log(`Adding ${pluginName} from ${pluginFolder}`);
+
+			pluginList.set(pluginName, pluginPath);
+			logger.info(`Added ${pluginName} from ${pluginFolder}`);
+			has_changed++;
+		}
+	}
+
+	if (has_changed > 0) {
+		await libFileOps.safeOutputFile(pluginListPath, JSON.stringify([...pluginList], null, "\t"));
+	}
+}
+
+/**
+ * Loads the plugin list from the specified file and optionally discovers local plugins
+ *
+ * @param pluginListPath - Path to the plugin list JSON file
+ * @param findLocal - Whether to look for local plugins in plugins/ and external_plugins/ directories
+ * @returns Map of plugin name to plugin path
+ */
+export async function loadPluginList(pluginListPath: string, findLocal = true): Promise<Map<string, string>> {
+	let pluginList = new Map<string, string>();
+
+	// Try to load existing plugin list
+	try {
+		pluginList = new Map(JSON.parse(await fs.readFile(pluginListPath, { encoding: "utf8" })));
+		logger.info(`Loaded ${pluginList.size} plugins from ${pluginListPath}`);
+	} catch (err: any) {
+		if (err.code !== "ENOENT") {
+			throw err;
+		}
+		logger.info(`No existing plugin list found at ${pluginListPath}`);
+	}
+
+	// Optionally discover local plugins
+	if (findLocal) {
+		await findLocalPlugins(pluginList, pluginListPath);
+	}
+
+	return pluginList;
+}

--- a/packages/lib/src/plugin_loader.ts
+++ b/packages/lib/src/plugin_loader.ts
@@ -30,7 +30,7 @@ export async function loadPluginInfos(pluginList: Map<string, string>) {
 		try {
 			require.resolve(pluginPath);
 		} catch (err) {
-			logger.warn(`Plugin path ${pluginPath} does not exist, not loading ${pluginName}`);
+			logger.error(`Plugin path ${pluginPath} does not exist, not loading ${pluginName}`);
 			pluginList.delete(pluginName);
 			continue;
 		}

--- a/packages/lib/src/plugin_loader.ts
+++ b/packages/lib/src/plugin_loader.ts
@@ -26,6 +26,15 @@ export async function loadPluginInfos(pluginList: Map<string, string>) {
 		let pluginInfo: libPlugin.PluginNodeEnvInfo;
 		let pluginPackage: { name?: string, version: string, main?: string, private?: boolean };
 
+		// Check if plugin path exists, otherwise remove it
+		try {
+			require.resolve(pluginPath);
+		} catch (err) {
+			logger.warn(`Plugin path ${pluginPath} does not exist, removing ${pluginName}`);
+			pluginList.delete(pluginName);
+			continue;
+		}
+
 		try {
 			pluginInfo = require(pluginPath).plugin;
 			pluginPackage = require(path.posix.join(pluginPath, "package.json"));

--- a/packages/lib/src/plugin_loader.ts
+++ b/packages/lib/src/plugin_loader.ts
@@ -30,7 +30,7 @@ export async function loadPluginInfos(pluginList: Map<string, string>) {
 		try {
 			require.resolve(pluginPath);
 		} catch (err) {
-			logger.warn(`Plugin path ${pluginPath} does not exist, removing ${pluginName}`);
+			logger.warn(`Plugin path ${pluginPath} does not exist, not loading ${pluginName}`);
 			pluginList.delete(pluginName);
 			continue;
 		}

--- a/packages/web_ui/package.json
+++ b/packages/web_ui/package.json
@@ -10,7 +10,8 @@
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"keywords": [
-		"clusterio"
+		"clusterio",
+		"factorio"
 	],
 	"engines": {
 		"node": ">=12"

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -8,7 +8,9 @@
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
 	"keywords": [
-		"clusterio-plugin"
+		"clusterio",
+		"clusterio-plugin",
+		"factorio"
 	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",
 		"test": "echo \"Error: run tests from root\" && exit 1"

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -8,7 +8,9 @@
 	"repository": "clusterio/factorioClusterio",
 	"main": "dist/node/index.js",
 	"keywords": [
-		"clusterio-plugin"
+		"clusterio",
+		"clusterio-plugin",
+		"factorio"
 	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"repository": "clusterio/factorioClusterio",
 	"main": "dist/node/index.js",
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",
 		"test": "echo \"Error: run tests from root\" && exit 1"

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -8,7 +8,9 @@
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
 	"keywords": [
-		"clusterio-plugin"
+		"clusterio",
+		"clusterio-plugin",
+		"factorio"
 	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",
 		"test": "echo \"Error: run tests from root\" && exit 1"

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -8,7 +8,9 @@
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
 	"keywords": [
-		"clusterio-plugin"
+		"clusterio",
+		"clusterio-plugin",
+		"factorio"
 	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",
 		"test": "echo \"Error: run tests from root\" && exit 1"

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -8,7 +8,9 @@
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
 	"keywords": [
-		"clusterio-plugin"
+		"clusterio",
+		"clusterio-plugin",
+		"factorio"
 	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",
 		"test": "echo \"Error: run tests from root\" && exit 1"

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -8,7 +8,9 @@
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
 	"keywords": [
-		"clusterio-plugin"
+		"clusterio",
+		"clusterio-plugin",
+		"factorio"
 	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -7,6 +7,9 @@
 	"license": "MIT",
 	"repository": "clusterio/clusterio",
 	"main": "dist/node/index.js",
+	"keywords": [
+		"clusterio-plugin"
+	],
 	"scripts": {
 		"prepare": "tsc --build && webpack-cli --env production",
 		"test": "echo \"Error: run tests from root\" && exit 1"

--- a/test/lib/plugin_loader.js
+++ b/test/lib/plugin_loader.js
@@ -198,6 +198,22 @@ describe("lib/plugin_loader", function() {
 			assert.strictEqual(pluginList.get("monorepo-plugin"), monorepoPluginPathAbs);
 		});
 
+		it("should not throw when package.json has no dependencies field", async function() {
+			// Create a package.json without dependencies
+			await fs.outputFile(
+				path.join("package.json"),
+				JSON.stringify({
+					name: "test-package",
+					version: "1.0.0",
+				})
+			);
+
+			// Should not throw
+			await assert.doesNotReject(async () => {
+				await lib.loadPluginList(pluginListPath, true);
+			});
+		});
+
 		after(async function() {
 			process.chdir(old_cwd);
 			await fs.remove(baseDir);

--- a/test/lib/plugin_loader.js
+++ b/test/lib/plugin_loader.js
@@ -33,11 +33,9 @@ describe("lib/plugin_loader", function() {
 			await writePlugin(invalidPlugin, "wrong");
 		});
 
-		it("should throw on missing plugin", async function() {
-			await assert.rejects(
-				lib.loadPluginInfos(new Map([["missing", missingPlugin]]), []),
-				new RegExp(`^Error: PluginError: Cannot find module '${escapeRegExp(missingPlugin)}'`)
-			);
+		it("should ignore missing plugins", async function() {
+			const result = await lib.loadPluginInfos(new Map([["missing", missingPlugin]]), []);
+			assert.deepEqual(result, []);
 		});
 		it("should load test plugin", async function() {
 			assert.deepEqual(

--- a/test/lib/plugin_loader.js
+++ b/test/lib/plugin_loader.js
@@ -133,7 +133,7 @@ describe("lib/plugin_loader", function() {
 					JSON.stringify({
 						name: path.basename(pluginPath),
 						version: "0.0.1",
-						keywords: ["clusterio-plugin"]
+						keywords: ["clusterio-plugin"],
 					})
 				);
 			}
@@ -149,8 +149,8 @@ describe("lib/plugin_loader", function() {
 				path.join(baseDir, "package.json"),
 				JSON.stringify({
 					dependencies: {
-						"npm-plugin": "^1.0.0"
-					}
+						"npm-plugin": "^1.0.0",
+					},
 				})
 			);
 
@@ -176,14 +176,13 @@ describe("lib/plugin_loader", function() {
 		it("should load existing plugin list", async function() {
 			const existingList = new Map([["test", "/test/path"]]);
 			await fs.outputFile(pluginListPath, JSON.stringify([...existingList]));
-			const pluginList = await lib.loadPluginList(pluginListPath, false);
-			assert.ok(pluginList.has("test"));
-			assert.strictEqual(pluginList.get("test"), "/test/path");
+			const loadedPlugins = await lib.loadPluginList(pluginListPath, false);
+			assert.ok(loadedPlugins.has("test"));
+			assert.strictEqual(loadedPlugins.get("test"), "/test/path");
 		});
 
 		after(async function() {
 			process.chdir(old_cwd);
-			console.log(baseDir, process.cwd());
 			await fs.remove(baseDir);
 		});
 	});


### PR DESCRIPTION
Adds detected plugins automatically on startup. Collisions are handled by name, priority is as follows:
1. Plugins in plugin-list.json, added using existing command or earlier discovery run
2. Plugins in /plugins
3. Plugins in /external_plugins
4. Plugins in the package.json dependencies field - these are where our users would typically have their plugins after installing with `npm install -S @clusterio/plugin-subspace_storage`

Similarly, during development plugins installed with `pnpm i xxxx -w` will get automatically added as well.

Plugins are enabled by default. Opting out of plugins during development is now done by disabling the unwanted plugins in the web interface.

This is preparation for a future PR where it is planned to add the ability to update/install plugins from npm. A restart will still be required to apply them.

## Changelog

```markdown
### Features
- Automatically add plugins from ./plugins, ./external_plugins and installed npm modules [#692](https://github.com/clusterio/clusterio/pull/692)

### Breaking changes
- Plugins now require the keyword "clusterio-plugin" in package.json to be automatically loaded [#692](https://github.com/clusterio/clusterio/pull/692)
```