### PR TITLE
Recreate instance's required subfolders on startup

### DIFF
--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -641,6 +641,7 @@ export default class Host extends lib.Link {
 		} else {
 			instanceInfo = this.discoveredInstanceInfos.get(instanceId);
 			if (instanceInfo) {
+				await Instance.populate_folders(instanceInfo.path);
 				instanceInfo.config.update(config, true, "controller");
 
 			} else {
@@ -650,7 +651,7 @@ export default class Host extends lib.Link {
 				let instanceDir = await this._createNewInstanceDir(instanceConfig.get("instance.name"));
 
 				logger.info(`Creating ${instanceDir}`);
-				await Instance.create(instanceDir, this.config.get("host.factorio_directory"));
+				await Instance.populate_folders(instanceDir);
 				instanceInfo = {
 					path: instanceDir,
 					config: instanceConfig,

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -661,14 +661,12 @@ rcon.print(game.table_to_json(players))`.replace(/\r?\n/g, " ");
 	/**
 	 * Creates a new empty instance directory
 	 *
-	 * Creates the neccessary files for starting up a new instance into the
-	 * provided instance directory.
+	 * Ensures the neccessary files for starting up a new instance into the
+	 * provided instance directory are present.
 	 *
 	 * @param instanceDir -
-	 *     Directory to create the new instance into.
-	 * @param factorioDir - Path to factorio installation.
 	 */
-	static async create(instanceDir: string, factorioDir: string) {
+	static async populate_folders(instanceDir: string) {
 		await fs.ensureDir(path.join(instanceDir, "script-output"));
 		await fs.ensureDir(path.join(instanceDir, "saves"));
 	}


### PR DESCRIPTION
Fixes #698

## Changelog
```
### Bugfixes
- Fix instance crash when missing saves folder [#698](https://github.com/clusterio/clusterio/issues/698)
```
