### PR TITLE
Clusterio `update_instance` Race Condition Bug - FIX

### DIFF
--- a/packages/host/modules/clusterio/impl.lua
+++ b/packages/host/modules/clusterio/impl.lua
@@ -6,6 +6,15 @@ local compat = require("modules/clusterio/compat")
 local function check_patch()
 	if compat.script_data.clusterio_patch_number ~= clusterio_patch_number then
 		compat.script_data.clusterio_patch_number = clusterio_patch_number
+		-- Initialize clusterio table synchronously BEFORE raising async event
+		-- This prevents race condition where update_instance() accesses the table
+		-- before the on_server_startup event handler has run
+		if not compat.script_data.clusterio then
+			compat.script_data.clusterio = {
+				instance_id = nil,
+				instance_name = nil,
+			}
+		end
 		script.raise_event(api.events.on_server_startup, {
 			name = api.events.on_server_startup, tick = game.tick
 		})


### PR DESCRIPTION
# Clusterio `update_instance` Race Condition Bug Report

## Summary

I am running Clusterio in a docker cluster of 1x Host and 2x Containers.   My compose script has asynchronous and synchronous commands initializing the environment and starting game instances.   Bug was found while looking for way to optimize the docker startup with clusterio.   I believe this is the best place to insert the fix but there is an alternative.  Please scrutinize the proposed solution if there is a better workaround!


**Bug:** Factorio instance startup fails with error:
```
Error: __level__/modules/clusterio/impl.lua:80: attempt to index field 'clusterio' (a nil value)
```

**Impact:** Instances fail to start and immediately shut down with `remote-quit`.

**Affected Version:** Clusterio 2.0.0-alpha.22 (and likely earlier versions)

**Root Cause:** Race condition between RCON command execution and Lua event processing during instance startup.

---

## Error Details

### Error Message
```
Error starting world.zip: Expected empty response but got "Cannot execute command. 
Error: __level__/modules/clusterio/impl.lua:80: attempt to index field 'clusterio' (a nil value)"
```

### Stack Trace (Node.js side)
```
at FactorioServer.sendRcon (/usr/lib/node_modules/@clusterio/host/dist/node/src/server.js:1020:19)
at async Instance.sendRcon (/usr/lib/node_modules/@clusterio/host/dist/node/src/Instance.js:431:20)
at async Instance.updateInstanceData (/usr/lib/node_modules/@clusterio/host/dist/node/src/Instance.js:854:9)
at async Instance.start (/usr/lib/node_modules/@clusterio/host/dist/node/src/Instance.js:818:13)
```

---

## Technical Analysis

### Code Flow During Instance Startup

#### 1. Host Starts Factorio Instance
**File:** `packages/host/src/Instance.ts` (lines 956-977)

```typescript
async start(saveName: string) {
    this.server.on("rcon-ready", () => {
        this.logger.verbose("RCON connection established");
    });

    this.server.on("exit", () => this.notifyExit());
    this._loadedSave = saveName;
    await this.server.start(saveName);

    if (this.config.get("factorio.enable_save_patching") && 
        this.config.get("factorio.enable_script_commands")) {
        await this.server.disableAchievements();  // Step A
        await this.updateInstanceData();          // Step B - CRASHES HERE
        this._watchPlayerPromote();
    }
    // ...
}
```

#### 2. Host Calls `updateInstanceData()`
**File:** `packages/host/src/Instance.ts` (lines 1007-1010)

```typescript
async updateInstanceData() {
    let name = lib.escapeString(this.name);
    await this.sendRcon(`/sc clusterio_private.update_instance(${this.id}, "${name}")`, true);
}
```

#### 3. Lua Side: `clusterio_private.update_instance()` is Called
**File:** `packages/host/modules/clusterio/impl.lua` (lines 76-86)

```lua
clusterio_private = {}
function clusterio_private.update_instance(new_id, new_name)
    check_patch()                                    -- Raises on_server_startup event
    local script_data = compat.script_data
    script_data.clusterio.instance_id = new_id       -- LINE 80: CRASH - clusterio is nil!
    script_data.clusterio.instance_name = new_name
    script.raise_event(api.events.on_instance_updated, {
        instance_id = new_id,
        instance_name = new_name,
    })
end
```

#### 4. The Problem: `check_patch()` Raises Event but Doesn't Initialize Synchronously
**File:** `packages/host/modules/clusterio/impl.lua` (lines 6-13)

```lua
local function check_patch()
    if compat.script_data.clusterio_patch_number ~= clusterio_patch_number then
        compat.script_data.clusterio_patch_number = clusterio_patch_number
        script.raise_event(api.events.on_server_startup, {  -- Event is QUEUED, not synchronous
            name = api.events.on_server_startup, tick = game.tick
        })
    end
end
```

#### 5. The Initialization That Never Happens In Time
**File:** `packages/host/modules/clusterio/impl.lua` (lines 20-30)

```lua
impl.events[api.events.on_server_startup] = function()
    if not compat.script_data.clusterio then
        compat.script_data.clusterio = {        -- This should initialize the table
            instance_id = nil,
            instance_name = nil,
        }
    end
    game.disable_replay()
end
```

---

## Root Cause Explanation

### The Race Condition

1. **Factorio starts** and reaches `InGame` state
2. **RCON becomes available** - Host detects this and proceeds
3. **Host calls `disableAchievements()`** - Sends `/sc rcon.print('disabled')` twice
4. **Host immediately calls `updateInstanceData()`** - Sends `/sc clusterio_private.update_instance(...)`
5. **Lua executes `update_instance()`** which calls `check_patch()`
6. **`check_patch()` raises `on_server_startup` event** - But this event is **queued**, not executed immediately
7. **`update_instance()` continues to line 80** - Tries to access `script_data.clusterio` which is still `nil`
8. **CRASH**

