### PR TITLE
Add manual tap trunk-test demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ lib-cov
 coverage
 .nyc_output
 
+# tap test runner cache/coverage
+.tap/
+
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -500,4 +500,17 @@ export default defineConfig([{
 		"max-len": "off",
 		"indent": "off",
 	},
+}, {
+	files: ["tap-demo/**/*.js"],
+
+	languageOptions: {
+		sourceType: "commonjs",
+	},
+
+	"rules": {
+		// tap lifecycle/diagnostic CLI scripts: progress logging and startup-time sync I/O
+		// are intended here, matching how test/integration/index.js operates.
+		"no-console": "off",
+		"node/no-sync": "off",
+	},
 }, globalIgnores(["**/dist/", "dist/"])]);

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
 		"watch": "tsc --build --watch",
 		"build-mod": "pnpm run -r build-mod --output-dir ../../dist",
 		"test": "pnpm run build && NODE_EXTRA_CA_CERTS=$(pwd)/test/file/tls/cert.pem mocha --enable-source-maps --check-leaks -R spec --recursive test \"plugins/*/test/**\" --exclude \"test/manual/**\"",
+		"test:tap": "pnpm run build && NODE_EXTRA_CA_CERTS=$(pwd)/test/file/tls/cert.pem tap --disable-coverage --allow-incomplete-coverage --before=tap-demo/boot.js --after=tap-demo/teardown.js tap-demo/smoke.test.js",
 		"silent-test": "SILENT_TEST=y pnpm test",
 		"fast-test": "FAST_TEST=y pnpm test",
 		"cover": "nyc pnpm test",
 		"fast-cover": "FAST_TEST=y nyc pnpm test",
 		"ci-cover": "nyc --reporter=lcovonly pnpm run-script test",
-		"lint": "eslint packages plugins test",
-		"lint-fix": "eslint --fix packages plugins test",
+		"lint": "eslint packages plugins test tap-demo",
+		"lint-fix": "eslint --fix packages plugins test tap-demo",
 		"clean": "node ./clean.js",
 		"docs": "typedoc",
 		"bundle-dependencies": "bundle-dependencies"
