### PR TITLE
Add indicators for host version mismatch and required restart

### DIFF
--- a/packages/controller/controller.ts
+++ b/packages/controller/controller.ts
@@ -354,6 +354,8 @@ async function initialize(): Promise<InitializeParameters> {
 		}
 	}
 
+	controllerConfig.set("controller.version", version); // Allows tracking last loaded version
+
 	if (!controllerConfig.get("controller.auth_secret")) {
 		logger.info("Generating new controller authentication secret");
 		let asyncRandomBytes = util.promisify(crypto.randomBytes);

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -523,6 +523,18 @@ export default class Controller {
 				}
 				requests.push(hostConnection.send(new lib.SystemInfoRequest()));
 			}
+			if (!this.config.restartRequired) {
+				// If a restart isn't already required, then test if a new version is installed
+				try {
+					const runningVersion = this.config.get("controller.version");
+					const packageJson = await fs.readJSON(path.join(__dirname, "..", "package.json"));
+					if (runningVersion !== packageJson.version) {
+						this.config.restartRequired = true;
+					}
+				} catch (err: any) {
+					logger.warn(`Failed to read package json:\n${err.stack ?? err.message}`);
+				}
+			}
 			requests.push(lib.gatherSystemInfo("controller", this.canRestart, this.config.restartRequired));
 			const newMetrics = await Promise.all(requests);
 			for (const metric of newMetrics) {

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -523,7 +523,7 @@ export default class Controller {
 				}
 				requests.push(hostConnection.send(new lib.SystemInfoRequest()));
 			}
-			requests.push(lib.gatherSystemInfo("controller", this.canRestart));
+			requests.push(lib.gatherSystemInfo("controller", this.canRestart, this.config.restartRequired));
 			const newMetrics = await Promise.all(requests);
 			for (const metric of newMetrics) {
 				this.systems.set(metric);

--- a/packages/host/host.ts
+++ b/packages/host/host.ts
@@ -176,13 +176,14 @@ async function startHost() {
 		}
 	}
 
+	hostConfig.set("host.version", version); // Allows tracking last loaded version
+
 	if (command === "config") {
 		await lib.handleConfigCommand(args, hostConfig, args.config);
 		return;
 	}
 
 	// If we get here the command was run
