### PR TITLE
Fix antd Modal destroyOnClose deprecation and version TreeSelect duplicate-value warnings

### DIFF
--- a/packages/web_ui/src/components/AssignInstanceModal.tsx
+++ b/packages/web_ui/src/components/AssignInstanceModal.tsx
@@ -67,7 +67,7 @@ export default function AssignInstanceModal(props: AssignInstanceModalProps) {
 			confirmLoading={applying}
 			onOk={handleAssign}
 			onCancel={handleCancel}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Paragraph style={{ maxWidth: "30em" }}>
 				Select a Host to assign this instance to.  Assignment

--- a/packages/web_ui/src/components/CreateSaveModal.tsx
+++ b/packages/web_ui/src/components/CreateSaveModal.tsx
@@ -106,7 +106,7 @@ export default function CreateSaveModal(props: CreateSaveModalProps) {
 			confirmLoading={creatingSave}
 			onOk={createSave}
 			onCancel={handleCancel}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form} layout="vertical">
 				<Form.Item name="saveName" label="Save Name">

--- a/packages/web_ui/src/components/InputVersion.tsx
+++ b/packages/web_ui/src/components/InputVersion.tsx
@@ -58,7 +58,10 @@ function InputVersion<
 			title: majorMinor,
 			value: majorMinor,
 			key: majorMinor,
-			children: patchVersions.map((v) => ({
+			// Skip a patch equal to the group key (a bare major.minor version,
+			// e.g. the ApiVersions fallback): the selectable group node already
+			// represents it, and a duplicate value warns in the TreeSelect.
+			children: patchVersions.filter((v) => v !== majorMinor).map((v) => ({
 				title: v,
 				value: v,
 				key: v,

--- a/packages/web_ui/src/components/InstancesPage.tsx
+++ b/packages/web_ui/src/components/InstancesPage.tsx
@@ -53,7 +53,7 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 			open={open}
 			onOk={() => { createInstance().catch(notifyErrorHandler("Error creating instance")); }}
 			onCancel={() => { setOpen(false); }}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form}>
 				<Form.Item name="instanceName" label="Name">

--- a/packages/web_ui/src/components/LoadScenarioModal.tsx
+++ b/packages/web_ui/src/components/LoadScenarioModal.tsx
@@ -103,7 +103,7 @@ export default function LoadScenarioModal(props: LoadScenarioModalProps) {
 			confirmLoading={loadingScenario}
 			onOk={loadScenario}
 			onCancel={handleCancel}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form} layout="vertical">
 				<Form.Item name="scenario" label="Scenario">

--- a/packages/web_ui/src/components/ModPackViewPage.tsx
+++ b/packages/web_ui/src/components/ModPackViewPage.tsx
@@ -1052,7 +1052,7 @@ function ExportButton(props: { modPack: lib.ModPack }) {
 			open={open}
 			onOk={close}
 			onCancel={close}
-			destroyOnClose
+			destroyOnHidden
 			footer={<Space>
 				<CopyButton content={exportString} />
 				<Button onClick={close}>Close</Button>

--- a/packages/web_ui/src/components/NpmButton.tsx
+++ b/packages/web_ui/src/components/NpmButton.tsx
@@ -170,7 +170,7 @@ export function NpmButton(props: {
 			okButtonProps={{disabled: formAction === undefined}}
 			onOk={() => { onOk().catch(notifyErrorHandler(`Error running ${formAction}`)); }}
 			onCancel={() => { setOpen(false); }}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form} onValuesChange={onValuesChange} clearOnDestroy>
 				<Form.Item label="Action" name="action">

--- a/packages/web_ui/src/components/RolesPage.tsx
+++ b/packages/web_ui/src/components/RolesPage.tsx
@@ -47,7 +47,7 @@ function CreateRoleButton() {
 			open={open}
 			onOk={() => { createRole().catch(notifyErrorHandler("Error creating role")); }}
 			onCancel={() => { setOpen(false); }}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form}>
 				<Form.Item name="roleName" label="Name">

--- a/packages/web_ui/src/components/SavesList.tsx
+++ b/packages/web_ui/src/components/SavesList.tsx
@@ -119,7 +119,7 @@ function TransferModal(props: ModalProps) {
 			open={open}
 			onOk={() => form.submit()}
 			onCancel={() => setOpen(false)}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form
 				form={form}

--- a/packages/web_ui/src/components/UsersPage.tsx
+++ b/packages/web_ui/src/components/UsersPage.tsx
@@ -50,7 +50,7 @@ function CreateUserButton() {
 			open={open}
 			onOk={() => { createUser().catch(notifyErrorHandler("Error creating user")); }}
 			onCancel={() => { setOpen(false); }}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form}>
 				<Form.Item name="userName" label="Name">
@@ -345,7 +345,7 @@ function BulkUserActionButton() {
 			okButtonProps={{ disabled: formAction === undefined }}
 			onOk={() => { onOk().catch(notifyErrorHandler(`Error running ${formAction}`)); }}
 			onCancel={() => { setOpen(false); }}
-			destroyOnClose
+			destroyOnHidden
 		>
 			<Form form={form} onValuesChange={onValuesChange} clearOnDestroy>
 				<Form.Item label="Action" name="action">


### PR DESCRIPTION
## Summary

Fixes two Ant Design console warnings in the Web UI.

## What changed

- **`destroyOnClose` deprecation** — antd 5.25 deprecated the Modal `destroyOnClose` prop in favour of `destroyOnHidden` (`[antd: Modal] \`destroyOnClose\` is deprecated. Please use \`destroyOnHidden\` instead.`). Renamed it on all 10 `Modal` usages across the web UI (InstancesPage, RolesPage, NpmButton, UsersPage ×2, SavesList, LoadScenarioModal, AssignInstanceModal, ModPackViewPage, CreateSaveModal).
- **`TreeSelect` duplicate value** — the version selector (`InputVersion.tsx`) logged `Warning: Same \`value\` exist in the tree: 0.13` (and 0.14/0.15/…). A version group node uses the major.minor as its (selectable) value, and when the version list contains a bare major.minor entry — e.g. the `ApiVersions` fallback shown before the version fetch resolves — it was also added as a child with the same value. Children equal to their group key are now skipped, since the group node already represents that value.

No behaviour change beyond silencing the warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Changelog
```
### Fixes

- Silenced two Ant Design console warnings in the Web UI: the deprecated Modal `destroyOnClose` prop, and a duplicate-value warning from the instance version selector. #940
```
