### PR TITLE
Setting filepath on config makes it dirty

### DIFF
--- a/packages/lib/src/config/classes.ts
+++ b/packages/lib/src/config/classes.ts
@@ -251,7 +251,7 @@ export class Config<
 	constructor(
 		public location: ConfigLocation,
 		fields?: Static<typeof Config.jsonSchema>,
-		public filepath?: string,
+		private _filepath?: string,
 	) {
 		if (typeof location !== "string") {
 			throw new Error("location must be a string");
@@ -271,6 +271,15 @@ export class Config<
 		if (fields) {
 			this.update(this.constructor.migrations(fields), false, location);
 		}
+	}
+
+	get filepath() {
+		return this._filepath;
+	}
+
+	set filepath(filepath: string | undefined) {
+		this.dirty = true;
+		this._filepath = filepath;
 	}
 
 	/** A staging version of the config with changes tracked, invalided by revertStaging */

--- a/test/lib/config/classes.js
+++ b/test/lib/config/classes.js
@@ -176,6 +176,28 @@ describe("lib/config/classes", function() {
 			});
 		});
 
+		describe("get filepath", function() {
+			it("returns the current filepath for the config", function() {
+				const testInstance = new TestConfig("local", undefined, "foo/bar");
+				assert.equal(testInstance.filepath, "foo/bar");
+			});
+		});
+
+		describe("set filepath", function() {
+			it("sets the current filepath for the config", function() {
+				const testInstance = new TestConfig("local");
+				assert.equal(testInstance.filepath, undefined);
+				testInstance.filepath = "foo/bar";
+				assert.equal(testInstance.filepath, "foo/bar");
+			});
+			it("sets the dirty flag", function() {
+				const testInstance = new TestConfig("local");
+				assert.equal(testInstance.dirty, false);
+				testInstance.filepath = "foo/bar";
+				assert.equal(testInstance.dirty, true);
+			});
+		});
+
 		describe(".toJSON()", function() {
 			it("should serialize a basic config", function() {
 				const testInstance = new TestConfig("local");


### PR DESCRIPTION
Setting the filepath on a config will now make it dirty and cause it to be saved. This fixes the issue of newly created instances not having their config saved on assignment and creating duplicate folders if the config was never edited when the host is restarted.

### Changelog
```
### Fixes
- Instances always create their config file on assignment preventing duplicate folder creation. #945
```
