### PR TITLE
Fix webui error on setting host config

### DIFF
--- a/packages/web_ui/src/components/BaseConfigTree.tsx
+++ b/packages/web_ui/src/components/BaseConfigTree.tsx
@@ -9,7 +9,7 @@ import * as lib from "@clusterio/lib";
 import ControlContext from "./ControlContext";
 import { InputComponent, InputComponentProps } from "../BaseWebPlugin";
 import type { Control } from "../util/websocket";
-import { notifyErrorHandler } from "../util/notify";
+import notify from "../util/notify";
 
 const { Title } = Typography;
 
@@ -183,7 +183,7 @@ export default function BaseConfigTree(props: BaseConfigTreeProps) {
 							await props.setConfig(fields);
 							setChangedFields(new Set());
 						} catch (err: any) {
-							notifyErrorHandler(err.message);
+							notify(err.message, "error");
 						}
 
 						await updateConfig();

--- a/packages/web_ui/src/components/HostConfigTree.tsx
+++ b/packages/web_ui/src/components/HostConfigTree.tsx
@@ -14,7 +14,7 @@ export default function HostConfigTree(props: { id: number, available: boolean }
 	}
 
 	async function setConfig(fields: Record<string, string | Record<string, string>>) {
-		await control.send(new lib.HostConfigSetRequest(fields));
+		await control.sendTo({ hostId: props.id }, new lib.HostConfigSetRequest(fields));
 	}
 
 	return <BaseConfigTree


### PR DESCRIPTION
Fixes the webui using `send` rather than `sendTo` for setting the host config. This was a copy paste error from InstanceConfigTree and ControllerConfigTree. Also fixes the use of `notifyErrorHandler` rather than `notify` which prevented the wrong address error being shown to the user.

### Changelog
```
### Fixes
- Fix the webui being unable to set host config values and that no error was displayed. #891 
```

Fixes #891 