### PR TITLE
Add recovery startup mode

### DIFF
--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -270,6 +270,10 @@ async function initialize(): Promise<InitializeParameters> {
 				type: "boolean", nargs: 0, default: false,
 				describe: "Indicate that a process monitor will restart the controller on failure",
 			});
+			yargs.option("recovery", {
+				type: "boolean", nargs: 0, default: false,
+				describe: "Start the controller in recovery mode with all plugins disabled and hosts disconnected",
+			});
 			yargs.option("dev", { hidden: true, type: "boolean", nargs: 0 });
 			yargs.option("dev-plugin", { hidden: true, type: "array" });
 		})
@@ -313,6 +317,9 @@ async function initialize(): Promise<InitializeParameters> {
 	let shouldRun = false;
 	if (command === "run") {
 		logger.info(`Starting Clusterio controller ${version}`);
+		if (args.recovery) {
+			logger.warn("Controller recovery mode enabled. Some features will be disabled.");
+		}
 		shouldRun = true;
 	}
 
@@ -406,6 +413,7 @@ async function startup() {
 		controllerConfigPath,
 		controllerConfig,
 		Boolean(args.canRestart),
+		Boolean(args.recovery),
 		...await Controller.bootstrap(controllerConfig)
 	);
 

--- a/packages/controller/src/WsServer.ts
+++ b/packages/controller/src/WsServer.ts
@@ -239,6 +239,13 @@ ${err.stack}`
 	}
 
 	async registerHost(data: lib.RegisterHostData, socket: WebSocket, req: IncomingMessage) {
+		if (this.controller.recoveryMode) {
+			logger.warn(`Recovery | rejected host connection attempt for ${this.remoteAddr(req)}`);
+			wsRejectedConnectionsCounter.inc();
+			socket.close(lib.ConnectionClosed.TryAgainLater, "Connection Refused: Controller in recovery mode");
+			return;
+		}
+
 		try {
 			let tokenPayload = jwt.verify(
 				data.token,

--- a/packages/controller/src/WsServer.ts
+++ b/packages/controller/src/WsServer.ts
@@ -242,7 +242,7 @@ ${err.stack}`
 		if (this.controller.recoveryMode) {
 			logger.warn(`Recovery | rejected host connection attempt for ${this.remoteAddr(req)}`);
 			wsRejectedConnectionsCounter.inc();
-			socket.close(lib.ConnectionClosed.TryAgainLater, "Connection Refused: Controller in recovery mode");
+			socket.close(lib.ConnectionClosed.RecoveryMode, "Connection Refused: Controller in recovery mode");
 			return;
 		}
 

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -120,6 +120,10 @@ async function startHost() {
 				type: "boolean", nargs: 0, default: false,
 				describe: "Indicate that a process monitor will restart this host on failure",
 			});
+			yargs.option("recovery", {
+				type: "boolean", nargs: 0, default: false,
+				describe: "Start the host in recovery mode with all plugins disabled and controller disconnected",
+			});
 		})
 		.demandCommand(1, "You need to specify a command to run")
 		.strict()
@@ -144,6 +148,9 @@ async function startHost() {
 	let command = args._[0];
 	if (command === "run") {
 		logger.info(`Starting Clusterio host ${version}`);
+		if (args.recovery) {
+			logger.warn("Host recovery mode enabled. Some features will be disabled.");
+		}
 	}
 
 	logger.info(`Loading available plugins from ${args.pluginList}`);
@@ -226,6 +233,7 @@ async function startHost() {
 		tlsCa,
 		pluginInfos,
 		Boolean(args.canRestart),
+		Boolean(args.recovery),
 		...await Host.bootstrap(hostConfig)
 	);
 

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -646,6 +646,11 @@ end`.replace(/\r?\n/g, " ");
 				continue;
 			}
 
+			if (this._host.recoveryMode) {
+				this.logger.warn(`Recovery | force disabled plugin ${pluginInfo.name}`);
+				continue;
+			}
+
 			try {
 				await this._loadPlugin(pluginInfo, this._host);
 			} catch (err) {

--- a/packages/lib/src/link/connectors.ts
+++ b/packages/lib/src/link/connectors.ts
@@ -23,6 +23,7 @@ export enum ConnectionClosed {
 	ProtocolError = 1002, // Protocol not followed
 	PolicyViolation = 1008, // Generic code for any endpoint policy
 	InternalError = 1011, // Endpoint failed to fulfil request
+	TryAgainLater = 1013, // Temporary server condition blocking requests
 
 	// Codes after 3000 are available for frameworks
 	// However they should be registered to IANA

--- a/packages/lib/src/link/connectors.ts
+++ b/packages/lib/src/link/connectors.ts
@@ -33,6 +33,7 @@ export enum ConnectionClosed {
 
 	// Codes after 4000 are available for applications
 	MalformedMessage = 4000,
+	RecoveryMode = 4001,
 };
 
 /**


### PR DESCRIPTION
Adds a recovery mode to controller and host startup which limits their behaviour. The intention of this feature is to be proactive and provide a base from which we can expand should difficulties arise in the future; therefore, the scope of disabled behaviours is very limited at the moment.

**Considerations:**
- Although possible, I have not provided a way for ctl or the web ui to initiate a recovery state as I foresee this being used from the physical machine if the process fails to start normally. We can revist this if we find a need for it.
- I am not confident in my abilty to modify the existing "restart on failure" code, and therefore I have not linked it to recovery mode despite there being value in doing so. We may also want this as a config option to control this behaviour.
- Our current integration tests assume there is a singleton controller and host instance running, this makes it non-trival to test a feature which requires the controller to be restarted. Therefore, tests have not been written.

**Recovery Mode:**
- Controller / Host / Instance - Disable plugin loading
- Controller - Disable autosaving of data
- Controller - Reject incoming host connections
- Host - Disable auto start of instances

Closes: #752 

## Changelog
```
### Features
- Added a recovery mode to host and controller accessible as an option on the run command. [#752](https://github.com/clusterio/clusterio/issues/752)
```
