### PR TITLE
Add bidirectional whitelist sync

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -266,6 +266,15 @@ export default class Instance extends lib.Link {
 			}
 		});
 
+		this.server.on("whitelist-change", (added: string[], removed: string[]) => {
+			for (const player of added) {
+				this._recordUserUpdate("WHITELISTED", player);
+			}
+			for (const player of removed) {
+				this._recordUserUpdate("UNWHITELISTED", player);
+			}
+		});
+
 		this.handle(lib.InstanceExtractPlayersRequest, this.handleInstanceExtractPlayersRequest.bind(this));
 		this.handle(lib.InstanceAdminlistUpdateEvent, this.handleInstanceAdminlistUpdateEvent.bind(this));
 		this.handle(lib.InstanceBanlistUpdateEvent, this.handleInstanceBanlistUpdateEvent.bind(this));
@@ -1031,7 +1040,6 @@ end`.replace(/\r?\n/g, " ");
 		name: string,
 		reason: string = ""
 	) {
-		// TODO: Implement bidirectional whitelist sync, likely by watching the json file
 		const addr = lib.Address.fromShorthand("allInstances");
 		const expectedIndex = this._expectedUserUpdates.findIndex(
 			expected => expected.name === name && expected.action === action && expected.reason === reason

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -476,12 +476,13 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 		},
 		"factorio.enable_whitelist": {
 			description: "Turn on whitelist for joining the server.",
+			restartRequired: true, // Because of the cli option "--use-server-whitelist"
 			type: "boolean",
 			initialValue: false,
 		},
 		"factorio.enable_authserver_bans": {
 			description: "Turn on Factorio.com based multiplayer bans.",
-			restartRequired: true,
+			restartRequired: true, // Because of the cli option "--use-authserver-bans"
 			type: "boolean",
 			initialValue: false,
 		},
@@ -499,13 +500,13 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 		},
 		"factorio.verbose_logging": {
 			description: "Enable verbose logging on the Factorio server",
-			restartRequired: true,
+			restartRequired: true, // Because of the cli option "--verbose"
 			type: "boolean",
 			initialValue: false,
 		},
 		"factorio.console_logging": {
 			description: "Enable console logging to a separate file, useful for 3rd party integrations",
-			restartRequired: true,
+			restartRequired: true, // Because of the cli option "--console-log"
 			type: "boolean",
 			initialValue: false,
 		},
@@ -522,10 +523,10 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			initialValue: "bidirectional",
 		},
 		"factorio.sync_whitelist": {
-			description: "Synchronize whitelist with the controller",
+			description: "Synchronize whitelist with the controller (whitelist must be enabled)",
 			type: "string",
-			enum: ["disabled", "enabled"], // TODO: Implement bidirectional
-			initialValue: "enabled",
+			enum: ["disabled", "enabled", "bidirectional"],
+			initialValue: "bidirectional",
 		},
 		"factorio.sync_banlist": {
 			description: "Synchronize banlist with the controller",

--- a/test/host/Instance.js
+++ b/test/host/Instance.js
@@ -200,7 +200,7 @@ describe("class Instance", function() {
 		beforeEach(function() {
 			instance.config.set("factorio.sync_banlist", "bidirectional");
 			instance.config.set("factorio.sync_adminlist", "bidirectional");
-			// instance.config.set("factorio.sync_whitelist", "bidirectional"); // Not Implemented
+			instance.config.set("factorio.sync_whitelist", "bidirectional");
 		});
 		it("should send InstanceBanlistUpdateEvent for bans", function() {
 			instance._recordUserUpdate("BAN", "player", "reason");
@@ -257,7 +257,6 @@ describe("class Instance", function() {
 			);
 		});
 		it("should send InstanceWhitelistUpdateEvent for whitelist add", function() {
-			this.skip(); // Bidirectional not implemented
 			instance._recordUserUpdate("WHITELISTED", "player");
 			assert.deepEqual(
 				connector.sentMessages[0],
@@ -271,7 +270,6 @@ describe("class Instance", function() {
 			);
 		});
 		it("should send InstanceWhitelistUpdateEvent for whitelist remove", function() {
-			this.skip(); // Bidirectional not implemented
 			instance._recordUserUpdate("UNWHITELISTED", "player");
 			assert.deepEqual(
 				connector.sentMessages[0],

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -30,6 +30,7 @@ describe("Clusterio Instance", function() {
 
 		// Create a new instance
 		await execCtl(`instance create ${instName} --id ${instId}`);
+		await execCtl(`instance config set ${instName} factorio.enable_whitelist true`);
 		await execCtl(`instance config set-prop ${instName} factorio.settings visibility "${visibility}"`);
 		await execCtl(`instance config set-prop ${instName} factorio.settings require_user_verification false`);
 		await execCtl(`instance assign ${instName} 4`);
@@ -42,6 +43,7 @@ describe("Clusterio Instance", function() {
 
 		// Create a new alt instance
 		await execCtl(`instance create ${instAltName} --id ${instAltId}`);
+		await execCtl(`instance config set ${instAltName} factorio.enable_whitelist true`);
 		await execCtl(`instance config set-prop ${instAltName} factorio.settings visibility "${visibility}"`);
 		await execCtl(`instance config set-prop ${instAltName} factorio.settings require_user_verification false`);
 		await execCtl(`instance assign ${instAltName} 4`);
@@ -98,12 +100,14 @@ describe("Clusterio Instance", function() {
 				it("should respond to a player ban and unban event", async function() {
 					await execCtl(`instance config set ${instName} factorio.sync_banlist bidirectional`);
 					await sendRcon(instId, "/ban BannedPlayer");
+					await lib.wait(15); // Propagation time, 10ms worked for me, so i made it 15ms
 					const userBanned = await getUser("BannedPlayer");
 					assert(userBanned.isBanned, "Player is not banned");
 					const isAltBanned = await sendRcon(instAltId, "/banlist get BannedPlayer");
 					assert.equal(isAltBanned, "BannedPlayer is banned.\n", "User is not banned on alt");
 
 					await sendRcon(instId, "/unban BannedPlayer");
+					await lib.wait(15); // Propagation time, 10ms worked for me, so i made it 15ms
 					const userUnbanned = await getUser("BannedPlayer");
 					assert(!userUnbanned.isBanned, "Player is not unbanned");
 					const isAltUnbanned = await sendRcon(instAltId, "/banlist get BannedPlayer");
@@ -113,6 +117,7 @@ describe("Clusterio Instance", function() {
 					// Because there is no admin list command this test will be different to the other two
 					await execCtl(`instance config set ${instName} factorio.sync_adminlist bidirectional`);
 					await sendRcon(instId, "/promote AdminPlayer");
+					await lib.wait(15); // Propagation time, 10ms worked for me, so i made it 15ms
 					const userPromote = await getUser("AdminPlayer");
 					assert(userPromote.isAdmin, "Player is not promoted");
 					const isAltPromoted = await sendRcon(instAltId, "/promote AdminPlayer");
@@ -122,6 +127,7 @@ describe("Clusterio Instance", function() {
 					);
 
 					await sendRcon(instId, "/demote AdminPlayer");
+					await lib.wait(15); // Propagation time, 10ms worked for me, so i made it 15ms
 					const userDemote = await getUser("AdminPlayer");
 					assert(!userDemote.isAdmin, "Player is not demoted");
 					const isAltDemoted = await sendRcon(instAltId, "/demote AdminPlayer");
@@ -131,21 +137,22 @@ describe("Clusterio Instance", function() {
 					);
 				});
 				it("should respond to a player whitelist add and remove event", async function() {
-					this.skip(); // Not implemented
 					await execCtl(`instance config set ${instName} factorio.sync_whitelist bidirectional`);
 					await sendRcon(instId, "/whitelist add WhitelistPlayer");
+					await lib.wait(15); // Propagation time, 10ms worked for me, so i made it 15ms
 					const userAdded = await getUser("WhitelistPlayer");
 					assert(userAdded.isWhitelisted, "Player is not whitelisted");
-					const isAltAdded = await sendRcon(instAltId, "/whitelist get whitelisted");
+					const isAltAdded = await sendRcon(instAltId, "/whitelist get WhitelistPlayer");
 					assert.equal(isAltAdded,
 						"WhitelistPlayer is whitelisted.\n",
 						"User is not whitelisted on alt"
 					);
 
 					await sendRcon(instId, "/whitelist remove WhitelistPlayer");
+					await lib.wait(15); // Propagation time, 10ms worked for me, so i made it 15ms
 					const userRemoved = await getUser("WhitelistPlayer");
 					assert(!userRemoved.isWhitelisted, "Player is not unwhitelisted");
-					const isAltRemoved = await sendRcon(instAltId, "/whitelist get whitelisted");
+					const isAltRemoved = await sendRcon(instAltId, "/whitelist get WhitelistPlayer");
 					assert.equal(isAltRemoved,
 						"WhitelistPlayer is not whitelisted.\n",
 						"User is not unwhitelisted on alt"


### PR DESCRIPTION
Adds bidirectional whitelist syncing using file watching. This comes with three limitations:
1) `fs.watch` is not guaranteed to work on all platforms, although all the [major platforms are covered](https://nodejs.org/docs/latest/api/fs.html#availability).
2) To enable file watching, the cli option `--use-server-whitelist` is required, this is already handled by `enable_whitelist` but does create a dependency between the options.
3) Although it is possible to detect the use of `/whitelist enable/disable` using `on_console_command`, it is not possible to sync this to the config because `enable_whitelist` requires a server restart. This behaviour was previously undocumented but is a result of it using `--use-server-whitelist`.

Closes: #716

## Changelog
```
### Features
- Added bidirectional whitelist syncing. [#716](https://github.com/clusterio/clusterio/issues/716)
```
