### PR TITLE
Add bulk user actions (Import/Export/Restore)

### DIFF
--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -914,7 +914,9 @@ export default class ControlConnection extends BaseConnection {
 				if (user.isBanned) {
 					send = true;
 					userToSend.is_banned = true;
-					userToSend.ban_reason = user.banReason;
+					if (user.banReason !== "") {
+						userToSend.ban_reason = user.banReason;
+					}
 				}
 				if (user.isAdmin) {
 					send = true;
@@ -934,7 +936,7 @@ export default class ControlConnection extends BaseConnection {
 			const usersToSend = [] as Array<string | { username: string, reason: string }>;
 			for (const user of this._controller.userManager.users.values()) {
 				if (user.isBanned) {
-					if (user.banReason) {
+					if (user.banReason && user.banReason !== "") {
 						usersToSend.push({ username: user.name, reason: user.banReason });
 					} else {
 						usersToSend.push(user.name);

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -116,6 +116,8 @@ export default class ControlConnection extends BaseConnection {
 		this.handle(lib.UserSetBannedRequest, this.handleUserSetBannedRequest.bind(this));
 		this.handle(lib.UserSetWhitelistedRequest, this.handleUserSetWhitelistedRequest.bind(this));
 		this.handle(lib.UserDeleteRequest, this.handleUserDeleteRequest.bind(this));
+		this.handle(lib.UserBulkImportRequest, this.handleUserBulkImportRequest.bind(this));
+		this.handle(lib.UserBulkExportRequest, this.handleUserBulkExportRequest.bind(this));
 		this.handle(lib.DebugDumpWsRequest, this.handleDebugDumpWsRequest.bind(this));
 	}
 
@@ -750,6 +752,15 @@ export default class ControlConnection extends BaseConnection {
 		if (user.isBanned) {
 			this._controller.sendTo("allInstances", new lib.InstanceBanlistUpdateEvent(name, false, ""));
 		}
+	}
+
+	async handleUserBulkImportRequest(request: lib.UserBulkImportRequest) {
+		logger.info(`handleUserBulkImportRequest ${JSON.stringify(request)}`);
+	}
+
+	async handleUserBulkExportRequest(request: lib.UserBulkExportRequest) {
+		logger.info(`handleUserBulkExportRequest ${JSON.stringify(request)}`);
+		return [] as any;
 	}
 
 	async handleDebugDumpWsRequest(request: lib.DebugDumpWsRequest) {

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -901,7 +901,7 @@ export default class ControlConnection extends BaseConnection {
 			lib.Address.fromShorthand("allHosts")
 		);
 
-		return backup;
+		return backup ?? [];
 	}
 
 	async handleUserBulkExportRequest(request: lib.UserBulkExportRequest) {

--- a/packages/ctl/src/commands.ts
+++ b/packages/ctl/src/commands.ts
@@ -1873,7 +1873,7 @@ async function handleImportOrRestore(args: {
 
 	print(`${restore ? "Restored" : "Imported"} ${importType} from ${args.filepath}`);
 	if (restore && backup && !args.noBackup) {
-		fs.writeJSON(`${importType}-backup.json`, backup, { spaces: 2 });
+		await fs.writeJSON(`${importType}-backup.json`, backup, { spaces: 2 });
 		print(`Wrote backup to ${importType}-backup.json`);
 	}
 }
@@ -1897,10 +1897,10 @@ userCommands.add(new lib.Command({
 	definition: ["restore <filepath>", "Restore user data from a file", (yargs) => {
 		yargs.positional("filepath", { describe: "Path to the file to import", type: "string" });
 		yargs.options({
-			"users": { describe: "Import users json", nargs: 0, type: "boolean", default: false },
-			"bans": { describe: "Import banlist json", nargs: 0, type: "boolean", default: false },
-			"admins": { describe: "Import adminlist json", nargs: 0, type: "boolean", default: false },
-			"whitelist": { describe: "Import whitelist json", nargs: 0, type: "boolean", default: false },
+			"users": { describe: "Restore users json", nargs: 0, type: "boolean", default: false },
+			"bans": { describe: "Restore banlist json", nargs: 0, type: "boolean", default: false },
+			"admins": { describe: "Restore adminlist json", nargs: 0, type: "boolean", default: false },
+			"whitelist": { describe: "Restore whitelist json", nargs: 0, type: "boolean", default: false },
 			"no-backup": { describe: "Don't save a backup to the cwd", nargs: 0, type: "boolean", default: false },
 		});
 	}],
@@ -1913,17 +1913,19 @@ userCommands.add(new lib.Command({
 	definition: ["export <filepath>", "Export user data to a file", (yargs) => {
 		yargs.positional("filepath", { describe: "Path to the file to save to", type: "string" });
 		yargs.options({
-			"bans": { describe: "Import banlist json", nargs: 0, type: "boolean", default: false },
-			"admins": { describe: "Import adminlist json", nargs: 0, type: "boolean", default: false },
-			"whitelist": { describe: "Import whitelist json", nargs: 0, type: "boolean", default: false },
+			"users": { describe: "Export users json", nargs: 0, type: "boolean", default: false },
+			"bans": { describe: "Export banlist json", nargs: 0, type: "boolean", default: false },
+			"admins": { describe: "Export adminlist json", nargs: 0, type: "boolean", default: false },
+			"whitelist": { describe: "Export whitelist json", nargs: 0, type: "boolean", default: false },
 		});
 	}],
 	handler: async function(args: {
 		filepath: string,
+		users: boolean,
 		bans: boolean,
 		admins: boolean,
 		whitelist: boolean,
-	}, control: any) {
+	}, control: Control) {
 		let exportType = "users" as ConstructorParameters<typeof lib.UserBulkExportRequest>[0];
 		const optionCount = [args.bans, args.admins, args.whitelist]
 			.reduce((acc, bool) => (bool ? acc + 1 : acc), 0);
@@ -1933,7 +1935,9 @@ userCommands.add(new lib.Command({
 		}
 
 		// Assign based on options or attempt to guess based on filename
-		if (args.bans) {
+		if (args.users) {
+			exportType = "users";
+		} else if (args.bans) {
 			exportType = "bans";
 		} else if (args.admins) {
 			exportType = "admins";

--- a/packages/lib/src/data/messages_user.ts
+++ b/packages/lib/src/data/messages_user.ts
@@ -394,10 +394,10 @@ export class UserBulkImportRequest {
 		}
 	}
 
-	static Response = plainJson(Type.Optional(Type.Union([
+	static Response = plainJson(Type.Union([
 		Type.Array(ClusterioUserExport.factorioUserSchema),
 		ClusterioUserExport.jsonSchema,
-	])));
+	]));
 
 	constructor(
 		public importType: "users" | "bans" | "admins" | "whitelist",

--- a/packages/lib/src/data/messages_user.ts
+++ b/packages/lib/src/data/messages_user.ts
@@ -394,6 +394,11 @@ export class UserBulkImportRequest {
 		}
 	}
 
+	static Response = plainJson(Type.Optional(Type.Union([
+		Type.Array(ClusterioUserExport.factorioUserSchema),
+		ClusterioUserExport.jsonSchema,
+	])));
+
 	constructor(
 		public importType: "users" | "bans" | "admins" | "whitelist",
 		public users: Static<typeof ClusterioUserExport.clusterioUserSchema>[]

--- a/packages/lib/src/link/messages.ts
+++ b/packages/lib/src/link/messages.ts
@@ -118,4 +118,6 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	user.UserSetBannedRequest,
 	user.UserDeleteRequest,
 	user.UserUpdatesEvent,
+	user.UserBulkImportRequest,
+	user.UserBulkExportRequest,
 ];

--- a/packages/lib/src/permissions.ts
+++ b/packages/lib/src/permissions.ts
@@ -495,6 +495,12 @@ definePermission({
 	description: "Bulk export users including admin, whitelist, and bans.",
 });
 definePermission({
+	name: "core.user.bulk_restore",
+	title: "Bulk user restore",
+	description: "Bulk restore users including admin, whitelist, and bans.",
+});
+
+definePermission({
 	name: "core.log.follow",
 	title: "Follow cluster log",
 	description: "Receive new entries in the cluster log.  Required to see instance console.",

--- a/packages/lib/src/permissions.ts
+++ b/packages/lib/src/permissions.ts
@@ -487,7 +487,8 @@ definePermission({
 definePermission({
 	name: "core.user.bulk_import",
 	title: "Bulk user import",
-	description: "Bulk import users including admin, whitelist, and bans.",
+	description: "Bulk import users including admin, whitelist, and bans." +
+	" (Imports types are restricted by other permissions, e.g. core.user.set_admin)",
 });
 definePermission({
 	name: "core.user.bulk_export",
@@ -497,7 +498,8 @@ definePermission({
 definePermission({
 	name: "core.user.bulk_restore",
 	title: "Bulk user restore",
-	description: "Bulk restore users including admin, whitelist, and bans.",
+	description: "Bulk restore users including admin, whitelist, and bans." +
+	" (Restore types are restricted by other permissions, e.g. core.user.set_admin)",
 });
 
 definePermission({

--- a/packages/lib/src/permissions.ts
+++ b/packages/lib/src/permissions.ts
@@ -485,6 +485,16 @@ definePermission({
 	description: "Delete users and all data stored for them.",
 });
 definePermission({
+	name: "core.user.bulk_import",
+	title: "Bulk user import",
+	description: "Bulk import users including admin, whitelist, and bans.",
+});
+definePermission({
+	name: "core.user.bulk_export",
+	title: "Bulk user export",
+	description: "Bulk export users including admin, whitelist, and bans.",
+});
+definePermission({
 	name: "core.log.follow",
 	title: "Follow cluster log",
 	description: "Receive new entries in the cluster log.  Required to see instance console.",

--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -24,6 +24,8 @@ function isActiveDropzone(element: HTMLElement | null): boolean {
 	while (element && depth < checkDepth) {
 		if (element.classList.contains("dropzone")) {
 			return element.classList.contains("enabled");
+		} else if (element.classList.contains("ant-upload-drag")) {
+			return !element.classList.contains("disabled");
 		}
 		element = element.parentElement;
 		depth += 1;

--- a/packages/web_ui/src/components/UsersPage.tsx
+++ b/packages/web_ui/src/components/UsersPage.tsx
@@ -76,10 +76,11 @@ function saveJson(name: string, json: object) {
 
 type UserBulkActionProps = {
 	setApplyAction(func: () => Promise<void>): void,
-	form: FormInstance
+	form: FormInstance,
+	restore?: boolean,
 }
 
-function UserBulkActionImport({ setApplyAction, form }: UserBulkActionProps) {
+function UserBulkActionImport({ setApplyAction, form, restore }: UserBulkActionProps) {
 	const control = useContext(ControlContext);
 	const account = useAccount();
 
@@ -202,7 +203,7 @@ function UserBulkActionImport({ setApplyAction, form }: UserBulkActionProps) {
 						throw new Error(`Unknown json (could not guess by file name): ${file.name}`);
 					}
 				}
-				await control.send(new lib.UserBulkImportRequest("users", [...usersToSend.values()]));
+				await control.send(new lib.UserBulkImportRequest("users", [...usersToSend.values()], restore));
 				break;
 			}
 
@@ -212,7 +213,7 @@ function UserBulkActionImport({ setApplyAction, form }: UserBulkActionProps) {
 				for (const file of values.fileList as File[]) {
 					parseUsers(JSON.parse(await file.text()), usersToSend);
 				}
-				await control.send(new lib.UserBulkImportRequest("users", [...usersToSend.values()]));
+				await control.send(new lib.UserBulkImportRequest("users", [...usersToSend.values()], restore));
 				break;
 			}
 
@@ -222,7 +223,7 @@ function UserBulkActionImport({ setApplyAction, form }: UserBulkActionProps) {
 				for (const file of values.fileList as File[]) {
 					parseBans(JSON.parse(await file.text()), usersToSend);
 				}
-				await control.send(new lib.UserBulkImportRequest("bans", [...usersToSend.values()]));
+				await control.send(new lib.UserBulkImportRequest("bans", [...usersToSend.values()], restore));
 				break;
 			}
 
@@ -233,7 +234,7 @@ function UserBulkActionImport({ setApplyAction, form }: UserBulkActionProps) {
 				for (const file of values.fileList as File[]) {
 					parseAdminsWhitelist(JSON.parse(await file.text()), usersToSend);
 				}
-				await control.send(new lib.UserBulkImportRequest(values.importType, [...usersToSend.keys()]));
+				await control.send(new lib.UserBulkImportRequest(values.importType, [...usersToSend.keys()], restore));
 				break;
 			}
 
@@ -355,10 +356,13 @@ function BulkUserActionButton() {
 							? <Radio.Button value="import">Import</Radio.Button> : undefined}
 						{account.hasPermission("core.user.bulk_export")
 							? <Radio.Button value="export">Export</Radio.Button> : undefined}
+						{account.hasPermission("core.user.bulk_restore")
+							? <Radio.Button value="restore">Restore</Radio.Button> : undefined}
 					</Radio.Group>
 				</Form.Item>
 				{formAction === "import" ? <UserBulkActionImport {...{setApplyAction, form}}/> : undefined}
 				{formAction === "export" ? <UserBulkActionExport {...{setApplyAction, form}}/> : undefined}
+				{formAction === "restore" ? <UserBulkActionImport restore {...{setApplyAction, form}}/> : undefined}
 			</Form>
 		</Modal>
 	</>;

--- a/packages/web_ui/src/components/UsersPage.tsx
+++ b/packages/web_ui/src/components/UsersPage.tsx
@@ -247,7 +247,7 @@ function UserBulkActionImport({ setApplyAction, form, restore }: UserBulkActionP
 				throw new Error(`Unknown importType: ${importType}`);
 			}
 		}
-		if (backup) {
+		if (restore && backup) {
 			saveJson(`${importType}-backup.json`, backup);
 		}
 	});

--- a/packages/web_ui/src/components/UsersPage.tsx
+++ b/packages/web_ui/src/components/UsersPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button, Form, Input, Modal, Space, Table, Tag } from "antd";
+import { Button, Form, FormInstance, GetProp, Input, Modal, Radio, Space, Table, Tag, Upload, UploadProps } from "antd";
+import { InboxOutlined } from "@ant-design/icons";
 
 import * as lib from "@clusterio/lib";
 
@@ -15,7 +16,6 @@ import { formatFirstSeen, formatLastSeen, sortFirstSeen, sortLastSeen, useUsers 
 import Link from "./Link";
 
 const strcmp = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }).compare;
-
 
 function CreateUserButton() {
 	let control = useContext(ControlContext);
@@ -57,6 +57,154 @@ function CreateUserButton() {
 	</>;
 }
 
+// This is the most common and best supported method
+// For full support we should consider using npm:file-saver
+function saveFile(name: string, blob: Blob) {
+	const a = document.createElement("a");
+	a.href = URL.createObjectURL(blob);
+	a.download = name;
+	a.addEventListener("click", (e) => {
+		setTimeout(() => URL.revokeObjectURL(a.href), 30 * 1000);
+	});
+	a.click();
+};
+
+function saveJson(name: string, json: object) {
+	return saveFile(name, new Blob([JSON.stringify(json, null, 2)], { type: "application/json" }));
+}
+
+type UserBulkActionProps = {
+	setApplyAction(func: () => Promise<void>): void,
+	form: FormInstance
+}
+
+function UserBulkActionImport({ setApplyAction, form }: UserBulkActionProps) {
+	const control = useContext(ControlContext);
+	const account = useAccount();
+
+	const uploadProps: UploadProps = {
+		accept: ".json",
+		multiple: true,
+		beforeUpload: (file) => false,
+	};
+
+	setApplyAction(async () => {
+		const values = form.getFieldsValue();
+		// console.log(values);
+		for (const file of values.fileList as File[]) {
+			// console.log(JSON.parse(await file.text()));
+		}
+	});
+
+	const normaliseFiles = (e: any) => (Array.isArray(e) ? e : e.fileList).map((f: any) => f.originFileObj);
+
+	return <>
+		<Form.Item label="Type" name="importType" initialValue="mixed">
+			<Radio.Group>
+				<Radio.Button value="mixed" disabled={!account.hasAnyPermission(
+					"core.user.set_admin", "core.user.set_banned", "core.user.set_whitelisted"
+				)}>Mixed</Radio.Button>
+				<Radio.Button value="users" disabled={!account.hasAllPermission(
+					"core.user.set_admin", "core.user.set_banned", "core.user.set_whitelisted"
+				)}>Users</Radio.Button>
+				<Radio.Button value="admins" disabled={!account.hasPermission(
+					"core.user.set_admin"
+				)}>Admins</Radio.Button>
+				<Radio.Button value="bans" disabled={!account.hasPermission(
+					"core.user.set_banned"
+				)}>Bans</Radio.Button>
+				<Radio.Button value="whitelist" disabled={!account.hasPermission(
+					"core.user.set_whitelisted"
+				)}>Whitelist</Radio.Button>
+			</Radio.Group>
+		</Form.Item>
+		<Form.Item name="fileList" valuePropName="fileList" getValueFromEvent={normaliseFiles} noStyle>
+			<Upload.Dragger {...uploadProps}>
+				<p className="ant-upload-drag-icon">
+					<InboxOutlined />
+				</p>
+				<p className="ant-upload-text">Click or drag file to this area to import</p>
+				<p className="ant-upload-hint">Support for a single or bulk import.</p>
+			</Upload.Dragger>
+		</Form.Item>
+	</>;
+}
+
+function UserBulkActionExport({ setApplyAction, form }: UserBulkActionProps) {
+	const control = useContext(ControlContext);
+
+	setApplyAction(async () => {
+		const values = form.getFieldsValue();
+		// console.log(values);
+		saveJson("test.json", values);
+	});
+
+	return <>
+		<Form.Item label="Type" name="exportType" initialValue="users">
+			<Radio.Group>
+				<Radio.Button value="users">Users</Radio.Button>
+				<Radio.Button value="admins">Admins</Radio.Button>
+				<Radio.Button value="bans">Bans</Radio.Button>
+				<Radio.Button value="whitelist">Whitelist</Radio.Button>
+			</Radio.Group>
+		</Form.Item>
+	</>;
+}
+
+function BulkUserActionButton() {
+	const account = useAccount();
+	const [open, setOpen] = useState(false);
+	const [formAction, setFormAction] = useState<string | undefined>(undefined);
+	const [form] = Form.useForm();
+
+	function onValuesChange({ action } : { action?: string }) {
+		if (action) {
+			setFormAction(action);
+		}
+	}
+
+	let applyAction: () => Promise<void>;
+	const setApplyAction = (func: () => Promise<void>) => { applyAction = func; };
+	async function onOk() {
+		if (!applyAction) {
+			form.setFields([{ name: "action", errors: ["Action is required"] }]);
+			return;
+		}
+		await applyAction();
+		setFormAction(undefined);
+		setOpen(false);
+	}
+
+	return <>
+		<Button
+			type="default"
+			onClick={() => { setOpen(true); }}
+		>Bulk Actions</Button>
+		<Modal
+			title="Bulk Actions"
+			okText="Apply"
+			open={open}
+			okButtonProps={{disabled: formAction === undefined}}
+			onOk={() => { onOk().catch(notifyErrorHandler(`Error running ${formAction}`)); }}
+			onCancel={() => { setOpen(false); }}
+			destroyOnClose
+		>
+			<Form form={form} onValuesChange={onValuesChange} clearOnDestroy>
+				<Form.Item label="Action" name="action">
+					<Radio.Group value={formAction}>
+						{account.hasPermission("core.user.bulk_import")
+							? <Radio.Button value="import">Import</Radio.Button> : undefined}
+						{account.hasPermission("core.user.bulk_export")
+							? <Radio.Button value="export">Export</Radio.Button> : undefined}
+					</Radio.Group>
+				</Form.Item>
+				{formAction === "import" ? <UserBulkActionImport {...{setApplyAction, form}}/> : undefined}
+				{formAction === "export" ? <UserBulkActionExport {...{setApplyAction, form}}/> : undefined}
+			</Form>
+		</Modal>
+	</>;
+}
+
 export default function UsersPage() {
 	let account = useAccount();
 	let control = useContext(ControlContext);
@@ -76,7 +224,11 @@ export default function UsersPage() {
 	return <PageLayout nav={[{ name: "Users" }]}>
 		<PageHeader
 			title="Users"
-			extra={account.hasPermission("core.user.create") ? <CreateUserButton /> : undefined}
+			extra={<>
+				{account.hasPermission("core.user.create") ? <CreateUserButton /> : undefined}
+				{account.hasAnyPermission("core.user.bulk_import", "core.user.bulk_export")
+					? <BulkUserActionButton /> : undefined}
+			</>}
 		/>
 		<Table
 			columns={[


### PR DESCRIPTION
Closes: #717

Adds web ui buttons and ctl commands which allow importing, exporting, and restoring user lists from json files. These lists include bans, admins, whitelist, and a combined format specific to clusteiro.  Please note the following behaviours:

* Importing is a strictly additive action, while restoring will match exactlly what is given by the files.
* Both the web ui and the ctl commands will attempt to guess the import type based on file name if it is not specified.
* The web ui supports multiple file uploads which are merged client side before being imported.
* When restoring, the client will save a backup file representing the state which was replaced.
* New bulk action permissions are added, but specific actions require their corresponding permission. e.g. importing bans requires "bulk import" and "set banned" and may require "create user".

The web ui components have been manually tested on the latest version of Firefox.

## Changelog
```
### Features
- Added import, export, and restore of user lists (bans / admins / whitelist / combined). [#717](https://github.com/clusterio/clusterio/issues/717)
```
