### PR TITLE
Bump tests: Remove Node 18 & Add Factorio 2.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
 	"image":"mcr.microsoft.com/devcontainers/universal:2",
-	"postCreateCommand": "wget https://factorio.com/get-download/1.1.107/headless/linux64 && tar -xf linux64 && pnpm install",
+	"postCreateCommand": "mkdir factorio && cd factorio && wget https://factorio.com/get-download/1.1.107/headless/linux64 && tar -xf linux64 && mv factorio factorio_1.1.107 && rm linux64 && wget https://factorio.com/get-download/2.0.47/headless/linux64 && tar -xf linux64 && mv factorio factorio_2.0.47 && rm linux64 && pnpm install",
 }

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        factorio-version: [1.1.110]
-        # Supported versions are latest stable/experimental and one minor version before stable (even if from a previous major) 
+        # Supported versions are active lts and maintenance see https://nodejs.org/en/about/releases/
+        node-version: [20.x, 22.x]
+        # Supported versions are latest stable and one minor version before stable (even if from a previous major) 
+        factorio-version: [1.1.110, 2.0.47]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,13 +31,13 @@ jobs:
     - name: Use Factorio ${{ matrix.factorio-version }}
       run: wget -q -O factorio.tar.gz https://www.factorio.com/get-download/${{ matrix.factorio-version }}/headless/linux64 && tar -xf factorio.tar.gz && rm factorio.tar.gz
     - name: Run tests
-      if: ${{ matrix.node-version != '18.x' || matrix.factorio-version != '1.1.110' }}
+      if: ${{ matrix.node-version != '20.x' || matrix.factorio-version != '1.1.110' }}
       run: pnpm test
     - name: Run coverage
-      if: ${{ matrix.node-version == '18.x' && matrix.factorio-version == '1.1.110' }}
+      if: ${{ matrix.node-version == '20.x' && matrix.factorio-version == '1.1.110' }}
       run: pnpm run ci-cover
     - name : Upload coverage to Codecov
-      if: ${{ matrix.node-version == '18.x' && matrix.factorio-version == '1.1.110' }}
+      if: ${{ matrix.node-version == '20.x' && matrix.factorio-version == '1.1.110' }}
       uses: codecov/codecov-action@v4
       with:
         files: ./coverage/lcov.info

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -286,11 +286,14 @@ describe("player_auth", function() {
 						new SetVerifyCodeRequest("test", verify_code)
 					);
 
+					const user = controllerPlugin.controller.userManager.getByName("test");
+					const token = controllerPlugin.controller.userManager.signUserToken(user);
 					const verifyResult = await postJSON(
 						`${controllerUrl}/api/player_auth/verify`,
 						{ player_code: playerCode, verify_code, verify_token }
 					);
-					assert.equal((await verifyResult.json()).verified, true);
+					assert.equal(verifyResult.status, 200);
+					assert.deepEqual(await verifyResult.json(), { verified: true, token: token });
 				});
 			});
 		});

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -707,9 +707,8 @@ describe("Integration of Clusterio", function() {
 				for (let [, , configName, expectedResult] of testConfigs) {
 					assert.equal(await sendRcon(44, `/config get ${configName}`), `${expectedResult}\n`);
 				}
-			});
-			it("should not change the instance status", async function() {
-				slowTest(this);
+
+				// should not change instance status
 				await checkInstanceStatus(44, "running");
 			});
 			it("should allow creating and removing props", async function() {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
 		"lib": ["es2023"],
-		"module": "node16",
+		"module": "nodenext",
 		"moduleResolution": "node16",
 		"target": "es2022",
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Node v18 is now end of life so we no longer offically support it; so we can stop testing it and bump our recomended ts config. At the same time the merge of #765 means that all tests are passing in factorio 2.0 and can be safely added to the test suite. Also fixed some flakey tests while I was checking results.

Draft until #766 is merged which implements fixes for broken tests.


## Changelog
```
### Meta
- Node 18 has reached end of life and is no longer maintained, we no longer guarantee support for it.
```
