### PR TITLE
Add log filters to web ui

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -191,7 +191,7 @@ module.exports = {
 		"multiline-comment-style": ["error", "separate-lines"],
 		"multiline-ternary": "off",
 		"new-cap": ["error", {
-			"capIsNewExceptions": ["StringEnum"],
+			"capIsNewExceptions": ["StringEnum", "StringKey"],
 			"capIsNewExceptionPattern": "^Type\\.",
 		}],
 		"new-parens": "error",

--- a/packages/lib/src/data/composites.ts
+++ b/packages/lib/src/data/composites.ts
@@ -4,6 +4,10 @@ export function StringEnum<T extends string[]>(values: [...T]) {
 	return Type.Unsafe<T[number]>({ type: "string", enum: values });
 }
 
+export function StringKey<T extends string>(object: Record<T, any>) {
+	return Type.Unsafe<keyof typeof object>({ type: "string", enum: Object.keys(object) });
+}
+
 export interface JSONDeserialisable<T> {
 	fromJSON(json: unknown): T;
 	jsonSchema: object;

--- a/packages/lib/src/data/messages_controller.ts
+++ b/packages/lib/src/data/messages_controller.ts
@@ -1,5 +1,5 @@
 import { Type, Static } from "@sinclair/typebox";
-import { JsonString, StringEnum, plainJson } from "./composites";
+import { JsonString, StringEnum, StringKey, plainJson } from "./composites";
 import { levels } from "../logging";
 import { ControllerConfig, HostConfig } from "../config";
 
@@ -217,12 +217,12 @@ export class LogMessageEvent {
 	static dst = ["controller", "control"] as const;
 
 	constructor(
-		public info: { level: string, message: string },
+		public info: { level: keyof typeof levels, message: string },
 	) { }
 
 	static jsonSchema = Type.Object({
 		"info": Type.Object({
-			"level": Type.String(),
+			"level": StringKey(levels),
 			"message": Type.String(),
 		}),
 	});

--- a/packages/web_ui/src/components/ControllerPage.tsx
+++ b/packages/web_ui/src/components/ControllerPage.tsx
@@ -4,7 +4,7 @@ import { Button, Descriptions, Flex, Popconfirm, Space, Typography } from "antd"
 import * as lib from "@clusterio/lib";
 
 import PluginExtra from "./PluginExtra";
-import LogConsole, { LogConsoleMaxLevel } from "./LogConsole";
+import LogConsole, { SelectMaxLogLevel } from "./LogConsole";
 import {
 	MetricCpuRatio, MetricCpuUsed, MetricMemoryRatio, MetricMemoryUsed,
 	MetricDiskUsed, MetricDiskRatio,
@@ -85,9 +85,9 @@ export default function ControllerPage() {
 		{account.hasPermission("core.log.follow") && <>
 			<Flex justify="space-between" align="baseline">
 				<Title level={5} style={{ marginTop: 16 }}>Console</Title>
-				<LogConsoleMaxLevel
+				<SelectMaxLogLevel
 					value={maxLevel}
-					onChange={value => setMaxLevel(value)}
+					onChange={setMaxLevel}
 					hidden={["server"]}
 				/>
 			</Flex>

--- a/packages/web_ui/src/components/ControllerPage.tsx
+++ b/packages/web_ui/src/components/ControllerPage.tsx
@@ -1,10 +1,10 @@
-import React, {useContext} from "react";
-import { Button, Descriptions, Popconfirm, Space, Typography } from "antd";
+import React, {useContext, useState} from "react";
+import { Button, Descriptions, Flex, Popconfirm, Space, Typography } from "antd";
 
 import * as lib from "@clusterio/lib";
 
 import PluginExtra from "./PluginExtra";
-import LogConsole from "./LogConsole";
+import LogConsole, { LogConsoleMaxLevel } from "./LogConsole";
 import {
 	MetricCpuRatio, MetricCpuUsed, MetricMemoryRatio, MetricMemoryUsed,
 	MetricDiskUsed, MetricDiskRatio,
@@ -26,6 +26,7 @@ export default function ControllerPage() {
 	const control = useContext(ControlContext);
 	const [systems] = useSystems();
 	const system = systems.get("controller");
+	const [maxLevel, setMaxLevel] = useState<keyof typeof lib.levels>("info");
 
 	return <PageLayout nav={[{ name: "Controller" }]}>
 		<PageHeader
@@ -82,8 +83,15 @@ export default function ControllerPage() {
 			<Descriptions.Item label="Disk"><MetricDiskUsed system={system} /></Descriptions.Item>
 		</Descriptions>
 		{account.hasPermission("core.log.follow") && <>
-			<Title level={5} style={{ marginTop: 16 }}>Console</Title>
-			<LogConsole controller={true} />
+			<Flex justify="space-between" align="baseline">
+				<Title level={5} style={{ marginTop: 16 }}>Console</Title>
+				<LogConsoleMaxLevel
+					value={maxLevel}
+					onChange={value => setMaxLevel(value)}
+					hidden={["server"]}
+				/>
+			</Flex>
+			<LogConsole controller={true} maxLevel={maxLevel}/>
 		</>}
 		{account.hasPermission("core.controller.get_config") && <ControllerConfigTree />}
 		<PluginExtra component="ControllerPage" />

--- a/packages/web_ui/src/components/HostViewPage.tsx
+++ b/packages/web_ui/src/components/HostViewPage.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from "react";
-import { Descriptions, Spin, Tag, Typography, Button, Space, Modal, Popconfirm } from "antd";
+import React, { useContext, useState } from "react";
+import { Descriptions, Spin, Tag, Typography, Button, Space, Modal, Popconfirm, Flex } from "antd";
 import { useParams } from "react-router-dom";
 
 import * as lib from "@clusterio/lib";
@@ -7,7 +7,7 @@ import notify, { notifyErrorHandler } from "../util/notify";
 import ControlContext from "./ControlContext";
 import HostConfigTree from "./HostConfigTree";
 import InstanceList from "./InstanceList";
-import LogConsole from "./LogConsole";
+import LogConsole, { LogConsoleMaxLevel } from "./LogConsole";
 import { useAccount } from "../model/account";
 import { useInstances } from "../model/instance";
 import { useHost } from "../model/host";
@@ -32,6 +32,7 @@ export default function HostViewPage() {
 	const [systems] = useSystems();
 	const system = systems.get(hostId);
 	const [host, synced] = useHost(hostId);
+	const [maxLevel, setMaxLevel] = useState<keyof typeof lib.levels>("info");
 	const hostInstances = new Map([...instances].filter(([_id, instance]) => instance.assignedHost === hostId));
 
 	let nav = [{ name: "Hosts", path: "/hosts" }, { name: host?.name ?? String(hostId) }];
@@ -141,8 +142,15 @@ export default function HostViewPage() {
 			<InstanceList instances={hostInstances} size="small" hideAssignedHost />
 		</>}
 		{account.hasPermission("core.log.follow") && <>
-			<Title level={5} style={{ marginTop: 16 }}>Console</Title>
-			<LogConsole hosts={[hostId]} />
+			<Flex justify="space-between" align="baseline">
+				<Title level={5} style={{ marginTop: 16 }}>Console</Title>
+				<LogConsoleMaxLevel
+					value={maxLevel}
+					onChange={value => setMaxLevel(value)}
+					hidden={["server", "http"]}
+				/>
+			</Flex>
+			<LogConsole hosts={[hostId]} maxLevel={maxLevel}/>
 		</>}
 		{account.hasPermission("core.host.get_config") && <HostConfigTree id={hostId} available={host.connected} />}
 		<PluginExtra component="HostViewPage" host={host} />

--- a/packages/web_ui/src/components/HostViewPage.tsx
+++ b/packages/web_ui/src/components/HostViewPage.tsx
@@ -7,7 +7,7 @@ import notify, { notifyErrorHandler } from "../util/notify";
 import ControlContext from "./ControlContext";
 import HostConfigTree from "./HostConfigTree";
 import InstanceList from "./InstanceList";
-import LogConsole, { LogConsoleMaxLevel } from "./LogConsole";
+import LogConsole, { SelectMaxLogLevel } from "./LogConsole";
 import { useAccount } from "../model/account";
 import { useInstances } from "../model/instance";
 import { useHost } from "../model/host";
@@ -144,9 +144,9 @@ export default function HostViewPage() {
 		{account.hasPermission("core.log.follow") && <>
 			<Flex justify="space-between" align="baseline">
 				<Title level={5} style={{ marginTop: 16 }}>Console</Title>
-				<LogConsoleMaxLevel
+				<SelectMaxLogLevel
 					value={maxLevel}
-					onChange={value => setMaxLevel(value)}
+					onChange={setMaxLevel}
 					hidden={["server", "http"]}
 				/>
 			</Flex>

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -12,7 +12,7 @@ import PageHeader from "./PageHeader";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
 import InstanceConfigTree from "./InstanceConfigTree";
-import LogConsole, { LogConsoleMaxLevel } from "./LogConsole";
+import LogConsole, { SelectMaxLogLevel } from "./LogConsole";
 import InstanceRcon from "./InstanceRcon";
 import AssignInstanceModal from "./AssignInstanceModal";
 import StartStopInstanceButton from "./StartStopInstanceButton";
@@ -242,7 +242,7 @@ export default function InstanceViewPage() {
 							checked={actionsOnly}
 							onChange={setActionsOnly}
 						/>
-						<LogConsoleMaxLevel
+						<SelectMaxLogLevel
 							value={maxLevel}
 							onChange={setMaxLevel}
 							hidden={["http"]}

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Alert, Button, Descriptions, Dropdown, MenuProps, Modal, Space, Spin, Typography } from "antd";
+import { Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Space, Spin, Typography } from "antd";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import DownOutlined from "@ant-design/icons/DownOutlined";
 
@@ -12,7 +12,7 @@ import PageHeader from "./PageHeader";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
 import InstanceConfigTree from "./InstanceConfigTree";
-import LogConsole from "./LogConsole";
+import LogConsole, { LogConsoleMaxLevel } from "./LogConsole";
 import InstanceRcon from "./InstanceRcon";
 import AssignInstanceModal from "./AssignInstanceModal";
 import StartStopInstanceButton from "./StartStopInstanceButton";
@@ -185,6 +185,7 @@ function InstanceButtons(props: { instance: lib.InstanceDetails }) {
 export default function InstanceViewPage() {
 	let params = useParams();
 	let instanceId = Number(params.id);
+	const [maxLevel, setMaxLevel] = useState<keyof typeof lib.levels>("server");
 
 	let navigate = useNavigate();
 
@@ -231,7 +232,17 @@ export default function InstanceViewPage() {
 			account.hasAnyPermission("core.log.follow", "core.instance.send_rcon")
 			&& <Title level={5} style={{ marginTop: 16 }}>Console</Title>
 		}
-		{account.hasPermission("core.log.follow") && <LogConsole instances={[instanceId]} />}
+		{account.hasPermission("core.log.follow") && <>
+			<Flex justify="space-between" align="baseline">
+				<Title level={5} style={{ marginTop: 16 }}>Console</Title>
+				<LogConsoleMaxLevel
+					value={maxLevel}
+					onChange={value => setMaxLevel(value)}
+					hidden={["http"]}
+				/>
+			</Flex>
+			<LogConsole instances={[instanceId]} maxLevel={maxLevel}/>
+		</>}
 		{
 			account.hasPermission("core.instance.send_rcon")
 			&& <InstanceRcon id={instanceId} disabled={instance.status !== "running"} />

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Space, Spin, Typography } from "antd";
+import { Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Space, Spin, Switch, Typography } from "antd";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import DownOutlined from "@ant-design/icons/DownOutlined";
 
@@ -186,6 +186,7 @@ export default function InstanceViewPage() {
 	let params = useParams();
 	let instanceId = Number(params.id);
 	const [maxLevel, setMaxLevel] = useState<keyof typeof lib.levels>("server");
+	const [actionsOnly, setActionsOnly] = useState<boolean>(true);
 
 	let navigate = useNavigate();
 
@@ -230,19 +231,30 @@ export default function InstanceViewPage() {
 		}
 		{
 			account.hasAnyPermission("core.log.follow", "core.instance.send_rcon")
-			&& <Title level={5} style={{ marginTop: 16 }}>Console</Title>
-		}
-		{account.hasPermission("core.log.follow") && <>
-			<Flex justify="space-between" align="baseline">
+			&& <Flex justify="space-between" align="baseline">
 				<Title level={5} style={{ marginTop: 16 }}>Console</Title>
-				<LogConsoleMaxLevel
-					value={maxLevel}
-					onChange={value => setMaxLevel(value)}
-					hidden={["http"]}
-				/>
+				{
+					account.hasPermission("core.log.follow")
+					&& <Flex align="center" gap="middle">
+						<Switch
+							checkedChildren="Chat"
+							unCheckedChildren="Log"
+							checked={actionsOnly}
+							onChange={setActionsOnly}
+						/>
+						<LogConsoleMaxLevel
+							value={maxLevel}
+							onChange={setMaxLevel}
+							hidden={["http"]}
+						/>
+					</Flex>
+				}
 			</Flex>
-			<LogConsole instances={[instanceId]} maxLevel={maxLevel}/>
-		</>}
+		}
+		{
+			account.hasPermission("core.log.follow")
+			&& <LogConsole instances={[instanceId]} maxLevel={maxLevel} actionsOnly={actionsOnly}/>
+		}
 		{
 			account.hasPermission("core.instance.send_rcon")
 			&& <InstanceRcon id={instanceId} disabled={instance.status !== "running"} />

--- a/packages/web_ui/src/components/LogConsole.tsx
+++ b/packages/web_ui/src/components/LogConsole.tsx
@@ -73,7 +73,7 @@ type LogConsoleProps = {
 	actionsOnly?: boolean;
 };
 
-export function LogConsoleMaxLevel(props: {
+export function SelectMaxLogLevel(props: {
 	value: keyof typeof lib.levels,
 	hidden?: (keyof typeof lib.levels)[],
 	onChange: (option: keyof typeof lib.levels) => void

--- a/packages/web_ui/src/util/websocket.ts
+++ b/packages/web_ui/src/util/websocket.ts
@@ -11,7 +11,7 @@ type saveListHandler = (saveListEvent: lib.SaveDetails) => void;
 type modPackHandler = (modPack: lib.ModPack) => void;
 type modInfoHandler = (modInfo: lib.ModInfo) => void;
 type userHandler = (rawUser: lib.User) => void;
-type logHandler = (info: { level:string, message:string }) => void;
+type logHandler = (info: { level: keyof typeof lib.levels, message: string }) => void;
 
 /**
  * Connector for control connection to controller


### PR DESCRIPTION
Adds two log filters to the web ui, one which is based on max log level, and a second which filters to only server actions such as chat messages or bans. The log level uses existing query logic to filter to a max log level. The server actions has no controller side logic instead opting to filter on the client. There is some inefficiency by making a request any time a filter changes, but I would rather get value from this and worry about efficiency at a later time.

## Changelog
```
### Features
- Added log level filtering to the web ui. [#745](https://github.com/clusterio/clusterio/issues/745)
- Added server action filter (aka "chat filter") to instance log in web ui. [#744](https://github.com/clusterio/clusterio/issues/744)
```
