### PR TITLE
Add better plugin load errors

### DIFF
--- a/packages/lib/src/plugin_loader.ts
+++ b/packages/lib/src/plugin_loader.ts
@@ -4,6 +4,7 @@
  * @module lib/plugin_loader
  */
 import path from "path";
+import fs from "fs/promises";
 import * as libErrors from "./errors";
 import * as libPlugin from "./plugin";
 import { logger } from "./logging";
@@ -29,8 +30,18 @@ export async function loadPluginInfos(pluginList: Map<string, string>) {
 		// Check if plugin path exists, otherwise remove it
 		try {
 			require.resolve(pluginPath);
-		} catch (err) {
-			logger.error(`Plugin path ${pluginPath} does not exist, not loading ${pluginName}`);
+		} catch {
+			let err = `Plugin path ${pluginPath} does not exist`;
+			try {
+				const index = path.join(pluginPath, "index.js");
+				await fs.access(pluginPath, fs.constants.F_OK);
+				err = `Plugin path ${index} does not exist`;
+				await fs.access(index, fs.constants.F_OK);
+				err = `Plugin path ${index} is not readable`;
+				await fs.access(index, fs.constants.R_OK);
+				err = `Plugin path ${index} has an unknown error`;
+			} catch { }
+			logger.error(`${err}, not loading ${pluginName}`);
 			pluginList.delete(pluginName);
 			continue;
 		}


### PR DESCRIPTION
Adds error messages for when a plugin index file doesnt exist or when it is not readable.

## Changelog
```
### Changes
- Better error message showing the reason a plugin was not loaded.
```
