### PR TITLE
Add missing instanceConfigUpdated to InstanceConfigSetRequest

### DIFF
--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -330,6 +330,7 @@ export default class ControlConnection extends BaseConnection {
 			}
 
 			instance.config.commitStaging();
+			await this._controller.instanceConfigUpdated(instance);
 		} finally {
 			instance.config.revertStaging();
 		}


### PR DESCRIPTION
Adds the missing `instanceConfigUpdated` call that should have been included in the `InstanceConfigSetRequest` handler, similar to the existing `InstanceConfigSetFieldRequest` and `InstanceConfigSetPropRequest`. The consequence of this missed line was that the host was not being notified of config changes to instances, meaning changes had no impact unless the instance was reassigned.

### Changelog
```
### Fixes
- Fix instance config not updating on changes being applied. #901
```
