### PR TITLE
Add version and connect button to player auth

### DIFF
--- a/plugins/player_auth/controller.ts
+++ b/plugins/player_auth/controller.ts
@@ -57,7 +57,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 				}
 
 				const host = this.controller.hosts.get(assignedHost);
-				if (!host || !host.publicAddress) {
+				if (!host) {
 					continue;
 				}
 

--- a/plugins/player_auth/controller.ts
+++ b/plugins/player_auth/controller.ts
@@ -3,11 +3,12 @@ import express, { type Request, type Response } from "express";
 import util from "util";
 import jwt from "jsonwebtoken";
 
+import { Static } from "@sinclair/typebox";
 import * as lib from "@clusterio/lib";
 import { BaseControllerPlugin } from "@clusterio/controller";
 const { basicType } = lib;
 
-import { FetchPlayerCodeRequest, SetVerifyCodeRequest } from "./messages";
+import { FetchPlayerCodeRequest, PlayerAuthServer, SetVerifyCodeRequest } from "./messages";
 
 
 async function generateCode(length: number): Promise<string> {
@@ -46,12 +47,32 @@ export class ControllerPlugin extends BaseControllerPlugin {
 		}, 60e3).unref();
 
 		this.controller.app.get("/api/player_auth/servers", (req: Request, res: Response) => {
-			let servers: string[] = [];
-			for (let instance of this.controller.instances.values()) {
-				if (instance.status === "running" && instance.config.get("player_auth.load_plugin")) {
-					servers.push(instance.config.get("factorio.settings")["name"] as string || "unnamed server");
+			const servers: Static<typeof PlayerAuthServer.jsonSchema>[] = [];
+
+			for (const instance of this.controller.instances.values()) {
+				const pluginLoaded = instance.config.get("player_auth.load_plugin");
+				const assignedHost = instance.config.get("instance.assigned_host");
+				if (instance.status !== "running" || !pluginLoaded || !assignedHost) {
+					continue;
 				}
+
+				const host = this.controller.hosts.get(assignedHost);
+				if (!host || !host.publicAddress) {
+					continue;
+				}
+
+				const address = instance.gamePort !== undefined
+					? `${host.publicAddress}:${instance.gamePort}`
+					: host.publicAddress;
+
+				const settings = instance.config.get("factorio.settings");
+				servers.push({
+					name: settings["name"] as string || "unnamed server",
+					factorioVersion: instance.factorioVersion,
+					address,
+				});
 			}
+
 			res.send(servers);
 		});
 

--- a/plugins/player_auth/controller.ts
+++ b/plugins/player_auth/controller.ts
@@ -66,10 +66,11 @@ export class ControllerPlugin extends BaseControllerPlugin {
 					: host.publicAddress;
 
 				const settings = instance.config.get("factorio.settings");
+				const includeAddress = this.controller.config.get("player_auth.show_connect_address");
 				servers.push({
 					name: settings["name"] as string || "unnamed server",
 					factorioVersion: instance.factorioVersion,
-					address,
+					address: includeAddress ? address : undefined,
 				});
 			}
 

--- a/plugins/player_auth/controller.ts
+++ b/plugins/player_auth/controller.ts
@@ -52,7 +52,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 			for (const instance of this.controller.instances.values()) {
 				const pluginLoaded = instance.config.get("player_auth.load_plugin");
 				const assignedHost = instance.config.get("instance.assigned_host");
-				if (instance.status !== "running" || !pluginLoaded || !assignedHost) {
+				if (instance.status !== "running" || !pluginLoaded || assignedHost === null) {
 					continue;
 				}
 
@@ -70,7 +70,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 				servers.push({
 					name: settings["name"] as string || "unnamed server",
 					factorioVersion: instance.factorioVersion,
-					address: includeAddress ? address : undefined,
+					address: (includeAddress && host.publicAddress !== "") ? address : undefined,
 				});
 			}
 

--- a/plugins/player_auth/index.ts
+++ b/plugins/player_auth/index.ts
@@ -8,6 +8,7 @@ declare module "@clusterio/lib" {
 	export interface ControllerConfigFields {
 		"player_auth.code_length": number;
 		"player_auth.code_timeout": number;
+		"player_auth.show_connect_address": boolean;
 	}
 }
 
@@ -30,6 +31,12 @@ export const plugin: lib.PluginDeclaration = {
 			description: "Time in seconds for the generated codes to stay valid.",
 			type: "number",
 			initialValue: 120,
+		},
+		"player_auth.show_connect_address": {
+			title: "Show Connect Address",
+			description: "Show server connect addresses to unauthenticated users.",
+			type: "boolean",
+			initialValue: false,
 		},
 	},
 

--- a/plugins/player_auth/messages.ts
+++ b/plugins/player_auth/messages.ts
@@ -21,7 +21,7 @@ export class PlayerAuthServer {
 			json.address = this.address;
 		}
 		if (this.factorioVersion !== undefined) {
-			json.factorioVersion = this.address;
+			json.factorioVersion = this.factorioVersion;
 		}
 		return json;
 	}

--- a/plugins/player_auth/messages.ts
+++ b/plugins/player_auth/messages.ts
@@ -1,5 +1,32 @@
 import { Type, Static } from "@sinclair/typebox";
 
+export class PlayerAuthServer {
+	declare ["constructor"]: typeof PlayerAuthServer;
+
+	static jsonSchema = Type.Object({
+		name: Type.String(),
+		address: Type.String(),
+		factorioVersion: Type.Optional(Type.String()),
+	});
+
+	constructor(
+		public name: string,
+		public address: string,
+		public factorioVersion?: string,
+	) {}
+
+	toJSON(): Static<typeof PlayerAuthServer.jsonSchema> {
+		if (this.factorioVersion === undefined) {
+			return { name: this.name, address: this.address };
+		}
+		return { name: this.name, address: this.address, factorioVersion: this.factorioVersion };
+	}
+
+	static fromJSON(json: Static<typeof PlayerAuthServer.jsonSchema>) {
+		return new this(json.name, json.address, json.factorioVersion);
+	}
+}
+
 class FetchPlayerCodeResponse {
 	constructor(
 		public playerCode: string,

--- a/plugins/player_auth/messages.ts
+++ b/plugins/player_auth/messages.ts
@@ -5,21 +5,25 @@ export class PlayerAuthServer {
 
 	static jsonSchema = Type.Object({
 		name: Type.String(),
-		address: Type.String(),
+		address: Type.Optional(Type.String()),
 		factorioVersion: Type.Optional(Type.String()),
 	});
 
 	constructor(
 		public name: string,
-		public address: string,
+		public address?: string,
 		public factorioVersion?: string,
 	) {}
 
 	toJSON(): Static<typeof PlayerAuthServer.jsonSchema> {
-		if (this.factorioVersion === undefined) {
-			return { name: this.name, address: this.address };
+		const json = { name: this.name } as Static<typeof PlayerAuthServer.jsonSchema>;
+		if (this.address !== undefined) {
+			json.address = this.address;
 		}
-		return { name: this.name, address: this.address, factorioVersion: this.factorioVersion };
+		if (this.factorioVersion !== undefined) {
+			json.factorioVersion = this.address;
+		}
+		return json;
 	}
 
 	static fromJSON(json: Static<typeof PlayerAuthServer.jsonSchema>) {

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -26,7 +26,7 @@ describe("player_auth", function() {
 			it("should be round trip json serialisable", function() {
 				testRoundTripJsonSerialisable(PlayerAuthServer, testMatrix(
 					["server1", "server2"], // name
-					["127.0.0.1", "10.0.0.1:1234"], // address
+					[undefined, "127.0.0.1", "10.0.0.1:1234"], // address
 					[undefined, "1.1.0", "2.0.0"], // version
 				));
 			});

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -132,7 +132,8 @@ describe("player_auth", function() {
 					addInstance(5, "running", true, undefined, "1.1.5", 34197);
 					addInstance(6, "running", true, "no port", "1.1.6", undefined);
 					addInstance(7, "running", true, "no host", "1.1.7", 34197, null);
-					addInstance(8, "running", true, "no version", undefined, 34197);
+					addInstance(8, "running", true, "invalid host", "1.1.8", 34197, 2);
+					addInstance(9, "running", true, "no version", undefined, 34197);
 
 					controllerPlugin.controller.hosts.set(1, {
 						publicAddress: "127.0.0.1",

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -100,7 +100,7 @@ describe("player_auth", function() {
 
 			describe("/api/player_auth/servers", function() {
 				it("should return a list of running servers with player_auth loaded", async function() {
-					function addInstance(id, status, load, name, version) {
+					function addInstance(id, status, load, name, version, gamePort, host=1) {
 						controllerPlugin.controller.instances.records.set(id, {
 							config: {
 								get(field) {
@@ -114,22 +114,25 @@ describe("player_auth", function() {
 										return id;
 									}
 									if (field === "instance.assigned_host") {
-										return 1;
+										return host;
 									}
 									throw new Error(`field ${field} not implemented`);
 								},
 							},
 							status,
-							gamePort: 34197,
+							gamePort,
 							factorioVersion: version,
 						});
 					}
 
-					addInstance(1, "running", true, "running loaded", "1.1.0");
-					addInstance(2, "stopped", true, "stopped loaded", "1.1.1");
-					addInstance(3, "running", false, "running unloaded", "1.1.2");
-					addInstance(4, "stopped", false, "stopped unloaded", "1.1.3");
-					addInstance(5, "running", true, undefined, undefined);
+					addInstance(1, "running", true, "running loaded", "1.1.1", 34197);
+					addInstance(2, "stopped", true, "stopped loaded", "1.1.2", 34197);
+					addInstance(3, "running", false, "running unloaded", "1.1.3", 34197);
+					addInstance(4, "stopped", false, "stopped unloaded", "1.1.4", 34197);
+					addInstance(5, "running", true, undefined, "1.1.5", 34197);
+					addInstance(6, "running", true, "no port", "1.1.6", undefined);
+					addInstance(7, "running", true, "no host", "1.1.7", 34197, null);
+					addInstance(8, "running", true, "no version", undefined, 34197);
 
 					controllerPlugin.controller.hosts.set(1, {
 						publicAddress: "127.0.0.1",
@@ -137,8 +140,10 @@ describe("player_auth", function() {
 
 					const result = await fetch(`${controllerUrl}/api/player_auth/servers`);
 					assert.deepEqual(await result.json(), [
-						{ name: "running loaded", address: "127.0.0.1:34197", factorioVersion: "1.1.0" },
-						{ name: "unnamed server", address: "127.0.0.1:34197" },
+						{ name: "running loaded", address: "127.0.0.1:34197", factorioVersion: "1.1.1" },
+						{ name: "unnamed server", address: "127.0.0.1:34197", factorioVersion: "1.1.5" },
+						{ name: "no port", address: "127.0.0.1", factorioVersion: "1.1.6" },
+						{ name: "no version", address: "127.0.0.1:34197" },
 					]);
 				});
 			});

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -7,8 +7,10 @@ const mock = require("../../../test/mock");
 const controller = require("../dist/node/controller");
 const instance = require("../dist/node/instance");
 const info = require("../dist/node/index").plugin;
-const { FetchPlayerCodeRequest, SetVerifyCodeRequest } = require("../dist/node/messages");
+const { FetchPlayerCodeRequest, SetVerifyCodeRequest, PlayerAuthServer } = require("../dist/node/messages");
+const { testRoundTripJsonSerialisable, testMatrix } = require("../../../test/common");
 const lib = require("@clusterio/lib");
+
 
 function postJSON(url, body) {
 	return fetch(url, {
@@ -19,6 +21,44 @@ function postJSON(url, body) {
 }
 
 describe("player_auth", function() {
+	describe("messages.js", function() {
+		describe("PlayerAuthServer", function() {
+			it("should be round trip json serialisable", function() {
+				testRoundTripJsonSerialisable(PlayerAuthServer, testMatrix(
+					["server1", "server2"], // name
+					["127.0.0.1", "10.0.0.1:1234"], // address
+					[undefined, "1.1.0", "2.0.0"], // version
+				));
+			});
+		});
+
+		describe("FetchPlayerCodeResponse", function() {
+			it("should be round trip json serialisable", function() {
+				testRoundTripJsonSerialisable(FetchPlayerCodeRequest.Response, testMatrix(
+					["abc123", "player-code"], // playerCode
+					["http://localhost", "https://example.com"], // controllerUrl
+				));
+			});
+		});
+
+		describe("FetchPlayerCodeRequest", function() {
+			it("should be round trip json serialisable", function() {
+				testRoundTripJsonSerialisable(FetchPlayerCodeRequest, testMatrix(
+					["player1", "player2"], // player
+				));
+			});
+		});
+
+		describe("SetVerifyCodeRequest", function() {
+			it("should be round trip json serialisable", function() {
+				testRoundTripJsonSerialisable(SetVerifyCodeRequest, testMatrix(
+					["player1", "player2"], // player
+					["code123", "verify456"], // verifyCode
+				));
+			});
+		});
+	});
+
 	describe("controller.js", function() {
 		describe("generateCode()", function() {
 			it("should generate a code of the given length", async function() {
@@ -60,33 +100,46 @@ describe("player_auth", function() {
 
 			describe("/api/player_auth/servers", function() {
 				it("should return a list of running servers with player_auth loaded", async function() {
-					function addInstance(id, status, load, name) {
+					function addInstance(id, status, load, name, version) {
 						controllerPlugin.controller.instances.records.set(id, {
 							config: {
 								get(field) {
 									if (field === "player_auth.load_plugin") {
 										return load;
-									} else if (field === "factorio.settings") {
+									}
+									if (field === "factorio.settings") {
 										return { name };
-									} else if (field === "instance.id") {
+									}
+									if (field === "instance.id") {
 										return id;
+									}
+									if (field === "instance.assigned_host") {
+										return 1;
 									}
 									throw new Error(`field ${field} not implemented`);
 								},
 							},
 							status,
+							gamePort: 34197,
+							factorioVersion: version,
 						});
 					}
-					addInstance(1, "running", true, "running loaded");
-					addInstance(2, "stopped", true, "stopped loaded");
-					addInstance(3, "running", false, "running unloaded");
-					addInstance(4, "stopped", false, "stopped unloaded");
-					addInstance(5, "running", true, undefined);
+
+					addInstance(1, "running", true, "running loaded", "1.1.0");
+					addInstance(2, "stopped", true, "stopped loaded", "1.1.1");
+					addInstance(3, "running", false, "running unloaded", "1.1.2");
+					addInstance(4, "stopped", false, "stopped unloaded", "1.1.3");
+					addInstance(5, "running", true, undefined, undefined);
+
+					controllerPlugin.controller.hosts.set(1, {
+						publicAddress: "127.0.0.1",
+					});
+
 					const result = await fetch(`${controllerUrl}/api/player_auth/servers`);
-					assert.deepEqual(await result.json(), ["running loaded", "unnamed server"]);
-					for (let id of [1, 2, 3, 4, 5]) {
-						controllerPlugin.controller.instances.records.delete(id);
-					}
+					assert.deepEqual(await result.json(), [
+						{ name: "running loaded", address: "127.0.0.1:34197", factorioVersion: "1.1.0" },
+						{ name: "unnamed server", address: "127.0.0.1:34197" },
+					]);
 				});
 			});
 

--- a/plugins/player_auth/web/index.tsx
+++ b/plugins/player_auth/web/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { BaseWebPlugin, notifyErrorHandler } from "@clusterio/web_ui";
-import { Button, Form, Input, Spin, Typography } from "antd";
+import { Alert, Button, Form, Input, Modal, Space, Spin, Typography } from "antd";
 
 import { PlayerAuthServer } from "../messages";
 import "./style.css";
@@ -18,6 +18,7 @@ function LoginForm(props: LoginFormProps) {
 	let [playerCodeError, setPlayerCodeError] = useState<string | null>(null);
 	let [verifyCode, setVerifyCode] = useState<string | undefined>();
 	let [verifyToken, setVerifyToken] = useState<string | null>(null);
+	const [connectServer, setConnectServer] = useState<{ name: string, address: string } | null>(null);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -115,6 +116,41 @@ function LoginForm(props: LoginFormProps) {
 	}
 
 	return <>
+		<Modal
+			open={connectServer !== null}
+			title={`Connect to ${connectServer?.name ?? ""}`}
+			okText="Connect"
+			cancelText="Back"
+			onCancel={() => setConnectServer(null)}
+			onOk={() => {
+				if (!connectServer) {
+					return;
+				}
+
+				window.location.href = `steam://run/427520//--mp-connect=${connectServer.address}`;
+				setConnectServer(null);
+			}}
+		>
+			<Space direction="vertical" style={{ width: "100%" }}>
+				<Paragraph>
+					This button launches Factorio through Steam. It only works if
+					you own and have installed the Steam version of Factorio, and
+					Factorio is not already running.
+				</Paragraph>
+
+				<Paragraph>
+					If you are using the standalone version, or Factorio is already
+					running, use the following address with <b>Multiplayer → Connect to address</b>:
+				</Paragraph>
+
+				<Typography.Paragraph
+					copyable={{ text: connectServer?.address ?? "" }}
+					style={{ marginBottom: 0 }}
+				>
+					{connectServer?.address}
+				</Typography.Paragraph>
+			</Space>
+		</Modal>
 		<Paragraph>Login using your Factorio account is a 3 step process:</Paragraph>
 		<style>
 		</style>
@@ -127,7 +163,7 @@ function LoginForm(props: LoginFormProps) {
 				<div style={{ maxHeight: 160, overflowY: "auto", paddingLeft: 16, padding: "8px 0" }}>
 					<ul style={{ margin: 0, paddingLeft: 16 }}>
 						{servers.map(server => (
-							<li key={server.address} style={{ marginBottom: 6 }}>
+							<li key={server.name} style={{ marginBottom: 6 }}>
 								<div style={{
 									display: "grid",
 									gridTemplateColumns: "1fr auto",
@@ -141,15 +177,19 @@ function LoginForm(props: LoginFormProps) {
 										)}
 									</span>
 
-									<Button
-										size="small"
-										onClick={() => {
-											window.location.href =
-												`steam://run/427520//--mp-connect=${server.address}`;
-										}}
-									>
-										Connect
-									</Button>
+									{server.address && (
+										<Button
+											size="small"
+											onClick={() => {
+												setConnectServer({
+													name: server.name,
+													address: server.address!,
+												});
+											}}
+										>
+											Connect
+										</Button>
+									)}
 								</div>
 							</li>
 						))}

--- a/plugins/player_auth/web/index.tsx
+++ b/plugins/player_auth/web/index.tsx
@@ -21,26 +21,27 @@ function LoginForm(props: LoginFormProps) {
 
 	useEffect(() => {
 		let cancelled = false;
-
-		async function load() {
-			let response = await fetch(`${webRoot}api/player_auth/servers`);
-			if (!response.ok) {
-				if (!cancelled) {
-					setServers([]);
-					const err = new Error(await response.text());
-					notifyErrorHandler("Error retrieving servers")(err);
+		async function loadServers() {
+			try {
+				const response = await fetch(`${webRoot}api/player_auth/servers`);
+				if (!response.ok) {
+					throw new Error(`Bad server response: ${response.status}`);
 				}
-				return;
-			}
 
-			const json = await response.json();
-			if (!cancelled) {
-				setServers(json.map((s: any) => PlayerAuthServer.fromJSON(s)));
+				const data = await response.json();
+				if (!cancelled) {
+					setServers(data);
+				}
+			} catch (err) {
+				if (!cancelled && err instanceof Error) {
+					setServers([]);
+					notifyErrorHandler("Error fetching servers")(err);
+				}
 			}
 		}
 
-		load();
-		const interval = setInterval(load, 15 * 1000);
+		loadServers();
+		const interval = setInterval(loadServers, 15 * 1000);
 
 		return () => {
 			cancelled = true;
@@ -49,42 +50,57 @@ function LoginForm(props: LoginFormProps) {
 	}, []);
 
 	useEffect(() => {
-		if (verifyToken) {
-			let checkLoop = setInterval(() => {
-				(async () => {
-					let response = await fetch(`${webRoot}api/player_auth/verify`, {
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({
-							verify_token: verifyToken,
-							verify_code: verifyCode,
-							player_code: playerCode,
-						}),
-					});
-					if (!response.ok) {
-						throw new Error(`Bad server response: ${response.status}`);
-					}
-					let json = await response.json();
-					if (json.error) {
-						// While there are other possibilites the most likely
-						// cause of an error response here is that the code expired.
-						setPlayerCodeError("Code expired");
-						setVerifyToken(null);
-						clearInterval(checkLoop);
-						return;
-					}
-					if (json.verified) {
-						props.setToken(json.token);
-					}
-				})().catch(err => {
-					clearInterval(checkLoop);
-					notifyErrorHandler("Error verifying code")(err);
-				});
-			}, 2 * 1000);
-			return () => { clearInterval(checkLoop); };
+		if (!verifyToken) {
+			return undefined;
 		}
 
-		return undefined;
+		let cancelled = false;
+		async function verify() {
+			try {
+				const response = await fetch(`${webRoot}api/player_auth/verify`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						verify_token: verifyToken,
+						verify_code: verifyCode,
+						player_code: playerCode,
+					}),
+				});
+
+				if (!response.ok) {
+					throw new Error(`Bad server response: ${response.status}`);
+				}
+
+				const json = await response.json();
+				if (cancelled) {
+					return;
+				}
+
+				if (json.error) {
+					setPlayerCodeError("Code expired");
+					setVerifyToken(null);
+					clearInterval(interval);
+					return;
+				}
+
+				if (json.verified) {
+					props.setToken(json.token);
+				}
+			} catch (err) {
+				if (!cancelled && err instanceof Error) {
+					clearInterval(interval);
+					notifyErrorHandler("Error verifying code")(err);
+				}
+			}
+		}
+
+		verify();
+		const interval = setInterval(verify, 2 * 1000);
+
+		return () => {
+			cancelled = true;
+			clearInterval(interval);
+		};
 	}, [verifyToken]);
 
 	if (!servers) {

--- a/plugins/player_auth/web/index.tsx
+++ b/plugins/player_auth/web/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { BaseWebPlugin, notifyErrorHandler } from "@clusterio/web_ui";
 import { Button, Form, Input, Spin, Typography } from "antd";
 
+import { PlayerAuthServer } from "../messages";
 import "./style.css";
 
 const { Paragraph, Text } = Typography;
@@ -12,21 +13,39 @@ interface LoginFormProps {
 }
 
 function LoginForm(props: LoginFormProps) {
-	let [servers, setServers] = useState<string[] | null>(null);
+	const [servers, setServers] = useState<PlayerAuthServer[] | null>(null);
 	let [playerCode, setPlayerCode] = useState<string | null>(null);
 	let [playerCodeError, setPlayerCodeError] = useState<string | null>(null);
 	let [verifyCode, setVerifyCode] = useState<string | undefined>();
 	let [verifyToken, setVerifyToken] = useState<string | null>(null);
 
 	useEffect(() => {
-		(async () => {
+		let cancelled = false;
+
+		async function load() {
 			let response = await fetch(`${webRoot}api/player_auth/servers`);
-			if (response.ok) {
-				setServers(await response.json());
-			} else {
-				setServers([]);
+			if (!response.ok) {
+				if (!cancelled) {
+					setServers([]);
+					const err = new Error(await response.text());
+					notifyErrorHandler("Error retrieving servers")(err);
+				}
+				return;
 			}
-		})();
+
+			const json = await response.json();
+			if (!cancelled) {
+				setServers(json.map((s: any) => PlayerAuthServer.fromJSON(s)));
+			}
+		}
+
+		load();
+		const interval = setInterval(load, 15 * 1000);
+
+		return () => {
+			cancelled = true;
+			clearInterval(interval);
+		};
 	}, []);
 
 	useEffect(() => {
@@ -61,7 +80,7 @@ function LoginForm(props: LoginFormProps) {
 					clearInterval(checkLoop);
 					notifyErrorHandler("Error verifying code")(err);
 				});
-			}, 2000);
+			}, 2 * 1000);
 			return () => { clearInterval(checkLoop); };
 		}
 
@@ -74,8 +93,8 @@ function LoginForm(props: LoginFormProps) {
 
 	if (servers.length === 0) {
 		return <Paragraph>
-			There are no servers in the cluster currently running that can complete
-			the login via Factorio.  Please try again later.
+			There are no running servers available for login via Factorio at the moment.
+			Please try again later.
 		</Paragraph>;
 	}
 
@@ -89,9 +108,35 @@ function LoginForm(props: LoginFormProps) {
 					Start Factorio, join one of the following multiplayer servers
 					and type <Text keyboard>/web-login</Text> into the chat:
 				</Paragraph>
-				<div style={{ maxHeight: 160, overflowY: "auto", paddingLeft: 16 }}>
-					<ul>
-						{servers.map(text => <li key={text}>{text}</li>)}
+				<div style={{ maxHeight: 160, overflowY: "auto", paddingLeft: 16, padding: "8px 0" }}>
+					<ul style={{ margin: 0, paddingLeft: 16 }}>
+						{servers.map(server => (
+							<li key={server.address} style={{ marginBottom: 6 }}>
+								<div style={{
+									display: "grid",
+									gridTemplateColumns: "1fr auto",
+									alignItems: "center",
+									gap: 8,
+								}}>
+									<span>
+										{server.name}
+										{server.factorioVersion && (
+											<Text type="secondary"> ({server.factorioVersion})</Text>
+										)}
+									</span>
+
+									<Button
+										size="small"
+										onClick={() => {
+											window.location.href =
+												`steam://run/427520//--mp-connect=${server.address}`;
+										}}
+									>
+										Connect
+									</Button>
+								</div>
+							</li>
+						))}
 					</ul>
 				</div>
 			</li>


### PR DESCRIPTION
Adds additional server context to the Factorio login flow to improve usability. The server list now includes the running Factorio version and a direct connect option via Steam, reducing friction when using player auth.

The API has been extended to include the required data, with corresponding updates to the web interface. I also made the server list refresh every 15 seconds and refactored `verifyToken` effect hook to be more readable.

### Changelog
```
### Features
- Display Factorio server version in login server list. #906
- Add "Connect via Steam" button to login server list. #915
```
Closes: #906