### PR TITLE
Fix incorrect use of Array.splice

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -1036,7 +1036,7 @@ end`.replace(/\r?\n/g, " ");
 			expected => expected.name === name && expected.action === action && expected.reason === reason
 		);
 		if (expectedIndex >= 0) {
-			this._expectedUserUpdates = this._expectedUserUpdates.splice(expectedIndex, 1);
+			this._expectedUserUpdates.splice(expectedIndex, 1);
 		} else if (action === "BAN") {
 			if (this.config.get("factorio.sync_banlist") !== "bidirectional") { return; }
 			this.sendTo(addr, new lib.InstanceBanlistUpdateEvent(name, true, reason ?? ""));


### PR DESCRIPTION
This should resolve the sync loops for bans and admins. Resolves: #736 

The race condition is as follows:
1) An instance receives a ban event from the controller, this adds ban A to the expected list and sends an rcon command.
2) The instance receives a second ban event from the controller, this adds the ban B to the expected list and sends an rcon command.
3) The instance receives the log event for ban A, but rather than remove it from the expected list, it sets the expected list to just ban A, therefore ban B is no longer in the list.
4) The instance receives the log event for ban B, because it is not in the expected list, it assumes this is a new event and sends it to the controller and all other instances, and now we got a loop.

The fix was correcting the use of Array.splice in step 3 where it was incorrectly assumed the returned array was the new array and not the removed elements.

## Changelog
```
### Fixes
- Fix looping between instances of ban and admin sync events. [#736](https://github.com/clusterio/clusterio/issues/736)
```
