### PR TITLE
Remove `phin` without introducing new dependencies

### DIFF
--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -6,7 +6,6 @@ const fs = require("fs-extra");
 const inquirer = require("inquirer");
 const os = require("os");
 const path = require("path");
-const phin = require("phin");
 const stream = require("stream");
 const util = require("util");
 const yargs = require("yargs");
@@ -624,7 +623,7 @@ async function inquirerMissingArgs(args) {
 			answers.publicAddress = args.publicAddress;
 		} else {
 			try {
-				let result = await phin("https://api.ipify.org/");
+				let result = await fetch("https://api.ipify.org/");
 				myIp = result.body.toString();
 			} catch (err) { /* ignore */ }
 		}
@@ -741,7 +740,7 @@ async function inquirerMissingArgs(args) {
 }
 
 async function downloadLinuxServer() {
-	let res = await phin("https://factorio.com/get-download/stable/headless/linux64");
+	let res = await fetch("https://factorio.com/get-download/stable/headless/linux64");
 
 	const url = new URL(res.headers.location);
 	// get the filename of the latest factorio archive from redirected url
@@ -764,14 +763,11 @@ async function downloadLinuxServer() {
 		await fs.ensureDir(tmpDir);
 
 		// follow the redirect
-		res = await phin({
-			url: url.href,
-			stream: true,
-		});
+		res = await fetch(url.href);
 
 		logger.info("Downloading latest Factorio server release. This may take a while.");
 		const writeStream = fs.createWriteStream(tmpArchivePath);
-		res.pipe(writeStream);
+		stream.Readable.fromWeb(res.body).pipe(writeStream);
 
 		await finished(writeStream);
 

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -19,7 +19,6 @@
 		"chalk": "^4.1.2",
 		"fs-extra": "^11.3.0",
 		"inquirer": "^8.2.4",
-		"phin": "^3.7.0",
 		"yargs": "^17.7.2"
 	},
 	"publishConfig": {

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -38,7 +38,6 @@
 		"@types/node": "^20.17.19",
 		"@types/react": "^18.3.18",
 		"antd": "^5.24.2",
-		"phin": "^3.7.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"typescript": "^5.7.3",

--- a/test/integration/create.js
+++ b/test/integration/create.js
@@ -4,7 +4,6 @@ const fs = require("fs-extra");
 const jwt = require("jsonwebtoken");
 const path = require("path");
 const events = require("events");
-const phin = require("phin");
 const child_process = require("child_process");
 const util = require("util");
 

--- a/test/lib/ModStore.test.js
+++ b/test/lib/ModStore.test.js
@@ -7,14 +7,7 @@ const JSZip = require("jszip"); // Added for creating mock zips
 // Capture native fetch before any potential mocks are applied
 const nativeFetch = global.fetch;
 
-// Removed logger mocking setup
-
 const { ModStore, ModInfo } = require("@clusterio/lib"); // Adjust path based on compiled output
-
-// Mock fetch function
-global.fetch = async (url, options) => {
-	throw new Error(`fetch mock not implemented for ${url}`);
-};
 
 const MODS_DIR = path.join("temp", "test", "mod_store", "mods");
 const CACHE_FILE = path.join(MODS_DIR, "mod-info-cache.json");
@@ -47,6 +40,10 @@ async function waitBriefly() {
 describe("lib/ModStore", function () {
 	before(async function () {
 		await fs.ensureDir(MODS_DIR);
+	});
+
+	after(function() {
+		global.fetch = nativeFetch;
 	});
 
 	beforeEach(function () {


### PR DESCRIPTION
Progress towards #754

New Issue: fetch does not support custom agents (required for keep alive and custom CA) which means we will need to add a new dependency as a replacement for phin. Native fetch uses `undici` which would give us access to custom agents if added, or we could consider alternatives such as `axios`. This should be decided before merging this PR.

## Changelog
N/A - Internal Refactor