@@ -23,6 +24,11 @@
 		"exclude": [
 			"test/**",
 			"plugins/*/test/**"
+		]
+	},
+	"tap": {
+		"files": [
+			"tap-demo/**/*.test.js"
 		]
 	},
 	"engines": {
@@ -56,6 +62,7 @@
 		"jszip": "^3.10.1",
 		"mocha": "^11.7.1",
 		"nyc": "^17.1.0",
+		"tap": "catalog:",
 		"typedoc": "^0.28.9",
 		"typescript": "^5.9.2",
 		"yargs": "^18.0.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalog:
   react-markdown: ^10.1.0
   react-router-dom: ^6.29.0
   set-blocking: ^2.0.0
+  tap: ^21.7.4
   typescript: ^5.7.3
   webpack: ^5.98.0
   webpack-cli: ^5.1.4

--- a/tap-demo/boot.js
+++ b/tap-demo/boot.js
@@ -1,0 +1,126 @@
+"use strict";
+// tap --before module: boots a real clusterio controller ONCE for the whole tap run,
+// leaves it running for the (isolated, per-file) test subprocesses, and records its pid
+// so teardown.js can stop it. Intentionally mirrors a minimal slice of
+// test/integration/index.js's root before() (see TEST_REFACTOR_PLAN.md).
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const cp = require("node:child_process");
+const { promisify } = require("node:util");
+const { workDir, logPath, pidPath, authSecret, httpPort, httpsPort } = require("./shared");
+
+const execAsync = promisify(cp.exec);
+
+function ctl(args) {
+	return execAsync(`node --enable-source-maps ../../packages/controller ${args}`, {
+		cwd: workDir, env: { ...process.env },
+	});
+}
+
+async function readStalePid() {
+	try {
+		return Number(await fsp.readFile(pidPath, "utf8"));
+	} catch {
+		return null;
+	}
+}
+
+// Kill a process by pid (if alive) and wait until it has actually exited and released its
+// ports. Best-effort: a tiny PID-reuse window remains, acceptable for a test harness.
+async function reap(pid, timeoutMs) {
+	if (!Number.isInteger(pid)) {
+		return;
+	}
+	try {
+		process.kill(pid, "SIGINT");
+	} catch {
+		return; // already gone
+	}
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			process.kill(pid, 0);
+		} catch {
+			return; // exited
+		}
+		if (Date.now() > deadline) {
+			try {
+				process.kill(pid, "SIGKILL");
+			} catch {
+				// already gone
+			}
+			return;
+		}
+		await new Promise(resolve => setTimeout(resolve, 100));
+	}
+}
+
+async function main() {
+	// Reap a controller orphaned by a previous aborted run BEFORE wiping the dir — otherwise
+	// its pidfile is deleted and it can never be found again while it still holds the ports.
+	await reap(await readStalePid(), 10000);
+
+	await fsp.rm(workDir, { force: true, recursive: true, maxRetries: 10 });
+	await fsp.mkdir(workDir, { recursive: true });
+
+	// minimal controller config (mirrors test/integration/index.js)
+	await ctl(`config set controller.auth_secret ${authSecret}`);
+	await ctl(`config set controller.http_port ${httpPort}`);
+	await ctl(`config set controller.https_port ${httpsPort}`);
+	await ctl("config set controller.tls_certificate ../../test/file/tls/cert.pem");
+	await ctl("config set controller.tls_private_key ../../test/file/tls/key.pem");
+	await ctl("bootstrap create-admin test");
+
+	// spawn the controller detached, logging to a file so it survives this short-lived process
+	const logFd = fs.openSync(logPath, "a");
+	let child;
+	try {
+		child = cp.spawn("node", ["--enable-source-maps", "../../packages/controller", "run"], {
+			cwd: workDir, env: { ...process.env }, detached: true, stdio: ["ignore", logFd, logFd],
+		});
+	} finally {
+		fs.closeSync(logFd); // the child kept its own dup; the parent's copy must not leak
+	}
+	await fsp.writeFile(pidPath, String(child.pid));
+	child.unref();
+
+	try {
+		const deadline = Date.now() + 30000;
+		for (;;) {
+			let content = "";
+			try {
+				content = await fsp.readFile(logPath, "utf8");
+			} catch {
+				content = ""; // log not written yet
+			}
+			if (/Started controller/.test(content)) {
+				break;
+			}
+			try {
+				process.kill(child.pid, 0);
+			} catch {
+				throw new Error(`controller exited early:\n${content}`);
+			}
+			if (Date.now() > deadline) {
+				throw new Error(`timed out waiting for controller:\n${content}`);
+			}
+			await new Promise(resolve => setTimeout(resolve, 250));
+		}
+	} catch (err) {
+		try {
+			child.kill("SIGINT"); // do not leave the controller orphaned on a failed boot
+		} catch {
+			// already gone
+		}
+		throw err;
+	}
+
+	console.log(`[--before] shared controller booted ONCE (pid ${child.pid})`);
+}
+
+// No process.exit(): let the loop drain so the final log line flushes, and signal failure via
+// the exit code instead (process.exit can truncate buffered stdout on a pipe).
+main().catch(err => {
+	process.exitCode = 1;
+	console.error(`[--before] boot failed: ${err.message}`);
+});

--- a/tap-demo/shared.js
+++ b/tap-demo/shared.js
@@ -1,0 +1,18 @@
+"use strict";
+// Single source of truth for the tap trunk demo, so the controller secret, ports, and
+// paths are not duplicated across boot/teardown/smoke. A real migration would instead
+// factor these out of test/integration/index.js into a hook-free shared module (see
+// TEST_REFACTOR_PLAN.md); this demo deliberately keeps a minimal local copy.
+const path = require("node:path");
+
+const workDir = path.join("temp", "tap-demo");
+
+module.exports = {
+	workDir,
+	logPath: path.join(workDir, "controller.log"),
+	pidPath: path.join(workDir, "controller.pid"),
+	authSecret: "TestSecretDoNotUse",
+	httpPort: 8880,
+	httpsPort: 4443,
+	controllerUrl: "https://localhost:4443/",
+};

