### PR TITLE
Add default mod packs

### DIFF
--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -127,6 +127,10 @@ export default class Controller {
 			lib.ModPack.fromJSON.bind(lib.ModPack)
 		).bootstrap());
 
+		if (modPacks.size === 0) {
+			modPacks.setMany(lib.ModPack.defaultModPacks);
+		}
+
 		const userManager = new UserManager(config);
 		await userManager.load(path.join(databaseDirectory, "users.json"));
 

--- a/packages/lib/src/data/ModPack.ts
+++ b/packages/lib/src/data/ModPack.ts
@@ -383,6 +383,27 @@ export default class ModPack {
 		}
 	}
 
+	/** Array of default mod packs which should exist on a newly installed cluster */
+	static defaultModPacks = [
+		...["0.17", "0.18", "1.0", "1.1", "2.0"]
+			.map(version => this.fromJSON({
+				name: `Base Game ${version}`,
+				description: `Factorio ${version} with no extra mods.`,
+				factorio_version: version,
+			} as any)),
+		...["2.0"]
+			.map(version => this.fromJSON({
+				name: `Space Age ${version}`,
+				description: `Factorio ${version} with Space Age expansion.`,
+				factorio_version: version,
+				mods: [
+					{ name: "elevated-rails", enabled: true, version },
+					{ name: "quality", enabled: true, version },
+					{ name: "space-age", enabled: true, version },
+				],
+			} as any)),
+	];
+
 	/**
 	 * Returns an array of ModInfo containing all mods included in factorio
 	 *

--- a/packages/lib/src/datastore.ts
+++ b/packages/lib/src/datastore.ts
@@ -189,6 +189,11 @@ export abstract class Datastore<
 		return this.data.get(key);
 	}
 
+	// Allow getting the size of the datastore
+	get size() {
+		return this.data.size;
+	}
+
 	// Allow iterating through the datastore like a Map.
 	[Symbol.iterator](): IterableIterator<[K, Readonly<V>]> {
 		return this.data.entries();

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -1072,8 +1072,15 @@ describe("Integration of Clusterio", function() {
 		});
 
 		describe("mod-pack list", function() {
+			let result = null;
 			it("runs", async function() {
-				await execCtl("mod-pack list");
+				result = await execCtl("mod-pack list");
+			});
+			it("contains defaults", function() {
+				assert(result !== null, "Failed to return a value");
+				const stdout = result.stdout.trim();
+				assert(stdout.indexOf("Base Game") >= 0, "No base game pack");
+				assert(stdout.indexOf("Space Age") >= 0, "No space age pack");
 			});
 		});
 

--- a/test/lib/data/ModPack.js
+++ b/test/lib/data/ModPack.js
@@ -378,6 +378,24 @@ describe("lib/data/ModPack", function() {
 				/* eslint-enable indent */
 			});
 		});
+		describe("defaultModPacks", function() {
+			it("should contain at least one base game only", function() {
+				const modPack = ModPack.defaultModPacks.find(pack => {
+					const base = pack.mods.get("base");
+					const spaceAge = pack.mods.get("space-age");
+					return base && base.enabled && (!spaceAge || !spaceAge.enabled);
+				});
+				assert(modPack, "Does not contain base game only");
+			});
+			it("should contain at least one space age expansion", function() {
+				const modPack = ModPack.defaultModPacks.find(pack => {
+					const base = pack.mods.get("base");
+					const spaceAge = pack.mods.get("space-age");
+					return base && base.enabled && spaceAge && spaceAge.enabled;
+				});
+				assert(modPack, "Does not contain space age expansion");
+			});
+		});
 		describe("getBuiltinMods()", function() {
 			it("should work with versions before 2.0", function() {
 				const builtinMods = ModPack.getBuiltinMods("1.1");

--- a/test/lib/datastore.js
+++ b/test/lib/datastore.js
@@ -413,6 +413,22 @@ describe("lib/datastore", function() {
 			});
 		});
 
+		describe("size", function() {
+			it("returns the correct size", function() {
+				assert.equal(datastore.size, 3);
+			});
+		});
+
+		describe("iterator", function() {
+			it("iterates all values", function() {
+				const entries = [];
+				for (const entry of datastore) {
+					entries.push(entry);
+				}
+				assert.deepEqual(entries, [...datastoreProvider.value.entries()]);
+			});
+		});
+
 		describe("values", function() {
 			it("returns all values", function() {
 				assert.deepEqual([...datastore.values()], [...datastoreProvider.value.values()]);


### PR DESCRIPTION
Closes: #719 
When a cluster is first created (has no mod packs) a set of default mod packs will be added which includes space age and base game for all valid versions. These values are hardcoded because they are not expected to change often and it has been done in the same location as `getBuiltinMods` to keep all version specific code to a single location. Also added a missing test for datastore as I needed to add `get size` to the class and was in the test file.

## Changelog
```
### Features
- A fresh install of Clusterio will include default mod packs. [#719](https://github.com/clusterio/clusterio/issues/719)
```
