### PR TITLE
Update link to message passing protocol specification

### DIFF
--- a/docs/developing-for-clusterio.md
+++ b/docs/developing-for-clusterio.md
@@ -120,7 +120,7 @@ There's also the `add_libraries` function exported by event_handler, which accep
 ## Communicating with Clusterio
 
 Clusterio uses a homebrew protocol based on sending JSON payloads over a WebSocket connection.
-See [socket.md](socket.md) for the implementation details of it.
+See [protocol.md](devs/protocol.md) for the implementation details of it.
 
 It's also possible to write a plugin for Clusterio that exposes a custom interface over HTTP, WebSocket or any other technology supported by Node.js.
 


### PR DESCRIPTION
Fix that the documentation had a dead link to details of the message passing protocol. The file was moved in 2021 (https://github.com/clusterio/clusterio/commit/de48d807f13944881f6eb1bbceeb4bd05c7d3d84) but the incoming link was not updated.

Closes #812 

## Changelog
```
### Fixes
- Fix that the documentation had a dead link to details of the message passing protocol (#812)
```
