### PR TITLE
Change config errors to be subclasses of RequestError

### DIFF
--- a/packages/lib/src/config/classes.ts
+++ b/packages/lib/src/config/classes.ts
@@ -9,6 +9,7 @@ import * as libSchema from "../schema";
 import { StringEnum } from "../data/composites";
 import { safeOutputFile } from "../file_ops";
 import * as validators from "./validators";
+import { RequestError } from "../errors";
 
 const ConfigLocation = StringEnum(["controller", "host", "control"]);
 export type ConfigLocation = Static<typeof ConfigLocation>;
@@ -21,7 +22,7 @@ export type ConfigLocation = Static<typeof ConfigLocation>;
  *
  * @extends Error
  */
-export class InvalidAccess extends Error { };
+export class InvalidAccess extends RequestError { };
 
 /**
  * Invalid Value exception
@@ -31,7 +32,7 @@ export class InvalidAccess extends Error { };
  *
  * @extends Error
  */
-export class InvalidValue extends Error { };
+export class InvalidValue extends RequestError { };
 
 /**
  * Invalid Field exception
@@ -41,7 +42,7 @@ export class InvalidValue extends Error { };
  *
  * @extends Error
  */
-export class InvalidField extends Error { };
+export class InvalidField extends RequestError { };
 
 
 const OldConfigGroupSchema = Type.Object({


### PR DESCRIPTION
This prevents them from being logged when raised during an event handler. The alternative would be to have try catch blocks on all config related requests and to rethrow the error as a request error. But that would be combersome for little value (if any) in comparison to having them inherit from request error.

### Changelog
```
### Changes
- Config validation errors are no longer logged when raised during an request handler. #888
```

Fixes #888