### PR TITLE
Time Format

### DIFF
--- a/packages/web_ui/src/util/time_format.ts
+++ b/packages/web_ui/src/util/time_format.ts
@@ -27,7 +27,7 @@ export function formatDuration(ms: number): string {
 		result += formatMinute(Math.floor(ms / 60e3));
 		ms %= 60e3;
 	}
-	result += formatSecond(Math.round(ms / 1e3));
+	result += formatSecond(Math.floor(ms / 1e3));
 	return result;
 }
 


### PR DESCRIPTION
[#723](https://github.com/clusterio/clusterio/issues/723)

### Changes
- use floor instead of round to prevent something like 1 minute and 60 seconds to happen