### PR TITLE
Fix headless download

### DIFF
--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -754,8 +754,8 @@ async function inquirerMissingArgs(args) {
 async function downloadLinuxServer() {
 	let res = await fetch("https://factorio.com/get-download/stable/headless/linux64");
 
-	const url = new URL(res.headers.location);
 	// get the filename of the latest factorio archive from redirected url
+	const url = new URL(res.url); // The res is redirects, need final url
 	const filename = path.posix.basename(url.pathname);
 	const match = filename.match(/(?<=factorio_headless_x64_|factorio-headless_linux_)\d+\.\d+\.\d+(?=\.tar\.xz)/);
 	if (!match || !match.length) {
@@ -772,10 +772,7 @@ async function downloadLinuxServer() {
 	if (await fs.pathExists(factorioDir)) {
 		logger.warn(`setting downloadDir to ${factorioDir}, but not downloading because already existing`);
 	} else {
-		await fs.ensureDir(tmpDir);
-
-		// follow the redirect
-		res = await fetch(url.href);
+		await fs.emptyDir(tmpDir);
 
 		logger.info("Downloading latest Factorio server release. This may take a while.");
 		const writeStream = fs.createWriteStream(tmpArchivePath);
@@ -794,8 +791,10 @@ async function downloadLinuxServer() {
 			throw e;
 		}
 
-		await fs.unlink(archivePath);
+		await fs.ensureDir("factorio");
 		await fs.rename(tmpFactorioDir, factorioDir);
+		await fs.unlink(archivePath);
+		await fs.rm(tmpDir);
 	}
 }
 
@@ -820,6 +819,10 @@ async function main() {
 		})
 		.option("http-port", {
 			nargs: 1, describe: "HTTP port to listen on [standalone/controller]", type: "number",
+		})
+		.option("download-headless", {
+			describe: "Download the latest headless release [standalone/controller] [linux only]",
+			type: "boolean", nargs: 0,
 		})
 		.option("host-name", {
 			nargs: 1, describe: "Host name [host]", type: "string",


### PR DESCRIPTION
Bug reported on discord, the following error message would appear when attempting to install on linux:

```
TypeError: Invalid URL
    at new URL (node:internal/url:806:29)
    at downloadLinuxServer (/home/clusterio/.npm/_npx/860a49d89133e22f/node_modules/@clusterio/create/create.js:757:14)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async main (/home/clusterio/.npm/_npx/860a49d89133e22f/node_modules/@clusterio/create/create.js:895:3)
```

This was casued by switching to fetch from phin where the redirect behaviour changed. However, this also uncovered that `--no-download-headless` did not work as an option. This has also been fixed.

## Changelog
```
### Fixes
- Fix headless download on linux install. [#815](https://github.com/clusterio/clusterio/issues/816)
- Fix option `--no-download-headless` being ignored. [#815](https://github.com/clusterio/clusterio/issues/816)
```