-
 	await fs.ensureDir(hostConfig.get("host.instances_directory"));
 	await fs.ensureDir(hostConfig.get("host.mods_directory"));
 	await fs.ensureDir("modules");

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -798,6 +798,18 @@ export default class Host extends lib.Link {
 	}
 
 	async handleSystemInfoRequest() {
+		if (!this.config.restartRequired) {
+			// If a restart isn't already required, then test if a new version is installed
+			try {
+				const runningVersion = this.config.get("host.version");
+				const packageJson = await fs.readJSON(path.join(__dirname, "..", "package.json"));
+				if (runningVersion !== packageJson.version) {
+					this.config.restartRequired = true;
+				}
+			} catch (err: any) {
+				logger.warn(`Failed to read package json:\n${err.stack ?? err.message}`);
+			}
+		}
 		return lib.gatherSystemInfo(this.config.get("host.id"), this.canRestart, this.config.restartRequired);
 	}
 

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -798,7 +798,7 @@ export default class Host extends lib.Link {
 	}
 
 	async handleSystemInfoRequest() {
-		return lib.gatherSystemInfo(this.config.get("host.id"), this.canRestart);
+		return lib.gatherSystemInfo(this.config.get("host.id"), this.canRestart, this.config.restartRequired);
 	}
 
 	async handleHostMetricsRequest() {

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -4,6 +4,7 @@ import type { PluginNodeEnvInfo, PluginWebpackEnvInfo } from "../plugin";
 import { Static } from "@sinclair/typebox";
 
 export interface ControllerConfigFields {
+	"controller.version": string;
 	"controller.name": string;
 	"controller.mods_directory": string;
 	"controller.database_directory": string;
@@ -46,6 +47,12 @@ export class ControllerConfig extends classes.Config<ControllerConfigFields> {
 	}
 
 	static fieldDefinitions: classes.ConfigDefs<ControllerConfigFields> = {
+		"controller.version": {
+			type: "string",
+			initialValue: "", // Set on start
+			readonly: ["controller"],
+			hidden: true,
+		},
 		"controller.name": {
 			title: "Name",
 			description: "Name of the cluster.",
@@ -215,6 +222,7 @@ export class ControllerConfig extends classes.Config<ControllerConfigFields> {
 }
 
 export interface HostConfigFields {
+	"host.version": string;
 	"host.name": string;
 	"host.id": number;
 	"host.factorio_directory": string;
@@ -237,6 +245,12 @@ export interface HostConfigFields {
 export class HostConfig extends classes.Config<HostConfigFields> {
 	declare static fromJSON: (json: classes.ConfigSchema, location: classes.ConfigLocation) => HostConfig;
 	static fieldDefinitions: classes.ConfigDefs<HostConfigFields> = {
+		"host.version": {
+			type: "string",
+			initialValue: "", // Set on start
+			readonly: ["host"],
+			hidden: true,
+		},
 		"host.name": {
 			description: "Name of the host",
 			type: "string",

--- a/packages/lib/src/data/messages_controller.ts
+++ b/packages/lib/src/data/messages_controller.ts
@@ -250,6 +250,7 @@ export class SystemInfo {
 		public diskCapacity: number,
 		public diskAvailable: number,
 		public canRestart: boolean,
+		public restartRequired: boolean,
 		/** Millisecond Unix timestamp this entry was last updated at */
 		public updatedAtMs: number,
 		public isDeleted: boolean,
@@ -268,6 +269,7 @@ export class SystemInfo {
 		"diskCapacity": Type.Number(),
 		"diskAvailable": Type.Number(),
 		"canRestart": Type.Boolean(),
+		"restartRequired": Type.Boolean(),
 		"updatedAtMs": Type.Number(),
 		"isDeleted": Type.Boolean(),
 	});
@@ -286,6 +288,7 @@ export class SystemInfo {
 			json.diskCapacity,
 			json.diskAvailable,
 			json.canRestart,
+			json.restartRequired,
 			json.updatedAtMs,
 			json.isDeleted,
 		);

--- a/packages/lib/src/system_collectors.ts
+++ b/packages/lib/src/system_collectors.ts
@@ -134,7 +134,7 @@ function minZip<T>(a: T[], b: T[]): [T, T][] {
 
 let previousTotalCpuMs: number[] = [];
 let previousIdleCpuMs: number[] = [];
-export async function gatherSystemInfo(id: SystemInfo["id"], canRestart: boolean) {
+export async function gatherSystemInfo(id: SystemInfo["id"], canRestart: boolean, restartRequired: boolean) {
 	const cpus = os.cpus();
 	const currentTotalCpuMs = cpus.map(({ times }) => times.user + times.idle + times.irq + times.nice + times.sys);
 	const currentIdleCpuMs = cpus.map(({ times }) => times.idle);
@@ -165,6 +165,7 @@ export async function gatherSystemInfo(id: SystemInfo["id"], canRestart: boolean
 		diskCapacity,
 		diskAvailable,
 		canRestart,
+		restartRequired,
 		Date.now(),
 		false,
 	);

--- a/packages/web_ui/src/components/ControllerPage.tsx
+++ b/packages/web_ui/src/components/ControllerPage.tsx
@@ -1,5 +1,6 @@
 import React, {useContext, useState} from "react";
-import { Button, Descriptions, Flex, Popconfirm, Space, Typography } from "antd";
+import { Button, Descriptions, Flex, Popconfirm, Space, Tooltip, Typography } from "antd";
+import { ExclamationCircleOutlined } from "@ant-design/icons";
 
 import * as lib from "@clusterio/lib";
 
@@ -54,16 +55,20 @@ export default function ControllerPage() {
 				}
 				{
 					account.hasPermission("core.controller.restart")
-					&& <Button
-						disabled={system?.canRestart === false}
-						onClick={() => {
-							control.send(
-								new lib.ControllerRestartRequest()
-							).catch(notifyErrorHandler("Error restarting controller"));
-						}}
-					>
-						Restart
-					</Button>
+					&& <Tooltip title={system?.restartRequired ? "Restart Required" : null}>
+						<Button
+							disabled={system?.canRestart === false}
+							onClick={() => {
+								control.send(
+									new lib.ControllerRestartRequest()
+								).catch(notifyErrorHandler("Error restarting controller"));
+							}}
+						>
+							Restart
+							{!system?.restartRequired ? undefined
+								: <ExclamationCircleOutlined style={{ color: "yellow" }}/>}
+						</Button>
+					</Tooltip>
 				}
 			</Space>}
 		/>

--- a/packages/web_ui/src/components/HostViewPage.tsx
+++ b/packages/web_ui/src/components/HostViewPage.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from "react";
-import { Descriptions, Spin, Tag, Typography, Button, Space, Modal, Popconfirm, Flex } from "antd";
+import { Descriptions, Spin, Tag, Typography, Button, Space, Modal, Popconfirm, Flex, Tooltip } from "antd";
+import { ExclamationCircleOutlined } from "@ant-design/icons";
 import { useParams } from "react-router-dom";
 
 import * as lib from "@clusterio/lib";
@@ -89,17 +90,21 @@ export default function HostViewPage() {
 		}
 		{
 			account.hasPermission("core.host.restart")
-			&& <Button
-				disabled={system?.canRestart === false}
-				onClick={() => {
-					control.sendTo(
-						{ hostId },
-						new lib.HostRestartRequest()
-					).catch(notifyErrorHandler("Error restarting host"));
-				}}
-			>
-				Restart
-			</Button>
+			&& <Tooltip title={system?.restartRequired ? "Restart Required" : null}>
+				<Button
+					disabled={system?.canRestart === false}
+					onClick={() => {
+						control.sendTo(
+							{ hostId },
+							new lib.HostRestartRequest()
+						).catch(notifyErrorHandler("Error restarting host"));
+					}}
+				>
+					Restart
+					{!system?.restartRequired ? undefined
+						: <ExclamationCircleOutlined style={{ color: "yellow" }} />}
+				</Button>
+			</Tooltip>
 		}
 	</Space>;
 

--- a/packages/web_ui/src/components/HostsPage.tsx
+++ b/packages/web_ui/src/components/HostsPage.tsx
@@ -1,10 +1,11 @@
 import React, { useContext, useRef, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button, Flex, Form, InputNumber, Modal, Progress, Switch, Table, Tag, Typography } from "antd";
-import CopyOutlined from "@ant-design/icons/lib/icons/CopyOutlined";
+import { Button, Flex, Form, InputNumber, Modal, Progress, Space, Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { ExclamationCircleOutlined, CopyOutlined } from "@ant-design/icons";
 
 import * as lib from "@clusterio/lib";
 
+import webUiPackage from "../../package.json";
 import { useAccount } from "../model/account";
 import ControlContext from "./ControlContext";
 import PageHeader from "./PageHeader";
@@ -13,6 +14,7 @@ import PluginExtra from "./PluginExtra";
 import {
 	MetricCpuRatio, MetricCpuUsed, MetricMemoryRatio, MetricMemoryUsed,
 	MetricDiskUsed, MetricDiskRatio,
+	RestartRequired,
 } from "./system_metrics";
 import { useHosts } from "../model/host";
 import { useSystems } from "../model/system";
@@ -268,6 +270,12 @@ export default function HostsPage() {
 				{
 					title: "Version",
 					dataIndex: "version",
+					render: (_, host) => <Space>
+						{host.version}
+						{webUiPackage.version === host.version ? undefined : <Tooltip title="Version Mismatch">
+							<ExclamationCircleOutlined style={{ color: "yellow" }}/>
+						</Tooltip>}
+					</Space>,
 					sorter: (a, b) => strcmp(a.version, b.version),
 				},
 				{
@@ -278,11 +286,14 @@ export default function HostsPage() {
 				{
 					title: "Connected",
 					key: "connected",
-					render: (_, host) => <Tag
-						color={host.connected ? "#389e0d" : "#cf1322"}
-					>
-						{host.connected ? "Connected" : "Disconnected"}
-					</Tag>,
+					render: (_, host) => <>
+						<Tag
+							color={host.connected ? "#389e0d" : "#cf1322"}
+						>
+							{host.connected ? "Connected" : "Disconnected"}
+						</Tag>
+						<RestartRequired system={systems.get(host.id)}/>
+					</>,
 					sorter: (a, b) => Number(a.connected) - Number(b.connected),
 				},
 			]}

--- a/packages/web_ui/src/components/system_metrics.tsx
+++ b/packages/web_ui/src/components/system_metrics.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 import * as lib from "@clusterio/lib";
-import { Progress } from "antd";
+import { Progress, Tooltip } from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
 
 export function MetricCpuRatio(props: { system?: lib.SystemInfo }) {
 	if (!props.system) {
@@ -52,4 +53,13 @@ export function MetricDiskUsed(props: { system?: lib.SystemInfo }) {
 	const used = lib.formatBytes(props.system.diskUsed);
 	const capacity = lib.formatBytes(props.system.diskCapacity);
 	return `${used} / ${capacity}`;
+}
+
+export function RestartRequired(props: { system?: lib.SystemInfo }) {
+	if (!props.system || !props.system.restartRequired) {
+		return "";
+	}
+	return <Tooltip title="Restart Required">
+		<ReloadOutlined style={{ color: "yellow" }}/>
+	</Tooltip>;
 }

--- a/test/lib/data/SystemInfo.js
+++ b/test/lib/data/SystemInfo.js
@@ -21,6 +21,7 @@ describe("lib/data/SystemInfo", function() {
 				2048,
 				512,
 				false,
+				false,
 				0,
 				false
 			);


### PR DESCRIPTION
Adds an indicator to the restart button on the controller and host pages when a "requires restart" config value has been modified. This indicator also appears when a new version of clusterio has been installed but is not the active version. The host list shows this indicator next to the status and also shows an indicator when there is a version mismatch with the controller.

## Changelog
```
### Features
- Added pending update detection for host and controller. [#758](https://github.com/clusterio/clusterio/issues/758)
- Added restart required indicator for host and controller. [#758](https://github.com/clusterio/clusterio/issues/758)
- Added version mismatch indicator in host list. [#758](https://github.com/clusterio/clusterio/issues/758)
```
