### PR TITLE
Fix achievements not being disabled when save patching disabled

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -962,10 +962,15 @@ end`.replace(/\r?\n/g, " ");
 		this._loadedSave = saveName;
 		await this.server.start(saveName);
 
-		if (this.config.get("factorio.enable_save_patching") && this.config.get("factorio.enable_script_commands")) {
+		if (this.config.get("factorio.enable_script_commands")) {
 			await this.server.disableAchievements();
-			await this.updateInstanceData();
+		}
+
+		if (this.config.get("factorio.enable_save_patching")) {
 			this._watchPlayerPromote();
+			if (this.config.get("factorio.enable_script_commands")) {
+				await this.updateInstanceData();
+			}
 		} else {
 			this._watchServerLogActions();
 		}


### PR DESCRIPTION
Fixes an issue where achievements were not disabled when script commands were enabled in the config. This also trivially allowed a small expansion of save-patched player events to work without script commands. This change has no external impact and only improves event stability.

## Changelog
```
### Fixes
- Fixed case where achievements were not disabled. [#817](https://github.com/clusterio/clusterio/pull/817)
```
