### PR TITLE
Fix incorrect use of `path.parse` within create template

### DIFF
--- a/packages/create/template.js
+++ b/packages/create/template.js
@@ -62,7 +62,7 @@ async function copyTemplateFile(src, dst, properties) {
 		});
 
 	// Create folder for output file
-	const dir = path.parse(dst);
+	const { dir } = path.parse(dst);
 	if (dir) {
 		await fs.mkdir(dir, { recursive: true });
 	}


### PR DESCRIPTION
As title. #877 introduced a bug which would prevent create from making templates for plugins.

### Changelog
```
### Fixes
- Fix incorrect use of `path.parse` within create template for plugins. #919
```
