### PR TITLE
Don't write input stats to both input and output

### DIFF
--- a/plugins/statistics_exporter/instance.ts
+++ b/plugins/statistics_exporter/instance.ts
@@ -98,7 +98,7 @@ function setForceFlowStatistic(
 			statisticName,
 			reverseDirection,
 			item
-		).set(value);
+		);
 	}
 }
 

--- a/plugins/statistics_exporter/test/plugin.js
+++ b/plugins/statistics_exporter/test/plugin.js
@@ -66,9 +66,19 @@ describe("statistics_exporter plugin", function() {
 				assert.equal(instance._instanceForceFlowStatistics.labels(
 					"7357", "nauvis", "player", "item_production_statistics", "input", "inserter").get(),
 				10);
+				assert.equal(instance._instanceForceFlowStatistics.labels(
+					"7357", "nauvis", "player", "item_production_statistics", "output", "iron-plate").get(),
+				24);
+				// Assert that it didn't record inserter consumption as production
+				assert.equal(instance._instanceForceFlowStatistics.labels(
+					"7357", "nauvis", "player", "item_production_statistics", "output", "inserter").get(),
+				0);
 				assert.equal(instance._instanceGameFlowStatistics.labels(
 					"7357", "nauvis", "pollution_statistics", "input", "boiler").get(),
 				2000);
+				assert.equal(instance._instanceGameFlowStatistics.labels(
+					"7357", "nauvis", "pollution_statistics", "output", "tree-proxy").get(),
+				560);
 				assert.equal(instance._instancePlatformMapping.labels(
 					"7357", "platform-1", "player", "nauvis").get(),
 				1);


### PR DESCRIPTION
Describe why and what has been changed by this pullrequest, feel free to also ask for input on decisions you are unsure about etc.
The changelog lines below will be copied directly from merged pull requests to the changelog on new releases. Changes are expected to preferrentially link to the associated issues. If there are no relevant issues, link to the pull request itself.

## Changelog
```
### Fixes
- Fixed production statistics overwriting consumption statistics and vise versa [#734](https://github.com/clusterio/clusterio/pulls/734)
```
