### PR TITLE
Refactor execCtl and Ctl to speed up unit testing

### DIFF
--- a/plugins/global_chat/test/plugin.js
+++ b/plugins/global_chat/test/plugin.js
@@ -26,7 +26,6 @@ describe("global_chat plugin", function() {
 		let instancePlugin;
 
 		before(async function() {
-			lib.Link.register(ChatEvent);
 			instancePlugin = new instance.InstancePlugin(info, new mock.MockInstance(), new mock.MockHost());
 			await instancePlugin.init();
 		});

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -13,7 +13,8 @@ const { wait } = lib;
 const testStrings = require("../lib/factorio/test_strings");
 const {
 	TestControl, TestControlConnector, url, controlToken, slowTest,
-	exec, execCtl, sendRcon, getControl, spawnNode, instancesDir, factorioDir,
+	exec, execCtl, execCtlProcess, execHost, sendRcon, getControl,
+	spawnNode, instancesDir, factorioDir,
 } = require("./index");
 
 
@@ -39,11 +40,11 @@ async function startAltHost() {
 	await fs.remove(path.join("temp", "test", "alt-instances"));
 	await fs.remove(path.join("temp", "test", "alt-mods"));
 	await execCtl(`host create-config --id 5 --name alt-host --generate-token --output ${config}`);
-	await exec(`node ../../packages/host --config ${config} config set host.tls_ca ../../test/file/tls/cert.pem`);
-	await exec(`node ../../packages/host --config ${config} config set host.instances_directory alt-instances`);
+	await execHost(`--config ${config} config set host.tls_ca ../../test/file/tls/cert.pem`);
+	await execHost(`--config ${config} config set host.instances_directory alt-instances`);
 	const dir = path.isAbsolute(factorioDir) ? factorioDir : path.join("..", "..", factorioDir);
-	await exec(`node ../../packages/host --config ${config} config set host.factorio_directory ${dir}`);
-	await exec(`node ../../packages/host --config ${config} config set host.mods_directory alt-mods`);
+	await execHost(`--config ${config} config set host.factorio_directory ${dir}`);
+	await execHost(`--config ${config} config set host.mods_directory alt-mods`);
 	return await spawnAltHost(config);
 }
 
@@ -259,9 +260,9 @@ describe("Integration of Clusterio", function() {
 
 		describe("controller config set", function() {
 			it("sets given config option", async function() {
-				await execCtl('controller config set controller.name "Test Cluster"');
+				await execCtl("controller config set controller.name Test-Cluster");
 				let result = await getControl().send(new lib.ControllerConfigGetRequest());
-				assert.equal(result["controller.name"], "Test Cluster");
+				assert.equal(result["controller.name"], "Test-Cluster");
 			});
 			it("should not allow setting auth_secret", async function() {
 				await assert.rejects(execCtl("controller config set controller.auth_secret root"));
@@ -329,7 +330,7 @@ describe("Integration of Clusterio", function() {
 		describe("host config", function() {
 			it("changes host config", async function() {
 				await execCtl("host config set 4 host.name My-Host");
-				const result = await execCtl("host config list 4");
+				const result = await execCtlProcess("host config list 4");
 				assert(/My-Host/.test(result.stdout), "New host name not in config output");
 			});
 			it("should not allow setting host.controller_token", async function() {
@@ -416,9 +417,12 @@ describe("Integration of Clusterio", function() {
 				slowTest(this);
 				let sawDisconnected;
 				await runWithAltHost(async () => {
-					getControl().hostUpdates = [];
+					const control = getControl();
+					control.hostUpdates = [];
+					await wait(50); // Allow for host to update instances
 					await execCtl("host revoke-token 5");
-					for (let update of getControl().hostUpdates) {
+					await wait(50); // Allow controller to notify control
+					for (let update of control.hostUpdates) {
 						if (update.name !== "alt-host") {
 							continue;
 						}
@@ -448,10 +452,8 @@ describe("Integration of Clusterio", function() {
 				assert.equal(instances.get(44).status, "unassigned", "incorrect instance status");
 
 				// Make sure the following tests does not fail due to not having internet
-				let value = JSON.stringify({ lan: true, public: false }).replace(
-					/"/g, process.platform === "win32" ? '""' : '\\"'
-				);
-				await execCtl(`instance config set-prop test factorio.settings visibility "${value}"`);
+				const value = jsonArg({ lan: true, public: false });
+				await execCtlProcess(`instance config set-prop test factorio.settings visibility ${value}`);
 				await execCtl("instance config set-prop test factorio.settings require_user_verification false");
 			});
 			it("can clone an instance", async function() {
@@ -500,7 +502,7 @@ describe("Integration of Clusterio", function() {
 		describe("instance save list", function() {
 			it("lists the created save", async function() {
 				slowTest(this);
-				let result = await execCtl("instance save list test");
+				let result = await execCtlProcess("instance save list test");
 				assert(/world\.zip/.test(result.stdout), "world.zip not present in list save output");
 			});
 		});
@@ -698,8 +700,8 @@ describe("Integration of Clusterio", function() {
 				];
 
 				for (let [prop, value] of testConfigs) {
-					let args = `test factorio.settings ${prop} ${jsonArg(value)}`;
-					await execCtl(`instance config set-prop ${args}`);
+					const args = `test factorio.settings ${prop} ${jsonArg(value)}`;
+					await execCtlProcess(`instance config set-prop ${args}`);
 				}
 
 				// Do this afterwards to leave enough to time for the
@@ -909,6 +911,7 @@ describe("Integration of Clusterio", function() {
 				await execCtl("instance config set 44 research_sync.load_plugin false");
 				await execCtl("instance config set 44 statistics_exporter.load_plugin false");
 				await execCtl("instance config set 44 subspace_storage.load_plugin false");
+				await execCtl("instance config set 44 inventory_sync.load_plugin false");
 
 				await execCtl("instance start 44");
 				const instance = (await getInstances()).get(44);
@@ -1188,7 +1191,7 @@ describe("Integration of Clusterio", function() {
 			});
 			it("should allow setting all fields", async function() {
 				const color = { r: 1, g: 0, b: 1, a: 0 };
-				await execCtl(
+				await execCtlProcess(
 					"mod-pack create full-pack 0.17.59 " +
 					"--description Description " +
 					"--mods empty_mod:1.0.0 " +
@@ -1220,7 +1223,7 @@ describe("Integration of Clusterio", function() {
 		describe("mod-pack list", function() {
 			let result = null;
 			it("runs", async function() {
-				result = await execCtl("mod-pack list");
+				result = await execCtlProcess("mod-pack list");
 			});
 			it("contains defaults", function() {
 				assert(result !== null, "Failed to return a value");
@@ -1249,7 +1252,7 @@ describe("Integration of Clusterio", function() {
 				reference.settings["runtime-global"].set("MyDouble", { value: 12.25 });
 				reference.settings["runtime-per-user"].set("MyString", { value: "a-string" });
 				await execCtl(`mod-pack import ${reference.toModPackString()}`);
-				const result = await execCtl("mod-pack export imported-pack");
+				const result = await execCtlProcess("mod-pack export imported-pack");
 				const roundtrip = lib.ModPack.fromModPackString(result.stdout.trim());
 				roundtrip.id = reference.id;
 				assert.deepEqual(roundtrip, reference);
@@ -1308,7 +1311,7 @@ describe("Integration of Clusterio", function() {
 
 		describe("mod show", function() {
 			it("gives details of a mod", async function() {
-				let result = await execCtl("mod show empty_mod 1.0.0");
+				let result = await execCtlProcess("mod show empty_mod 1.0.0");
 				let hash = await lib.hashFile(path.join("temp", "test", "mods", "empty_mod_1.0.0.zip"));
 				let stat = await fs.stat(path.join("temp", "test", "mods", "empty_mod_1.0.0.zip"));
 				assert.equal(
@@ -1333,14 +1336,14 @@ describe("Integration of Clusterio", function() {
 
 		describe("mod list", function() {
 			it("shows the list of mods", async function() {
-				let result = await execCtl("mod list");
+				let result = await execCtlProcess("mod list");
 				assert(result.stdout.indexOf("empty_mod") !== -1, "empty_mod is not in the list");
 			});
 		});
 
 		describe("mod search", function() {
 			it("searches the list of mods", async function() {
-				let result = await execCtl("mod search 1.1 name:empty_mod");
+				let result = await execCtlProcess("mod search 1.1 name:empty_mod");
 				assert(result.stdout.indexOf("empty_mod") !== -1, "empty_mod is not in the result");
 			});
 		});
@@ -1414,7 +1417,7 @@ describe("Integration of Clusterio", function() {
 		describe("role edit", function() {
 			it("should modify the given role", async function() {
 				let args = "--name new --description \"A new role\" --set-perms";
-				await execCtl(`role edit temp ${args}`);
+				await execCtlProcess(`role edit temp ${args}`);
 				let roles = await getControl().send(new lib.RoleListRequest());
 				let newRole = roles.find(role => role.name === "new");
 				assert.deepEqual(newRole, new lib.Role(5, "new", "A new role", new Set()));
@@ -1495,7 +1498,7 @@ describe("Integration of Clusterio", function() {
 		describe("user set-roles", function() {
 			it("should set the roles on the user", async function() {
 				getControl().userUpdates = [];
-				await execCtl('user set-roles temp "Cluster Admin"');
+				await execCtlProcess('user set-roles temp "Cluster Admin"');
 				let users = await getControl().send(new lib.UserListRequest());
 				let tempUser = users.find(user => user.id === "temp");
 				assert.deepEqual(tempUser.roleIds, new Set([0]));
@@ -1503,7 +1506,7 @@ describe("Integration of Clusterio", function() {
 			});
 
 			it("should restrict actions based on roles", async function() {
-				await execCtl('user set-roles temp "Player"');
+				await execCtl("user set-roles temp Player");
 				let tempControl;
 				try {
 					let tlsCa = await fs.readFile("test/file/tls/cert.pem");
@@ -1657,7 +1660,6 @@ describe("Integration of Clusterio", function() {
 				await execCtl("user create export_control");
 			});
 			it("should export users", async function() {
-				slowTest(this);
 				await execCtl("user set-admin export_user --create");
 				await execCtl("user set-whitelisted export_user");
 				await execCtl("user export --users user-export.json");
@@ -1669,7 +1671,6 @@ describe("Integration of Clusterio", function() {
 				});
 			});
 			it("should export bans", async function() {
-				slowTest(this);
 				await execCtl("user set-banned export_ban --create");
 				await execCtl("user set-banned export_ban_reason --create --reason banned");
 				await execCtl("user export --bans ban-export.json");

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -277,9 +277,9 @@ describe("Integration of Clusterio", function() {
 		describe("controller plugin update", function() {
 			it("runs", async function() {
 				// In dev plugins have no npm package, so best we can do is get an error from the controller
-				assert.rejects(
+				await assert.rejects(
 					execCtl("controller plugin update foo"),
-					"Plugin foo is not installed on this machine"
+					/Plugin foo is not installed on this machine/
 				);
 			});
 			// Update always fails, we can not test restart option
@@ -289,9 +289,9 @@ describe("Integration of Clusterio", function() {
 			it("runs", async function() {
 				// Default is to disallow updates, changing this value would require a restart
 				// Additionally, it can not be changed via ctl, so best we can do is get an error from the controller
-				assert.rejects(
+				await assert.rejects(
 					execCtl("controller plugin install foo"),
-					"Plugin installs are disabled on this machine"
+					/Plugin installs are disabled on this machine/
 				);
 			});
 			// Install always fails, we can not test restart option
@@ -303,9 +303,9 @@ describe("Integration of Clusterio", function() {
 			});
 			it("accepts --restart", async function() {
 				// We cannot restart the controller, so we check for controller error instead
-				assert.rejects(
+				await assert.rejects(
 					execCtl("controller update --restart"),
-					"Cannot restart, controller does not have a process monitor to restart it."
+					/Cannot restart, controller does not have a process monitor to restart it./
 				);
 			});
 		});
@@ -313,9 +313,9 @@ describe("Integration of Clusterio", function() {
 		describe("controller restart", function() {
 			it("runs", async function() {
 				// We cannot restart the controller, so we check for controller error instead
-				assert.rejects(
+				await assert.rejects(
 					execCtl("controller restart"),
-					"Cannot restart, controller does not have a process monitor to restart it."
+					/Cannot restart, controller does not have a process monitor to restart it./
 				);
 			});
 		});
@@ -359,9 +359,9 @@ describe("Integration of Clusterio", function() {
 		describe("host plugin update", function() {
 			it("runs", async function() {
 				// In dev plugins have no npm package, so best we can do is get an error from the host
-				assert.rejects(
+				await assert.rejects(
 					execCtl("host plugin update 4 foo"),
-					"Plugin foo is not installed on this machine"
+					/Plugin foo is not installed on this machine/
 				);
 			});
 			// Update always fails, we can not test restart option
@@ -371,9 +371,9 @@ describe("Integration of Clusterio", function() {
 			it("runs", async function() {
 				// Default is to disallow updates, changing this value would require a restart
 				// Additionally, it can not be changed via ctl, so best we can do is get an error from the host
-				assert.rejects(
+				await assert.rejects(
 					execCtl("host plugin install 4 foo"),
-					"Plugin installs are disabled on this machine"
+					/Plugin installs are disabled on this machine/
 				);
 			});
 			// Install always fails, we can not test restart option
@@ -385,9 +385,9 @@ describe("Integration of Clusterio", function() {
 			});
 			it("accepts --restart", async function() {
 				// We cannot restart the host, so we check for host error instead
-				assert.rejects(
+				await assert.rejects(
 					execCtl("host update 4 --restart"),
-					"Cannot restart, host does not have a process monitor to restart it."
+					/Cannot restart, host does not have a process monitor to restart it./
 				);
 			});
 		});
@@ -395,9 +395,9 @@ describe("Integration of Clusterio", function() {
 		describe("host restart", function() {
 			it("runs", async function() {
 				// We cannot restart the host, so we check for host error instead
-				assert.rejects(
+				await assert.rejects(
 					execCtl("host restart 4"),
-					"Cannot restart, host does not have a process monitor to restart it."
+					/Cannot restart, host does not have a process monitor to restart it./
 				);
 			});
 		});
@@ -466,7 +466,7 @@ describe("Integration of Clusterio", function() {
 			});
 			it("errors when cloning an invalid instance", async function() {
 				slowTest(this);
-				assert.rejects(
+				await assert.rejects(
 					execCtl("instance create testClone --id 440 --from 441"),
 					new lib.RequestError("Instance with ID 441 does not exist")
 				);
@@ -615,7 +615,7 @@ describe("Integration of Clusterio", function() {
 				assert(r1.log.some(info => /\[COMMAND\]/.test(info.message)), "Command was not sent");
 				await execCtl("instance config set test factorio.enable_script_commands false");
 
-				assert.rejects(
+				await assert.rejects(
 					execCtl("instance send-rcon test /c"),
 					new Error(
 						"Attempted to use script command while disabled. " +
@@ -1648,7 +1648,7 @@ describe("Integration of Clusterio", function() {
 				);
 			});
 			it("should reject multiple provided options", async function() {
-				assert.rejects(execCtl("user import --bans --admins import-admins.json"));
+				await assert.rejects(execCtl("user import --bans --admins import-admins.json"));
 			});
 		});
 
@@ -1779,7 +1779,7 @@ describe("Integration of Clusterio", function() {
 				assert(data.indexOf("restore_control") >= 0, "restore_control is missing");
 			});
 			it("should reject multiple provided options", async function() {
-				assert.rejects(execCtl("user restore --bans --admins restore-admins.json"));
+				await assert.rejects(execCtl("user restore --bans --admins restore-admins.json"));
 			});
 		});
 	});

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -75,12 +75,12 @@ describe("Clusterio Instance", function() {
 				if (savePatchingEnabled) {
 					// IPC expects save patching to be enabled
 					it("should do nothing for an unknown type", async function() {
-						assert.rejects(getUser("DoesNotExist"), "User should not exist");
+						await assert.rejects(getUser("DoesNotExist"), "User should not exist");
 						await sendRcon(instId,
 							`/sc ${requireApi} api.send_json("player_event",` +
 							"{ type='invalid type', name='DoesNotExist' })"
 						);
-						assert.rejects(getUser("DoesNotExist"), "User was created");
+						await assert.rejects(getUser("DoesNotExist"), "User was created");
 					});
 					it("should respond to a player join and leave event", async function() {
 						await sendRcon(instId,

--- a/test/integration/instance.js
+++ b/test/integration/instance.js
@@ -3,7 +3,7 @@ const assert = require("assert").strict;
 const lib = require("@clusterio/lib");
 
 const {
-	slowTest, exec, execCtl, sendRcon, getControl,
+	slowTest, exec, execCtl, execCtlProcess, sendRcon, getControl,
 } = require("./index");
 
 const instId = 48;
@@ -31,12 +31,12 @@ describe("Clusterio Instance", function() {
 		// Create a new instance
 		await execCtl(`instance create ${instName} --id ${instId}`);
 		await execCtl(`instance config set ${instName} factorio.enable_whitelist true`);
-		await execCtl(`instance config set-prop ${instName} factorio.settings visibility "${visibility}"`);
+		await execCtlProcess(`instance config set-prop ${instName} factorio.settings visibility "${visibility}"`);
 		await execCtl(`instance config set-prop ${instName} factorio.settings require_user_verification false`);
 		await execCtl(`instance assign ${instName} 4`);
 
 		for (const plugin of [
-			"global_chat", "research_sync", "statistics_exporter", "subspace_storage", "player_auth",
+			"global_chat", "research_sync", "statistics_exporter", "subspace_storage", "player_auth", "inventory_sync",
 		]) {
 			await execCtl(`instance config set ${instName} ${plugin}.load_plugin false`);
 		}
@@ -44,7 +44,7 @@ describe("Clusterio Instance", function() {
 		// Create a new alt instance
 		await execCtl(`instance create ${instAltName} --id ${instAltId}`);
 		await execCtl(`instance config set ${instAltName} factorio.enable_whitelist true`);
-		await execCtl(`instance config set-prop ${instAltName} factorio.settings visibility "${visibility}"`);
+		await execCtlProcess(`instance config set-prop ${instAltName} factorio.settings visibility "${visibility}"`);
 		await execCtl(`instance config set-prop ${instAltName} factorio.settings require_user_verification false`);
 		await execCtl(`instance assign ${instAltName} 4`);
 		await execCtl(`instance start ${instAltName}`);

--- a/test/lib/config/classes.js
+++ b/test/lib/config/classes.js
@@ -201,32 +201,16 @@ describe("lib/config/classes", function() {
 			const filepath = path.join("temp", "test", "config_test.json");
 			it("should throw for file and json errors", async function() {
 				await fs.writeFile(filepath, "abc");
-				await assert.rejects(
-					TestConfig.fromFile("local", filepath),
-					new Error(
-						`${filepath}: SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data`
-					)
-				);
-				await assert.rejects(
-					TestConfig.fromFile("local", `${filepath}.notExist`),
-				);
+				await assert.rejects(TestConfig.fromFile("local", filepath));
+				await assert.rejects(TestConfig.fromFile("local", `${filepath}.notExist`));
 			});
 			it("should throw on incorrect input passed", async function() {
 				await fs.writeFile(filepath, "null");
-				await assert.rejects(
-					TestConfig.fromFile("local", filepath),
-					new Error("Invalid config")
-				);
+				await assert.rejects(TestConfig.fromFile("local", filepath));
 				await fs.writeFile(filepath, "undefined");
-				await assert.rejects(
-					TestConfig.fromFile("local", filepath),
-					new Error("Invalid config")
-				);
+				await assert.rejects(TestConfig.fromFile("local", filepath));
 				await fs.writeFile(filepath, "[]");
-				await assert.rejects(
-					TestConfig.fromFile("local", filepath),
-					new Error("Invalid config")
-				);
+				await assert.rejects(TestConfig.fromFile("local", filepath));
 			});
 			it("should load defaults for missing fields", async function() {
 				await fs.writeJSON(filepath, {

--- a/test/lib/config/classes.js
+++ b/test/lib/config/classes.js
@@ -201,13 +201,13 @@ describe("lib/config/classes", function() {
 			const filepath = path.join("temp", "test", "config_test.json");
 			it("should throw for file and json errors", async function() {
 				await fs.writeFile(filepath, "abc");
-				assert.rejects(
+				await assert.rejects(
 					TestConfig.fromFile("local", filepath),
 					new Error(
 						`${filepath}: SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data`
 					)
 				);
-				assert.rejects(
+				await assert.rejects(
 					TestConfig.fromFile("local", `${filepath}.notExist`),
 				);
 			});
@@ -218,12 +218,12 @@ describe("lib/config/classes", function() {
 					new Error("Invalid config")
 				);
 				await fs.writeFile(filepath, "undefined");
-				assert.rejects(
+				await assert.rejects(
 					TestConfig.fromFile("local", filepath),
 					new Error("Invalid config")
 				);
 				await fs.writeFile(filepath, "[]");
-				assert.rejects(
+				await assert.rejects(
 					TestConfig.fromFile("local", filepath),
 					new Error("Invalid config")
 				);

--- a/test/lib/rce_ops.js
+++ b/test/lib/rce_ops.js
@@ -52,14 +52,14 @@ describe("rce_ops", function() {
 			const pluginName = "a".repeat(215);
 			await assert.rejects(
 				lib.handlePluginInstall(pluginName),
-				`Invalid plugin name: ${pluginName}`
+				{ message: `Invalid plugin name: ${pluginName}` }
 			);
 		});
 		it("rejects when invalid symbol present", async function() {
 			const pluginName = "?";
 			await assert.rejects(
 				lib.handlePluginInstall(pluginName),
-				`Invalid plugin name: ${pluginName}`
+				{ message: `Invalid plugin name: ${pluginName}` },
 			);
 		});
 		it("rejects unregistered packages", async function() {

--- a/test/lib/rce_ops.js
+++ b/test/lib/rce_ops.js
@@ -22,9 +22,9 @@ describe("rce_ops", function() {
 			await lib.handlePluginUpdate("foo", [{ npmPackage: "foo" }]);
 		});
 		it("rejects when plugin not installed", async function() {
-			assert.rejects(
+			await assert.rejects(
 				lib.handlePluginUpdate("foo", []),
-				"Plugin foo is not installed on this machine"
+				/Plugin foo is not installed on this machine/
 			);
 		});
 	});
@@ -50,14 +50,14 @@ describe("rce_ops", function() {
 		});
 		it("rejects when name too long", async function() {
 			const pluginName = "a".repeat(215);
-			assert.rejects(
+			await assert.rejects(
 				lib.handlePluginInstall(pluginName),
 				`Invalid plugin name: ${pluginName}`
 			);
 		});
 		it("rejects when invalid symbol present", async function() {
 			const pluginName = "?";
-			assert.rejects(
+			await assert.rejects(
 				lib.handlePluginInstall(pluginName),
 				`Invalid plugin name: ${pluginName}`
 			);
@@ -69,7 +69,7 @@ describe("rce_ops", function() {
 				return { ok: false };
 			};
 
-			assert.rejects(lib.handlePluginInstall("foo"), "Unknown plugin: foo");
+			await assert.rejects(lib.handlePluginInstall("foo"), /Unknown plugin: foo/);
 			assert.equal(calledWith, "https://registry.npmjs.com/foo");
 		});
 	});

--- a/test/lib/subscriptions.js
+++ b/test/lib/subscriptions.js
@@ -245,7 +245,7 @@ describe("lib/subscriptions", function() {
 				request.eventName = UnregisteredEvent.name;
 				await assert.rejects(
 					subscriptions.handleRequest(getLink(0), request, addr({ controlId: 0 }), addr("controller")),
-					new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
+					new Error(`Event ${UnregisteredEvent.name} is not a registered event`)
 				);
 			});
 			it("should not accept subscriptions to events not handled by the class", async function() {
@@ -253,7 +253,7 @@ describe("lib/subscriptions", function() {
 				request.eventName = StringPermissionEvent.name;
 				await assert.rejects(
 					subscriptions.handleRequest(getLink(0), request, addr({ controlId: 0 }), addr("controller")),
-					new Error(`Event ${StringPermissionEvent.eventName} is not a registered as subscribable`)
+					new Error(`Event ${StringPermissionEvent.name} is not a registered as subscribable`)
 				);
 			});
 			it("should accept a subscription", async function() {

--- a/test/lib/subscriptions.js
+++ b/test/lib/subscriptions.js
@@ -240,18 +240,18 @@ describe("lib/subscriptions", function() {
 				subscriptions.handle(RegisteredEvent);
 			});
 
-			it("should not accept subscriptions to unregistered events", function() {
+			it("should not accept subscriptions to unregistered events", async function() {
 				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
 				request.eventName = UnregisteredEvent.name;
-				assert.rejects(
+				await assert.rejects(
 					subscriptions.handleRequest(getLink(0), request, addr({ controlId: 0 }), addr("controller")),
 					new Error(`Unregistered Event class ${UnregisteredEvent.name}`)
 				);
 			});
-			it("should not accept subscriptions to events not handled by the class", function() {
+			it("should not accept subscriptions to events not handled by the class", async function() {
 				const request = new lib.SubscriptionRequest(RegisteredEvent.name, true);
 				request.eventName = StringPermissionEvent.name;
-				assert.rejects(
+				await assert.rejects(
 					subscriptions.handleRequest(getLink(0), request, addr({ controlId: 0 }), addr("controller")),
 					new Error(`Event ${StringPermissionEvent.eventName} is not a registered as subscribable`)
 				);

--- a/test/messages/controller.test.js
+++ b/test/messages/controller.test.js
@@ -28,9 +28,9 @@ describe("messages/controller", function() {
 		});
 		it("rejects if updates are disabled", async function() {
 			controller.config.set("controller.allow_remote_updates", false);
-			assert.rejects(
+			await assert.rejects(
 				controlConnection.handleControllerUpdateRequest(new lib.ControllerUpdateRequest()),
-				"Remote updates are disabled on this machine"
+				/Remote updates are disabled on this machine/
 			);
 		});
 	});

--- a/test/messages/host.test.js
+++ b/test/messages/host.test.js
@@ -24,9 +24,9 @@ describe("messages/controller", function() {
 		});
 		it("rejects if updates are disabled", async function() {
 			host.config.set("host.allow_remote_updates", false);
-			assert.rejects(
+			await assert.rejects(
 				host.handleHostUpdateRequest(new lib.HostUpdateRequest()),
-				"Remote updates are disabled on this machine"
+				/Remote updates are disabled on this machine/
 			);
 		});
 	});

--- a/test/messages/plugin.test.js
+++ b/test/messages/plugin.test.js
@@ -154,22 +154,22 @@ describe("messages/plugin", function() {
 			controller.config.set("controller.allow_plugin_install", true);
 			await controlConnection.handlePluginInstallRequest(new lib.PluginInstallRequest("foo"));
 		});
-		it("rejects if updates are disabled on the controller", async function() {
+		it("rejects if installs are disabled on the controller", async function() {
 			controller.config.set("controller.allow_plugin_install", false);
 			await assert.rejects(
 				controlConnection.handlePluginInstallRequest(new lib.PluginInstallRequest("foo")),
-				/Plugin updates are disabled on this machine/
+				/Plugin installs are disabled on this machine/
 			);
 		});
 		it("runs on a host", async function() {
 			host.config.set("host.allow_plugin_install", true);
 			await host.handlePluginInstallRequest(new lib.PluginInstallRequest("foo"));
 		});
-		it("rejects if updates are disabled on the host", async function() {
+		it("rejects if installs are disabled on the host", async function() {
 			host.config.set("host.allow_plugin_install", false);
 			await assert.rejects(
 				host.handlePluginInstallRequest(new lib.PluginInstallRequest("foo")),
-				/Plugin updates are disabled on this machine/
+				/Plugin installs are disabled on this machine/
 			);
 		});
 	});

--- a/test/messages/plugin.test.js
+++ b/test/messages/plugin.test.js
@@ -115,9 +115,9 @@ describe("messages/plugin", function() {
 		});
 		it("rejects if updates are disabled on the controller", async function() {
 			controller.config.set("controller.allow_plugin_updates", false);
-			assert.rejects(
+			await assert.rejects(
 				controlConnection.handlePluginUpdateRequest(new lib.PluginUpdateRequest("foo")),
-				"Plugin updates are disabled on this machine"
+				/Plugin updates are disabled on this machine/
 			);
 		});
 		it("runs on a host", async function() {
@@ -127,9 +127,9 @@ describe("messages/plugin", function() {
 		});
 		it("rejects if updates are disabled on the host", async function() {
 			host.config.set("host.allow_plugin_updates", false);
-			assert.rejects(
+			await assert.rejects(
 				host.handlePluginUpdateRequest(new lib.PluginUpdateRequest("foo")),
-				"Plugin updates are disabled on this machine"
+				/Plugin updates are disabled on this machine/
 			);
 		});
 	});
@@ -156,9 +156,9 @@ describe("messages/plugin", function() {
 		});
 		it("rejects if updates are disabled on the controller", async function() {
 			controller.config.set("controller.allow_plugin_install", false);
-			assert.rejects(
+			await assert.rejects(
 				controlConnection.handlePluginInstallRequest(new lib.PluginInstallRequest("foo")),
-				"Plugin updates are disabled on this machine"
+				/Plugin updates are disabled on this machine/
 			);
 		});
 		it("runs on a host", async function() {
@@ -167,9 +167,9 @@ describe("messages/plugin", function() {
 		});
 		it("rejects if updates are disabled on the host", async function() {
 			host.config.set("host.allow_plugin_install", false);
-			assert.rejects(
+			await assert.rejects(
 				host.handlePluginInstallRequest(new lib.PluginInstallRequest("foo")),
-				"Plugin updates are disabled on this machine"
+				/Plugin updates are disabled on this machine/
 			);
 		});
 	});

--- a/test/mock.js
+++ b/test/mock.js
@@ -215,7 +215,6 @@ class MockController {
 }
 
 async function createControllerPlugin(ControllerPluginClass, info) {
-	lib.registerPluginMessages([info]);
 	let controller = new MockController();
 	let metrics = {};
 	let logger = new MockLogger();


### PR DESCRIPTION
By separating the initialisation and execution of Ctl, and where possible ensureing that Ctl commands are executed within the same process as the test runner, I was able to reduce test execution time from 6 minutes to 2 minutes.

During this process, I also identified several instances where `assert.rejects` was not being awaited properly or was expecting incorrect error messages. These issues have been corrected.

This PR does result in a reduction in the test coverage, but the lines which are missed are for logging and clean up which were not explicitly tested beforehand. Therefore, no meaningful coverage was lost and we should potentially look to add explict tests for these missed lines in the future.

## Changelog
No external changes, refactor of testing.