### Why This Happens

- `script.raise_event()` in Factorio **queues** the event to be processed later
- The event handler that initializes `compat.script_data.clusterio` runs in a **future tick**
- The code on line 80 executes **immediately** after `check_patch()` returns
- The `clusterio` table doesn't exist yet because the `on_server_startup` handler hasn't run

### Why It Might Work Sometimes

- If the instance had been started before and has persisted `script_data`, the `clusterio` table already exists
- If there's sufficient delay between RCON commands, a tick might process and run the event handler
- Fresh saves/new patches are most likely to hit this bug

---

## Proposed Fix

### Option 1: Synchronous Init in `check_patch()` (Recommended)

**File:** `packages/host/modules/clusterio/impl.lua`

The cleanest fix is to initialize the `clusterio` table **synchronously** inside `check_patch()`, before raising the async event. This ensures the table exists immediately when `check_patch()` returns.

Change lines 6-13 from:

```lua
local function check_patch()
    if compat.script_data.clusterio_patch_number ~= clusterio_patch_number then
        compat.script_data.clusterio_patch_number = clusterio_patch_number
        script.raise_event(api.events.on_server_startup, {
            name = api.events.on_server_startup, tick = game.tick
        })
    end
end
```

To:

```lua
local function check_patch()
    if compat.script_data.clusterio_patch_number ~= clusterio_patch_number then
        compat.script_data.clusterio_patch_number = clusterio_patch_number
        -- Initialize clusterio table synchronously BEFORE raising async event
        -- This prevents race condition where update_instance() accesses the table
        -- before the on_server_startup event handler has run
        if not compat.script_data.clusterio then
            compat.script_data.clusterio = {
                instance_id = nil,
                instance_name = nil,
            }
        end
        script.raise_event(api.events.on_server_startup, {
            name = api.events.on_server_startup, tick = game.tick
        })
    end
end
```

### Why This Fix is Better

1. **Correct location** - Initialization happens at patch detection time, which is the logical place
2. **Synchronous guarantee** - Table exists immediately when `check_patch()` returns, no race possible
3. **Clean separation** - `update_instance()` doesn't need defensive code for something it shouldn't manage
4. **Backwards compatible** - The `on_server_startup` handler's init check becomes a harmless no-op
5. **Minimal change** - Only 6 lines added to the right place

### Option 2: Guard in `update_instance()` (Alternative)

If modifying `check_patch()` is undesirable, a defensive guard can be added to `update_instance()` instead:

**File:** `packages/host/modules/clusterio/impl.lua` (lines 76-86)

```lua
function clusterio_private.update_instance(new_id, new_name)
    check_patch()
    local script_data = compat.script_data
    -- Guard: Initialize clusterio table if it doesn't exist yet
    if not script_data.clusterio then
        script_data.clusterio = {
            instance_id = nil,
            instance_name = nil,
        }
    end
    script_data.clusterio.instance_id = new_id
    script_data.clusterio.instance_name = new_name
    script.raise_event(api.events.on_instance_updated, {
        instance_id = new_id,
        instance_name = new_name,
    })
end
```

This works but is less elegant since it puts the fix at the symptom site rather than the root cause.

### Option 3: Host-Side Delay (Not Recommended)

The host could wait for a "ready" signal from Factorio before calling `updateInstanceData()`. However:
- More invasive change
- Requires protocol changes
- Adds latency to startup
- The Lua-side fix is simpler and more robust

---

## Files Affected

| File | Lines | Purpose |
|------|-------|---------|
| `packages/host/modules/clusterio/impl.lua` | 6-13 | `check_patch()` function - **recommended fix location** |
| `packages/host/modules/clusterio/impl.lua` | 76-86 | `update_instance()` function - alternative fix location |
| `packages/host/src/Instance.ts` | 1007-1010 | `updateInstanceData()` - calls the Lua function |
| `packages/host/src/Instance.ts` | 966-967 | `start()` - calls `updateInstanceData()` |

---

## Reproduction Steps

1. Set up Clusterio with save patching enabled (`factorio.enable_save_patching: true`)
2. Create a new instance with a fresh save (no existing `script_data`)
3. Start the instance
4. Instance will crash immediately after reaching `InGame` state
5. Host log shows the error about `clusterio` being nil

---

## Related Information

### Clusterio Version
- Version: 2.0.0-alpha.22
- Factorio: 2.0.72

### Relevant Factorio Behavior
- `script.raise_event()` queues events for later processing
- Events are processed during tick updates
- RCON commands execute immediately in the current context

### Existing Patterns
The same defensive pattern is already used in the `on_server_startup` handler (line 21):
```lua
if not compat.script_data.clusterio then
```

This establishes precedent for the proposed fix.

---

## Recommendation

Submit this fix as a pull request to the Clusterio repository. The recommended fix (Option 1 - synchronous init in `check_patch()`) is:
- **6 lines added** to the correct location
- **Root cause fix** - addresses the problem at the source, not the symptom
- **Safe** - no breaking changes, backwards compatible
- **Consistent** - matches existing defensive patterns in the codebase
- **Synchronous** - eliminates the race condition entirely



## Changelog
```
### Features
- Added doodad to web interface. [#999](https://github.com/clusterio/clusterio/issues/999)

### Changes
-  Initializes the `compat.script_data.clusterio` table with default fields (`instance_id`, `instance_name`) before raising the `on_server_startup` event, ensuring that any code accessing this table (such as `update_instance()`) will not encounter a nil value.…artup

### Fixes
- ...

### Breaking changes
- ...
```
