### PR TITLE
Upload test logs for debugging CI failures

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,6 +40,12 @@ jobs:
       with:
         files: ./coverage/lcov.info
         token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload test logs for debugging
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.node-version }}-${{ matrix.factorio-version }}
+        path: temp/test/logs
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI often fails with cryptic errors that would be much easier to debug if the logs from Factorio was provided.  Upload the cluster log that was written during the tests which includes Factorio logs so that these can be inspected after a test failure.

## Changelog
None. Internal change.