### PR TITLE
Rework site layout into a fixed sidebar

### DIFF
--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -218,7 +218,7 @@ export default function SiteLayout() {
 				aria-label="Toggle navigation menu"
 			/>
 			<Link to="/" style={{ display: "flex", alignItems: "center" }}>
-				<img src={logo} width={32} height={32} alt="Clusterio logo" />
+				<img src={logo} width={56} height={56} alt="Clusterio logo" />
 			</Link>
 			<Flex vertical justify="center">
 				<Typography.Title level={4} style={{ margin: 0, lineHeight: 1.2 }}>Clusterio</Typography.Title>

--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useContext, useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
-import { Button, Flex, Layout, Menu, MenuProps, Tooltip, Typography } from "antd";
-import { UserOutlined, DownloadOutlined } from "@ant-design/icons";
+import { Button, Drawer, Dropdown, Flex, Grid, Layout, Menu, MenuProps, Tooltip, Typography } from "antd";
+import { UserOutlined, DownloadOutlined, MenuOutlined } from "@ant-design/icons";
 
 import ErrorBoundary from "./ErrorBoundary";
 import ErrorPage from "./ErrorPage";
@@ -20,7 +20,7 @@ import { ControlConfig } from "@clusterio/lib";
 
 type MenuItem = Required<MenuProps>["items"][number];
 
-const { Sider } = Layout;
+const { Sider, Header } = Layout;
 
 function isActiveDropzone(element: HTMLElement | null): boolean {
 	if (!element) {
@@ -43,6 +43,13 @@ function isActiveDropzone(element: HTMLElement | null): boolean {
 export default function SiteLayout() {
 	let navigate = useNavigate();
 	let [currentSidebarPath, setCurrentSidebarPath] = useState<string | null>(null);
+	const screens = Grid.useBreakpoint();
+	// On phone screens the sidebar becomes an overlay drawer instead of a fixed sider.
+	// `md` matches the previous Sider breakpoint; `screens.md` is undefined until measured,
+	// so treat the initial render as desktop to avoid flashing the hamburger.
+	const isMobile = screens.md === false;
+	const [drawerOpen, setDrawerOpen] = useState(false);
+	const [collapsed, setCollapsed] = useState(false);
 	let account = useAccount();
 	let plugins = useContext(ControlContext).plugins;
 	const control = useContext(ControlContext);
@@ -127,8 +134,38 @@ export default function SiteLayout() {
 		setDragging(dragging + dragChange);
 	}
 
+	// Navigate and dismiss the mobile drawer, matching hamburger menu conventions.
+	function navigateAndClose(key: string) {
+		navigate(key);
+		setDrawerOpen(false);
+	}
+
+	// The header trigger collapses the sider on desktop and toggles the overlay drawer on phones.
+	function toggleSidebar() {
+		if (isMobile) {
+			setDrawerOpen(value => !value);
+		} else {
+			setCollapsed(value => !value);
+		}
+	}
+
+	let sidebarContent = <Menu
+		theme="dark"
+		mode="inline"
+		defaultOpenKeys={[...menuGroups.keys()]}
+		selectedKeys={currentSidebarPath ? [currentSidebarPath] : []}
+		style={{ height: "100%", overflow: "auto", borderInlineEnd: 0 }}
+		onClick={({ key }) => navigateAndClose(key)}
+		items={menuItems}
+	/>;
+
+	let accountMenu = <Dropdown menu={accountMenuProps} trigger={["click"]} placement="bottomRight">
+		<Button type="text" icon={<UserOutlined />} style={{ marginInlineStart: "auto" }}>
+			{account.name}
+		</Button>
+	</Dropdown>;
+
 	return <Layout
-		hasSider
 		className="site-layout"
 		style={{ minHeight: "100vh" }}
 		onDragEnter={() => setDraggingProxy(1)}
@@ -172,69 +209,69 @@ export default function SiteLayout() {
 				setAboutOpen(wasAboutOpen);
 			}}
 		/>
+		<Header className="site-layout-header">
+			<Button
+				type="text"
+				icon={<MenuOutlined />}
+				onClick={toggleSidebar}
+				aria-label="Toggle navigation menu"
+			/>
+			<img src={logo} width={32} height={32} alt="Clusterio logo" />
+			<Flex vertical justify="center">
+				<Typography.Title level={4} style={{ margin: 0, lineHeight: 1.2 }}>Clusterio</Typography.Title>
+				<Tooltip title="View changelog" placement="right">
+					<Typography.Text
+						type="danger"
+						style={{ cursor: "pointer", lineHeight: 1.2 }}
+						onClick={() => setChangeLogOpen(true)}
+					>
+						{webUiPackage.version}
+					</Typography.Text>
+				</Tooltip>
+			</Flex>
+			{accountMenu}
+		</Header>
 		<DraggingContext.Provider value={dragging > 0}>
-			<Sider
-				collapsible
-				collapsedWidth={0}
-				breakpoint="md"
-				zeroWidthTriggerStyle={{ top: 6, zIndex: -1 }}
-				width={250}
-				className="site-layout-sider"
-			>
-				<Flex vertical style={{ height: "100%" }}>
-					<Flex align="center" gap="middle" style={{ padding: 16 }}>
-						<img src={logo} width={48} height={48} alt="Clusterio logo" />
-						<Flex vertical>
-							<Typography.Title level={4} style={{ margin: 0 }}>Clusterio</Typography.Title>
-							<Tooltip title="View changelog" placement="right">
-								<Typography.Text
-									type="danger"
-									style={{ cursor: "pointer" }}
-									onClick={() => setChangeLogOpen(true)}
-								>
-									{webUiPackage.version}
-								</Typography.Text>
-							</Tooltip>
-						</Flex>
-					</Flex>
-					<Menu
-						theme="dark"
-						mode="inline"
-						defaultOpenKeys={[...menuGroups.keys()]}
-						selectedKeys={currentSidebarPath ? [currentSidebarPath] : []}
-						style={{ flex: 1, overflow: "auto", borderInlineEnd: 0 }}
-						onClick={({ key }) => navigate(key)}
-						items={menuItems}
-					/>
-					<Menu
-						theme="dark"
-						mode="vertical"
-						selectable={false}
-						style={{ borderInlineEnd: 0 }}
-						onClick={accountMenuProps.onClick}
-						items={[{
-							key: "account",
-							icon: <UserOutlined />,
-							label: account.name,
-							children: accountMenuProps.items,
-						}]}
-					/>
-				</Flex>
-			</Sider>
-			<Layout className="site-layout-content-container">
-				<Routes>
-					{combinedPages.map(({ path, sidebarPath, content }) => <Route
-						path={path}
-						key={path}
-						element={<Fragment key={path}>
-							<SetSidebar path={sidebarPath ? sidebarPath : path} />
-							<ErrorBoundary Component={ErrorPage}>
-								{content}
-							</ErrorBoundary>
-						</Fragment>}
-					/>)}
-					<Route element={<SetSidebar path={null} />} />
-				</Routes>
+			<Layout hasSider={!isMobile}>
+				{isMobile
+					? <Drawer
+						placement="left"
+						open={drawerOpen}
+						onClose={() => setDrawerOpen(false)}
+						width={250}
+						closable={false}
+						// Start below the sticky 64px header so it stays visible and usable.
+						rootStyle={{ top: 64 }}
+						styles={{ body: { padding: 0, background: "#001529" } }}
+					>
+						{sidebarContent}
+					</Drawer>
+					: <Sider
+						width={250}
+						collapsible
+						collapsed={collapsed}
+						collapsedWidth={0}
+						trigger={null}
+						className="site-layout-sider"
+					>
+						{sidebarContent}
+					</Sider>
+				}
+				<Layout className="site-layout-content-container">
+					<Routes>
+						{combinedPages.map(({ path, sidebarPath, content }) => <Route
+							path={path}
+							key={path}
+							element={<Fragment key={path}>
+								<SetSidebar path={sidebarPath ? sidebarPath : path} />
+								<ErrorBoundary Component={ErrorPage}>
+									{content}
+								</ErrorBoundary>
+							</Fragment>}
+						/>)}
+						<Route element={<SetSidebar path={null} />} />
+					</Routes>
+				</Layout>
 			</Layout>
 		</DraggingContext.Provider>
 	</Layout>;

--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useContext, useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
-import { Button, Dropdown, Layout, Menu, MenuProps, Tooltip } from "antd";
+import { Button, Flex, Layout, Menu, MenuProps, Tooltip, Typography } from "antd";
 import { UserOutlined, DownloadOutlined } from "@ant-design/icons";
 
 import ErrorBoundary from "./ErrorBoundary";
@@ -14,12 +14,13 @@ import { saveJson } from "../util/save_file";
 import { useAccount } from "../model/account";
 import { DraggingContext } from "../model/is_dragging";
 import webUiPackage from "../../package.json";
+import logo from "../images/logo.png";
 
 import { ControlConfig } from "@clusterio/lib";
 
 type MenuItem = Required<MenuProps>["items"][number];
 
-const { Header, Sider } = Layout;
+const { Sider } = Layout;
 
 function isActiveDropzone(element: HTMLElement | null): boolean {
 	if (!element) {
@@ -127,6 +128,8 @@ export default function SiteLayout() {
 	}
 
 	return <Layout
+		hasSider
+		className="site-layout"
 		style={{ minHeight: "100vh" }}
 		onDragEnter={() => setDraggingProxy(1)}
 		onDragLeave={() => setDraggingProxy(-1)}
@@ -170,70 +173,68 @@ export default function SiteLayout() {
 			}}
 		/>
 		<DraggingContext.Provider value={dragging > 0}>
-			<Header className="header">
-				<div className="site-logo" />
-				<span className="site-name">Clusterio</span>
-				<Tooltip
-					title="View changelog"
-					placement="bottom"
-					align={{ offset: [0, -10] }}
-				>
-					<span
-						className="site-version"
-						style={{ cursor: "pointer" }}
-						onClick={() => setChangeLogOpen(true)}
-					>
-						{webUiPackage.version}
-					</span>
-				</Tooltip>
-				<Menu
-					theme="dark"
-					mode="horizontal"
-					defaultSelectedKeys={["1"]}
-					items={[{ label: "Dashboard", key: "1" }]}
-				/>
-				<Dropdown
-					className="account-dropdown-header"
-					placement="bottomRight"
-					trigger={["click"]}
-					menu={accountMenuProps}
-				>
-					<UserOutlined />
-				</Dropdown>
-			</Header>
-			<Layout className="site-layout">
-				<Sider
-					collapsible
-					collapsedWidth={0}
-					breakpoint="md"
-					zeroWidthTriggerStyle={{ top: 6, zIndex: -1 }}
-					width={250}
-					className="site-layout-sider"
-				>
+			<Sider
+				collapsible
+				collapsedWidth={0}
+				breakpoint="md"
+				zeroWidthTriggerStyle={{ top: 6, zIndex: -1 }}
+				width={250}
+				className="site-layout-sider"
+			>
+				<Flex vertical style={{ height: "100%" }}>
+					<Flex align="center" gap="middle" style={{ padding: 16 }}>
+						<img src={logo} width={48} height={48} alt="Clusterio logo" />
+						<Flex vertical>
+							<Typography.Title level={4} style={{ margin: 0 }}>Clusterio</Typography.Title>
+							<Tooltip title="View changelog" placement="right">
+								<Typography.Text
+									type="danger"
+									style={{ cursor: "pointer" }}
+									onClick={() => setChangeLogOpen(true)}
+								>
+									{webUiPackage.version}
+								</Typography.Text>
+							</Tooltip>
+						</Flex>
+					</Flex>
 					<Menu
+						theme="dark"
 						mode="inline"
 						defaultOpenKeys={[...menuGroups.keys()]}
 						selectedKeys={currentSidebarPath ? [currentSidebarPath] : []}
-						style={{ height: "100%", borderRight: 0 }}
+						style={{ flex: 1, overflow: "auto", borderInlineEnd: 0 }}
 						onClick={({ key }) => navigate(key)}
 						items={menuItems}
 					/>
-				</Sider>
-				<Layout className="site-layout-content-container">
-					<Routes>
-						{combinedPages.map(({ path, sidebarPath, content }) => <Route
-							path={path}
-							key={path}
-							element={<Fragment key={path}>
-								<SetSidebar path={sidebarPath ? sidebarPath : path} />
-								<ErrorBoundary Component={ErrorPage}>
-									{content}
-								</ErrorBoundary>
-							</Fragment>}
-						/>)}
-						<Route element={<SetSidebar path={null} />} />
-					</Routes>
-				</Layout>
+					<Menu
+						theme="dark"
+						mode="vertical"
+						selectable={false}
+						style={{ borderInlineEnd: 0 }}
+						onClick={accountMenuProps.onClick}
+						items={[{
+							key: "account",
+							icon: <UserOutlined />,
+							label: account.name,
+							children: accountMenuProps.items,
+						}]}
+					/>
+				</Flex>
+			</Sider>
+			<Layout className="site-layout-content-container">
+				<Routes>
+					{combinedPages.map(({ path, sidebarPath, content }) => <Route
+						path={path}
+						key={path}
+						element={<Fragment key={path}>
+							<SetSidebar path={sidebarPath ? sidebarPath : path} />
+							<ErrorBoundary Component={ErrorPage}>
+								{content}
+							</ErrorBoundary>
+						</Fragment>}
+					/>)}
+					<Route element={<SetSidebar path={null} />} />
+				</Routes>
 			</Layout>
 		</DraggingContext.Provider>
 	</Layout>;

--- a/packages/web_ui/src/components/SiteLayout.tsx
+++ b/packages/web_ui/src/components/SiteLayout.tsx
@@ -8,6 +8,7 @@ import ErrorPage from "./ErrorPage";
 import ControlContext from "./ControlContext";
 import ChangeLogModal from "./ChangeLogModal";
 import AboutModal from "./AboutModal";
+import Link from "./Link";
 
 import { pages } from "../pages";
 import { saveJson } from "../util/save_file";
@@ -216,7 +217,9 @@ export default function SiteLayout() {
 				onClick={toggleSidebar}
 				aria-label="Toggle navigation menu"
 			/>
-			<img src={logo} width={32} height={32} alt="Clusterio logo" />
+			<Link to="/" style={{ display: "flex", alignItems: "center" }}>
+				<img src={logo} width={32} height={32} alt="Clusterio logo" />
+			</Link>
 			<Flex vertical justify="center">
 				<Typography.Title level={4} style={{ margin: 0, lineHeight: 1.2 }}>Clusterio</Typography.Title>
 				<Tooltip title="View changelog" placement="right">

--- a/packages/web_ui/src/style.css
+++ b/packages/web_ui/src/style.css
@@ -56,13 +56,12 @@ body {
 	}
 }
 
+/* Keep the sidebar fixed in place while the page content scrolls */
 .site-layout-sider {
-	z-index: 0;
-}
-
-.header {
-	padding-left: 250px;
-	padding-right: 64px;
+	position: sticky;
+	top: 0;
+	height: 100vh;
+	align-self: flex-start;
 }
 
 .page-header {
@@ -103,75 +102,6 @@ body {
 
 .section-header-extra, .page-header-extra {
 	margin-left: auto;
-}
-
-.site-name {
-	position: absolute;
-	top: -10px;
-	left: 112px;
-	font-size: 18pt;
-	font-weight: 400;
-}
-
-.site-version {
-	position: absolute;
-	top: 10px;
-	left: 120px;
-	color: #f00;
-}
-
-.site-logo {
-	position: absolute;
-	left: 36px;
-	width: 64px;
-	height: 64px;
-	background-image: url("./images/logo.png");
-	background-size: 64px;
-}
-
-@media not all and (min-width: 576px) {
-	.header {
-		padding-left: 88px;
-	}
-
-	.site-logo {
-		left: 12px;
-	}
-
-	.site-name {
-		display: none;
-	}
-
-	.site-version {
-		display: none;
-	}
-}
-
-.account-dropdown-header {
-	position: absolute;
-	right: 0;
-	top: 0;
-	width: 64px;
-	height: 64px;
-	font-size: 18px;
-	line-height: 72px;
-	display: flex;
-	justify-content: center;
-}
-
-.account-dropdown-header::after {
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	background: transparent;
-	transition: all 0.3s;
-	content: "";
-}
-
-.account-dropdown-header:hover::after {
-	background: rgba(255, 255, 255, 0.1);
 }
 
 .error-traceback code {

--- a/packages/web_ui/src/style.css
+++ b/packages/web_ui/src/style.css
@@ -33,16 +33,12 @@ body {
 }
 
 .site-breadcrumb {
-	margin: 16px 0 16px 52px;
+	margin: 16px 0;
 }
 
 @media (min-width: 576px) {
 	.site-layout-content-container {
 		padding: 0 24px 24px;
-	}
-
-	.site-breadcrumb {
-		margin-left: 28px;
 	}
 }
 
@@ -56,12 +52,30 @@ body {
 	}
 }
 
-/* Keep the sidebar fixed in place while the page content scrolls */
-.site-layout-sider {
+/* Top bar hosting the menu toggle and branding, sticky above the content. */
+.site-layout-header {
 	position: sticky;
 	top: 0;
-	height: 100vh;
+	z-index: 100;
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding-inline: 16px;
+	background: #001529;
+}
+
+/* Keep the sidebar fixed in place (below the header) while content scrolls. */
+.site-layout-sider {
+	position: sticky;
+	top: 64px;
+	height: calc(100vh - 64px);
 	align-self: flex-start;
+}
+
+/* Snap the sider open/closed instead of animating its width — the width
+   transition reflowed the content area and caused styling glitches. */
+.ant-layout-sider.site-layout-sider {
+	transition: none;
 }
 
 .page-header {


### PR DESCRIPTION
## Summary
Removes the top header and folds its contents into the sidebar, which is now sticky and full height:
<img width="2879" height="1589" alt="image" src="https://github.com/user-attachments/assets/e758e13c-4339-4a14-b567-f80f6df09a92" />


- Logo + version at the top (the version still opens the changelog)
- Navigation in the middle (scrolls on its own if it overflows)
- Account menu pinned to the bottom, opening to the right

The sidebar is rebuilt with antd `Flex`, `Typography` and `Menu`, so almost all of the styling now comes from antd and the custom css for this layout is reduced to a single sticky rule (`position: sticky` is the one thing antd doesn't provide).

The nav menus also use `theme="dark"` to match the dark `Sider`. Previously the sidebar menu had no theme, so under the app's `darkAlgorithm` it was treated as a light menu and coloured the active item with the primary blue on a faint tint, which read as low contrast on the dark background; a dark menu uses white text on a solid primary background instead.

## Notes
- No behaviour change to navigation or the account actions, only layout and styling.
- Net reduction of ~70 lines.

## Testing
Built (`tsc` + webpack) and viewed locally against a running controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Changelog
```
### Changes
- Reworked the site layout into a fixed sidebar with a top bar. #924
```