--- a/tap-demo/smoke.test.js
+++ b/tap-demo/smoke.test.js
@@ -1,0 +1,44 @@
+"use strict";
+// A trunk-style tap smoke test: runs in its own subprocess and talks to the controller
+// that --before booted once. Proves tap can host clusterio's shared-cluster model.
+// Needs NO Factorio install — only the controller + the control link layer.
+const tap = require("tap");
+const jwt = require("jsonwebtoken");
+const lib = require("@clusterio/lib");
+const { authSecret, controllerUrl } = require("./shared");
+
+class DemoControlConnector extends lib.WebSocketClientConnector {
+	register() {
+		this.sendHandshake(new lib.MessageRegisterControl(new lib.RegisterControlData(this.token, "tap-demo")));
+	}
+}
+
+// connect() retries forever on an unreachable controller, so bound it: reject with a clear
+// message instead of hanging until tap's generic timeout.
+function withTimeout(promise, ms, message) {
+	let timer;
+	const timeout = new Promise((resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), ms);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+tap.test("a tap test connects to the controller booted once by --before", async t => {
+	const token = jwt.sign({ aud: "user", user: "test" }, Buffer.from(authSecret, "base64"));
+	const connector = new DemoControlConnector(controllerUrl, 2);
+	connector.token = token;
+	const control = new lib.Link(connector);
+
+	// An 'error' emitted on the connector with no listener would crash the whole runner;
+	// capture it so a mid-session failure fails this test instead.
+	const errors = [];
+	connector.on("error", err => errors.push(err));
+	t.teardown(() => connector.close(1000, "test done"));
+
+	await withTimeout(connector.connect(), 20000, "control link did not connect within 20s");
+	t.pass("control link established a session with the shared controller");
+
+	const hosts = await control.sendTo("controller", new lib.HostListRequest());
+	t.same(hosts, [], "HostListRequest routed through the controller and returned the (empty) host list");
+	t.same(errors, [], "no errors were emitted on the control connector during the session");
+});

--- a/tap-demo/teardown.js
+++ b/tap-demo/teardown.js
@@ -1,0 +1,45 @@
+"use strict";
+// tap --after module: stops the shared controller booted by boot.js and waits for it to
+// actually exit (releasing its ports) before returning, so a subsequent run does not race it.
+const fsp = require("node:fs/promises");
+const { pidPath } = require("./shared");
+
+async function stop() {
+	let pid;
+	try {
+		pid = Number(await fsp.readFile(pidPath, "utf8"));
+	} catch {
+		return; // nothing was booted
+	}
+	if (!Number.isInteger(pid)) {
+		return;
+	}
+
+	// Only signal a process that is currently alive, to avoid killing an unrelated process if
+	// the pid was recycled (a tiny TOCTOU window remains). On POSIX SIGINT shuts the controller
+	// down gracefully; on Windows Node has no real signals so this is a forced terminate — CI
+	// runs on Linux, where the graceful path is exercised.
+	try {
+		process.kill(pid, "SIGINT");
+	} catch {
+		return; // already gone
+	}
+
+	const deadline = Date.now() + 15000;
+	for (;;) {
+		try {
+			process.kill(pid, 0);
+		} catch {
+			break; // exited and released its ports
+		}
+		if (Date.now() > deadline) {
+			break;
+		}
+		await new Promise(resolve => setTimeout(resolve, 100));
+	}
+	console.log(`[--after] stopped shared controller (pid ${pid})`);
+}
+
+stop().catch(err => {
+	console.error(`[--after] teardown note: ${err.message}`);
+});


### PR DESCRIPTION

 Relates to #843.

This is a small, PoC demo (not wired into CI) to kick off the conversation around #843.   The goal was to see how tap hosts clusterio for integration tests (trunks) that require a persist instance to chain cli unit tests (leafs) together.  Here are the results:  Tap's --before/--after once-per-run fixture is pretty straight forward, and human readable-ish.   I like that we can call them asynchronously and it feels like an upgrade.   Anyway the only goal of this PR is to inform the team, not land a migration decision.  I'm happy to adjust or drop based on what you decide.

What's here:

- **tap-demo/boot.js:** tap --before: boots a controller once (a minimal slice of test/integration/index.js's bootstrap).
- **tap-demo/teardown.js:** --after: stops it, waits for exit.
- **tap-demo/shared.js:** shared constants (secret/ports/paths), so nothing's duplicated across the three.
- **tap-demo/smoke.test.js:** an isolated test that connects a control link and routes a HostListRequest through the controller.

Run it:

pnpm run test:tap
→ boots a controller, runs the smoke test (3/3), tears down. Manual only — pnpm test (Mocha) is untouched.


 Mocha vs tap, at a glance (leaf tests convert ~1:1; only the trunk needs real work)

 |                      | Mocha                               | tap                       |
 |----------------------|-------------------------------------|---------------------------|
 | suite / case         | describe / it                       | nested t.test()           |
 | once-per-run fixture | root before() (one process, global) | --before / --after module |
 | isolation            | single process, shared globals      | one subprocess per file   |
 | coverage             | external nyc                        | built-in                  |
 | output               | spec                                | TAP (native)              |

 Open questions for you (your call, not assumed here)
 - Framework: tap vs node:test vs staying on Mocha.
 - Isolation for the trunk: keep the shared-world model (--before) vs. isolate each file.
 - Bootstrap reuse: ideally the trunk bootstrap gets factored out of index.js into a hook-free shared module as we migrate so both Mocha and tap could run same trunk as we migrate piece by piece.
 
Checks

pnpm run lint and the full pnpm run test matrix pass in CI.

### Changelog
```
### Features
- ...

### Changes
- ...

### Fixes
- ...

### Breaking Changes
- ...
```
