### PR TITLE
Add config option for console logging

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -218,6 +218,7 @@ export default class Instance extends lib.Link {
 			enableWhitelist: this.config.get("factorio.enable_whitelist"),
 			enableAuthserverBans: this.config.get("factorio.enable_authserver_bans"),
 			verboseLogging: this.config.get("factorio.verbose_logging"),
+			consoleLogging: this.config.get("factorio.console_logging"),
 			stripPaths: this.config.get("factorio.strip_paths"),
 			maxConcurrentCommands: this.config.get("factorio.max_concurrent_commands"),
 			shutdownTimeoutMs: this.config.get("factorio.shutdown_timeout") * 1000,

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -438,6 +438,8 @@ export interface FactorioServerOptions {
 	enableAuthserverBans?: boolean,
 	/** Enable verbose logging. */
 	verboseLogging?: boolean,
+	/** Enable console logging. */
+	consoleLogging?: boolean,
 	/** Strip paths in the console. */
 	stripPaths?: boolean,
 	/**
@@ -486,6 +488,8 @@ export class FactorioServer extends events.EventEmitter {
 	enableAuthserverBans: boolean;
 	/** Enable verbose logging */
 	verboseLogging: boolean;
+	/** Enable console logging */
+	consoleLogging: boolean;
 	_shutdownTimeoutMs = 0;
 	_stopTimeoutId?: ReturnType<typeof setTimeout>;
 
@@ -541,6 +545,8 @@ export class FactorioServer extends events.EventEmitter {
 		this.enableAuthserverBans = options.enableAuthserverBans || false;
 		/** Enable verbose logging */
 		this.verboseLogging = options.verboseLogging || false;
+		/** Enable console logging */
+		this.consoleLogging = options.consoleLogging || false;
 		/** Maximum number of RCON commands transmitted in parallel on the RCON connection  */
 		this.maxConcurrentCommands = options.maxConcurrentCommands || 5;
 		if (options.shutdownTimeoutMs !== undefined) {
@@ -973,6 +979,7 @@ export class FactorioServer extends events.EventEmitter {
 					...(this.enableWhitelist ? ["--use-server-whitelist"] : []),
 					...(this.enableAuthserverBans ? ["--use-authserver-bans"] : []),
 					...(this.verboseLogging ? ["--verbose"] : []),
+					...(this.consoleLogging ? ["--console-log", this.writePath("console.log")] : []),
 				],
 				{
 					detached: true,

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -333,6 +333,7 @@ export interface InstanceConfigFields {
 	"factorio.enable_authserver_bans": boolean;
 	"factorio.settings": Record<string, unknown>;
 	"factorio.verbose_logging": boolean;
+	"factorio.console_logging": boolean;
 	"factorio.strip_paths": boolean;
 	"factorio.sync_adminlist": "enabled" | "disabled" | "bidirectional";
 	"factorio.sync_whitelist": "enabled" | "disabled" | "bidirectional";
@@ -484,6 +485,12 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 		},
 		"factorio.verbose_logging": {
 			description: "Enable verbose logging on the Factorio server",
+			restartRequired: true,
+			type: "boolean",
+			initialValue: false,
+		},
+		"factorio.console_logging": {
+			description: "Enable console logging to a separate file, useful for 3rd party integrations",
 			restartRequired: true,
 			type: "boolean",
 			initialValue: false,

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -434,6 +434,18 @@ describe("Integration of Clusterio", function() {
 				await execCtl("instance start test --save world.zip");
 				await checkInstanceStatus(44, "running");
 			});
+			it("allows having a separate console log", async function() {
+				slowTest(this);
+				await execCtl("instance stop 44");
+				await execCtl("instance config set 44 factorio.console_logging true");
+				await execCtl("instance start test");
+				await checkInstanceStatus(44, "running");
+				const checkMessage = `check${Date.now()}`;
+				await sendRcon(44, checkMessage);
+				const consoleLog = await fs.readFile(path.join("temp", "test", "instances", "test", "console.log"));
+				assert(consoleLog.includes(checkMessage));
+				await execCtl("instance config set 44 factorio.console_logging false");
+			});
 			it("copies the save if an autosave is the target", async function() {
 				slowTest(this);
 				await execCtl("instance stop 44");


### PR DESCRIPTION
Adds a per instance config option which enables the deadicated console log for a server. This is useful for third party integrations which expect to be able to tail a file rather than communicate over a websocket. The file is always named `console.log` as I see no value in supporting custom file paths and the complications that brings.

## Changelog
```
### Features
- Added `factorio.console_logging` to enable deadicated console logs for a server [#748](https://github.com/clusterio/clusterio/issues/748)
```
