### PR TITLE
Add connect to server button to web UI using steam launch api

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ After completing the installation start up the controller and at least one host 
 The installer provides the `run-controller` and `run-host` scripts to make this simple.
 Once the controller process is running you can log into the web interface which is hosted by default on http://localhost:8080/ (adjust the port number if you changed it), use the admin authentication token provided from the installation to log in.
 
-The basics of setting up a Factorio server from the web interface is to create an instance, assign it to a host and then click start.
+The basics of setting up a Factorio server from the web interface is to create an instance, assign it to a host and then click start. You can also use the "Connect via Steam" button to launch Factorio directly and connect to the server using Steam's protocol handler.
 
 ### Running via Systemd
 

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -23,6 +23,7 @@ import { useInstance } from "../model/instance";
 import { useHost } from "../model/host";
 import InstanceStatusTag from "./InstanceStatusTag";
 import Link from "./Link";
+import { instancePublicAddress } from "../util/instance";
 
 type MenuItem = Required<MenuProps>["items"][number];
 const { Title } = Typography;
@@ -73,6 +74,7 @@ function InstanceButtons(props: { instance: lib.InstanceDetails }) {
 	let [exportingData, setExportingData] = useState(false);
 	let instance = props.instance;
 	let instanceId = instance.id!;
+	let [host] = useHost(instance.assignedHost);
 
 	let instanceButtonMenuItems: MenuItem[] = [];
 	if (account.hasPermission("core.instance.export_data")) {
@@ -156,6 +158,17 @@ function InstanceButtons(props: { instance: lib.InstanceDetails }) {
 			account.hasAnyPermission("core.instance.start", "core.instance.stop")
 			&& <StartStopInstanceButton instance={instance} />
 		}
+		<Button
+			onClick={() => {
+				const address = instancePublicAddress(instance, host);
+				if (address) {
+					window.location.href = `steam://run/427520//--mp-connect=${address}`;
+				}
+			}}
+			disabled={instance.status !== "running" || !instancePublicAddress(instance, host)}
+		>
+			Connect via Steam
+		</Button>
 		{account.hasPermission("core.instance.load_scenario") && <LoadScenarioModal instance={instance} />}
 		{account.hasAnyPermission(
 			"core.instance.export_data",

--- a/packages/web_ui/src/util/instance.ts
+++ b/packages/web_ui/src/util/instance.ts
@@ -1,0 +1,11 @@
+import * as lib from "@clusterio/lib";
+
+export function instancePublicAddress(instance: lib.InstanceDetails, host?: lib.HostDetails | null) {
+	if (instance.assignedHost === undefined || !host || !host.publicAddress) {
+		return "";
+	}
+	if (instance.gamePort === undefined) {
+		return host.publicAddress;
+	}
+	return `${host.publicAddress}:${instance.gamePort}`;
+} 

--- a/packages/web_ui/src/util/instance.ts
+++ b/packages/web_ui/src/util/instance.ts
@@ -8,4 +8,4 @@ export function instancePublicAddress(instance: lib.InstanceDetails, host?: lib.
 		return host.publicAddress;
 	}
 	return `${host.publicAddress}:${instance.gamePort}`;
-} 
+}


### PR DESCRIPTION
Does not work if factorio is already open. Resolves #608

![image](https://github.com/user-attachments/assets/46f30c3a-975b-407d-a909-f58a48592bb0)

I considered adding it to the server list as well, but I think that might just be extra vlsual clutter - you can't rapidly connect to multiple servers anyways. Hooking into the lua connect_to_server api can be done in the future, but I am not planning to include it here.

## Changelog
```
### Features
- Add "connect to server" button to web interface, launcehs with steam api [#608](https://github.com/clusterio/clusterio/issues/608)
```
