### PR TITLE
Guard against division by zero in CPU usage calculation

### DIFF
--- a/packages/lib/src/system_collectors.ts
+++ b/packages/lib/src/system_collectors.ts
@@ -132,7 +132,9 @@ export async function gatherSystemInfo(
 	const currentIdleCpuMs = cpus.map(({ times }) => times.idle);
 	const deltaTotalCpuMs = minZip(previousTotalCpuMs, currentTotalCpuMs).map(([prev, curr]) => curr - prev);
 	const deltaIdleCpuMs = minZip(previousIdleCpuMs, currentIdleCpuMs).map(([prev, curr]) => curr - prev);
-	const cpuUsage = minZip(deltaTotalCpuMs, deltaIdleCpuMs).map(([total, idle]) => (total - idle) / total);
+	const cpuUsage = minZip(deltaTotalCpuMs, deltaIdleCpuMs).map(
+		([total, idle]) => (total <= 0 ? 0 : (total - idle) / total)
+	);
 	previousTotalCpuMs = currentTotalCpuMs;
 	previousIdleCpuMs = currentIdleCpuMs;
 	const stats = await fs.statfs(".");


### PR DESCRIPTION
When total is zero it will result in `NaN` or `Infinity` which is then translated into `"null"` by `JSON.stringify` and fails to pass schema validation. Fix was to guard against division by zero.

### Changelog
```
### Fixes
- Fix division by zero in CPU usage calculation. #916
```
Closes: #916 