### PR TITLE
Add missing migrations for system info and tests

### DIFF
--- a/packages/controller/index.ts
+++ b/packages/controller/index.ts
@@ -5,6 +5,7 @@ export { default as ControllerRouter } from "./src/ControllerRouter";
 export { default as ControlConnection } from "./src/ControlConnection";
 export { default as HostConnection } from "./src/HostConnection";
 export { default as InstanceInfo } from "./src/InstanceInfo";
+export { default as HostInfo } from "./src/HostInfo";
 export { default as BaseControllerPlugin } from "./src/BaseControllerPlugin";
 export { default as UserManager } from "./src/UserManager";
 export { default as WsServer } from "./src/WsServer";

--- a/test/messages/controller.test.js
+++ b/test/messages/controller.test.js
@@ -16,7 +16,7 @@ describe("messages/controller", function() {
 			lib.Address.fromShorthand("controller"),
 			lib.Address.fromShorthand({ controlId: 1 }),
 		);
-		controller = new Controller(lib.logger, [], "", controllerConfig);
+		controller = new Controller(lib.logger, [], controllerConfig);
 		const user = new ControllerUser(controller.userManager, undefined, "test");
 		controlConnection = new ControlConnection({ version: "2.0.0" }, connection, controller, user, 1);
 	});

--- a/test/messages/host.test.js
+++ b/test/messages/host.test.js
@@ -14,7 +14,7 @@ describe("messages/controller", function() {
 			lib.Address.fromShorthand({ hostId: 1 }),
 			lib.Address.fromShorthand("controller"),
 		);
-		host = new Host(hostConnector, "", hostConfig, undefined, []);
+		host = new Host(hostConnector, hostConfig, undefined, []);
 	});
 
 	describe("HostUpdateRequest", function() {

--- a/test/messages/plugin.test.js
+++ b/test/messages/plugin.test.js
@@ -19,7 +19,7 @@ describe("messages/plugin", function() {
 			lib.Address.fromShorthand("controller"),
 			lib.Address.fromShorthand({ controlId: 1 }),
 		);
-		controller = new Controller(lib.logger, [], "", controllerConfig);
+		controller = new Controller(lib.logger, [], controllerConfig);
 		const user = new ControllerUser(controller.userManager, undefined, "test");
 		controlConnection = new ControlConnection({ version: "2.0.0" }, connection, controller, user, 1);
 
@@ -28,7 +28,7 @@ describe("messages/plugin", function() {
 			lib.Address.fromShorthand({ hostId: 1 }),
 			lib.Address.fromShorthand("controller"),
 		);
-		host = new Host(hostConnector, "", hostConfig, undefined, []);
+		host = new Host(hostConnector, hostConfig, undefined, []);
 	});
 
 	describe("PluginDetails", function() {


### PR DESCRIPTION
Adds the missing migrations which should have been added for `canRestart` and `restartRequired`. Also adds the tests which were missing for these and existing migrations, and fixes 3 broken tests related to remote updates.
