### PR TITLE
Fix the instance console hiding Factorio diagnostics

### DIFF
--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -1,7 +1,8 @@
 import React, { useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
-	Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Space, Spin, Switch, Typography, message,
+	Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Segmented, Space, Spin, Tooltip, Typography,
+	message,
 } from "antd";
 import CopyOutlined from "@ant-design/icons/CopyOutlined";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
@@ -34,7 +35,7 @@ import { MetricRelativeDate } from "./system_metrics";
 type MenuItem = Required<MenuProps>["items"][number];
 const { Title } = Typography;
 
-// Remembers the console "Chat/Log" toggle across reloads (defaults to on).
+// Remembers the console "Chat/Log" selection across reloads (defaults to chat).
 const consoleActionsOnlyKey = "instance-console-actions-only";
 
 type InstanceDescriptionProps = {
@@ -249,12 +250,22 @@ export default function InstanceViewPage() {
 				{
 					account.hasPermission("core.log.follow")
 					&& <Flex align="center" gap="middle">
-						<Switch
-							checkedChildren="Chat"
-							unCheckedChildren="Log"
-							checked={actionsOnly}
-							onChange={setActionsOnly}
-						/>
+						<Tooltip
+							title={
+								"Chat shows what happened on the server: player chat, joins, leaves, " +
+								"commands and the replies to them, plus anything that went wrong. Log adds " +
+								"the Factorio engine log and Clusterio's own account of running the instance."
+							}
+						>
+							<Segmented
+								value={actionsOnly ? "chat" : "log"}
+								onChange={value => setActionsOnly(value === "chat")}
+								options={[
+									{ label: "Chat", value: "chat" },
+									{ label: "Log", value: "log" },
+								]}
+							/>
+						</Tooltip>
 						<SelectMaxLogLevel
 							value={maxLevel}
 							onChange={setMaxLevel}

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -252,9 +252,8 @@ export default function InstanceViewPage() {
 					&& <Flex align="center" gap="middle">
 						<Tooltip
 							title={
-								"Game shows what happened on the server: player chat, joins, leaves, " +
-								"commands and the replies to them, plus anything that went wrong. Instance " +
-								"adds the Factorio engine log and Clusterio's own account of running it."
+								"Game filters to in-game actions and errors: player chat, joins, leaves, etc." +
+								"Instance is the full unfiltered log including the engine log."
 							}
 						>
 							<Segmented

--- a/packages/web_ui/src/components/InstanceViewPage.tsx
+++ b/packages/web_ui/src/components/InstanceViewPage.tsx
@@ -1,7 +1,8 @@
 import React, { useContext, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
-	Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Space, Spin, Switch, Typography, message,
+	Alert, Button, Descriptions, Dropdown, Flex, MenuProps, Modal, Segmented, Space, Spin, Tooltip, Typography,
+	message,
 } from "antd";
 import CopyOutlined from "@ant-design/icons/CopyOutlined";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
@@ -34,7 +35,7 @@ import { MetricRelativeDate } from "./system_metrics";
 type MenuItem = Required<MenuProps>["items"][number];
 const { Title } = Typography;
 
-// Remembers the console "Chat/Log" toggle across reloads (defaults to on).
+// Remembers the console "Game/Instance" selection across reloads (defaults to game).
 const consoleActionsOnlyKey = "instance-console-actions-only";
 
 type InstanceDescriptionProps = {
@@ -249,12 +250,22 @@ export default function InstanceViewPage() {
 				{
 					account.hasPermission("core.log.follow")
 					&& <Flex align="center" gap="middle">
-						<Switch
-							checkedChildren="Chat"
-							unCheckedChildren="Log"
-							checked={actionsOnly}
-							onChange={setActionsOnly}
-						/>
+						<Tooltip
+							title={
+								"Game shows what happened on the server: player chat, joins, leaves, " +
+								"commands and the replies to them, plus anything that went wrong. Instance " +
+								"adds the Factorio engine log and Clusterio's own account of running it."
+							}
+						>
+							<Segmented
+								value={actionsOnly ? "game" : "instance"}
+								onChange={value => setActionsOnly(value === "game")}
+								options={[
+									{ label: "Game", value: "game" },
+									{ label: "Instance", value: "instance" },
+								]}
+							/>
+						</Tooltip>
 						<SelectMaxLogLevel
 							value={maxLevel}
 							onChange={setMaxLevel}

--- a/packages/web_ui/src/components/LogConsole.tsx
+++ b/packages/web_ui/src/components/LogConsole.tsx
@@ -68,6 +68,36 @@ function formatLog(info: Info, key: number): ReactElement {
 	return <span key={key}>[{level}] {info.message}<br/></span>;
 }
 
+/**
+ * Test if a log entry survives the console's actions only filter
+ *
+ * The filter narrows the console down to what happened on the server,
+ * rather than everything the cluster wrote about it.  Anything reporting
+ * that something went wrong is kept regardless of source, as hiding it is
+ * what makes a filtered console misleading rather than merely terse.
+ */
+function passesActionsOnly(info: Info) {
+	// Clusterio's own entries are its account of running the instance.
+	// Keep the ones reporting a problem, drop the routine bookkeeping.
+	if (info.level !== "server") {
+		return lib.levels[info.level] <= lib.levels.warn;
+	}
+
+	// Factorio writes two interleaved streams to stdout.  The console log
+	// is date stamped and carries the things done to the server: chat,
+	// joins, leaves, commands, and the server's replies to them.  It is
+	// kept whole, because a reply is not always an action -- a rejected
+	// command is answered with a plain message, and dropping it makes the
+	// console look like the command did nothing at all.
+	//
+	// The engine log is stamped with seconds since start and is verbose
+	// diagnostic output, so only its warnings and errors are kept.
+	if (info.parsed?.format === "seconds") {
+		return info.parsed.level === "Warning" || info.parsed.level === "Error";
+	}
+	return true;
+}
+
 type LogConsoleProps = {
 	all?: boolean;
 	controller?: boolean;
@@ -159,11 +189,7 @@ export default function LogConsole(props: LogConsoleProps) {
 				"desc",
 			)).then(result => {
 				setPastLines(result.log
-					.filter(info => (
-						!props.actionsOnly
-						|| (info as Info).level !== "server"
-						|| (info as Info).parsed?.type === "action"
-					))
+					.filter(info => !props.actionsOnly || passesActionsOnly(info as Info))
 					.map((info, index) => formatLog(info as Info, -index - 1))
 					.reverse()
 				);
@@ -175,7 +201,7 @@ export default function LogConsole(props: LogConsoleProps) {
 		}
 
 		function logHandler(info: Info) {
-			if (!props.actionsOnly || info.level !== "server" || info.parsed?.type === "action") {
+			if (!props.actionsOnly || passesActionsOnly(info)) {
 				setLines(currentLines => currentLines.concat(
 					[formatLog(info, currentLines.length)]
 				));

--- a/packages/web_ui/src/components/LogConsole.tsx
+++ b/packages/web_ui/src/components/LogConsole.tsx
@@ -22,7 +22,7 @@ type Parsed = {
 	message: string;
 };
 
-function formatParsedOutput(parsed: Parsed, key: number) {
+function formatParsedOutput(parsed: Parsed) {
 	let time: ReactElement|string = "";
 	if (parsed.format === "seconds") {
 		time = <span className="factorio-time">{parsed.time.padStart(8)} </span>;
@@ -51,7 +51,7 @@ function formatParsedOutput(parsed: Parsed, key: number) {
 		info = <>[<span className="factorio-action">{parsed.action}</span>] </>;
 	}
 
-	return <span key={key}>{time}{info}{parsed.message}<br/></span>;
+	return <>{time}{info}{parsed.message}</>;
 }
 
 type Info = {
@@ -61,11 +61,9 @@ type Info = {
 };
 
 function formatLog(info: Info, key: number): ReactElement {
-	if (info.level === "server" && info.parsed) {
-		return formatParsedOutput(info.parsed, key);
-	}
 	let level = <span className={`log-${info.level}`}>{info.level}</span>;
-	return <span key={key}>[{level}] {info.message}<br/></span>;
+	let message = info.level === "server" && info.parsed ? formatParsedOutput(info.parsed) : info.message;
+	return <span key={key}>[{level}] {message}<br/></span>;
 }
 
 /**

--- a/packages/web_ui/src/components/LogConsole.tsx
+++ b/packages/web_ui/src/components/LogConsole.tsx
@@ -68,6 +68,24 @@ function formatLog(info: Info, key: number): ReactElement {
 	return <span key={key}>[{level}] {info.message}<br/></span>;
 }
 
+/**
+ * Test if a log entry survives the console's actions only filter
+ */
+function passesActionsOnly(info: Info) {
+	// Clusterio's own entries are bookkeeping, only keep those reporting a problem.
+	if (info.level !== "server") {
+		return lib.levels[info.level] <= lib.levels.warn;
+	}
+
+	// Factorio's seconds stamped engine log is verbose diagnostics, only keep warnings and errors.
+	if (info.parsed?.format === "seconds") {
+		return info.parsed.level === "Warning" || info.parsed.level === "Error";
+	}
+
+	// What is left is the date stamped console log: the actions done to the server and the replies to them.
+	return true;
+}
+
 type LogConsoleProps = {
 	all?: boolean;
 	controller?: boolean;
@@ -159,11 +177,7 @@ export default function LogConsole(props: LogConsoleProps) {
 				"desc",
 			)).then(result => {
 				setPastLines(result.log
-					.filter(info => (
-						!props.actionsOnly
-						|| (info as Info).level !== "server"
-						|| (info as Info).parsed?.type === "action"
-					))
+					.filter(info => !props.actionsOnly || passesActionsOnly(info as Info))
 					.map((info, index) => formatLog(info as Info, -index - 1))
 					.reverse()
 				);
@@ -175,7 +189,7 @@ export default function LogConsole(props: LogConsoleProps) {
 		}
 
 		function logHandler(info: Info) {
-			if (!props.actionsOnly || info.level !== "server" || info.parsed?.type === "action") {
+			if (!props.actionsOnly || passesActionsOnly(info)) {
 				setLines(currentLines => currentLines.concat(
 					[formatLog(info, currentLines.length)]
 				));

--- a/packages/web_ui/src/style.css
+++ b/packages/web_ui/src/style.css
@@ -257,6 +257,10 @@ body {
 	color: #ad3939;
 }
 
+.log-server {
+	font-weight: bold;
+}
+
 .log-fatal {
 	font-weight: bold;
 	background-color: #ad3939;


### PR DESCRIPTION
Closes #853.

Three separate commits, each can be dropped independently.

**Making the filter discoverable.** The control was a `Switch` with `checkedChildren="Chat"` / `unCheckedChildren="Log"`, which renders only the label of the mode you are already in. Defaulting to the filtered mode, it read as a button labelled "Chat" with nothing to suggest another mode existed. It is now a `Segmented` control listing both modes, so the one you are not in is always visible, with a tooltip describing what each covers. Per review the modes are named **Game** and **Instance** rather than Chat / Log.

**Not swallowing diagnostics.** The filter kept Factorio output only when it parsed as an action, which dropped the server's *replies* to those actions. The example in the issue — a typo'd `/command` echoing and then printing nothing — happens because `Cannot execute command. Error: ...` is a plain message, not an `[ACTION]` line. Factorio's own engine-level errors were dropped the same way, so e.g. a failed multiplayer connection left no trace in either mode.

Rather than special-casing command replies, the filter now selects by *where a line came from*. Factorio interleaves two streams on stdout: the date-stamped console log carrying what was done to the server and the replies to it, and the seconds-stamped engine log which is verbose diagnostic output. Game mode keeps the console log whole and takes only warnings and errors from the engine log. The same rule is applied to Clusterio's own entries, which were previously kept in full and drowned the Factorio output they were mixed with — those are now kept at `warn` or worse.

I replayed both the old and new predicates over a development cluster's full log history for one instance (5271 entries at the default max level). Game mode goes from 781 lines to 605: it loses 415 purely informational Clusterio entries, and gains the command replies plus engine errors like `0.911 Error ServerMultiplayerManager.cpp:743: Matching server connection failed` that were previously invisible in *both* modes.

**Labelling Factorio's output.** Also per review: the console rendered `server` level entries as bare parsed Factorio output while every other level was prefixed with its name, so nothing in a line distinguished what the game wrote from what Clusterio wrote about it. Those entries now carry the `[server]` prefix too, matching what `TerminalFormat` already does for the host and controller logs, styled with the same bold the terminal colourises the level with. This applies to every console using `LogConsole`, not just the instance one, which I read as the intent of "any server level log messages".

Two things I would still like your call on:

- **The default is unchanged.** The issue opens with "by default the console view for an instance filters out log messages that might be vital", and I have read that as being about the labelling and the over-filtering rather than a request to flip the default. Happy to flip it if that was the intent.
- **No test covers this.** `packages/web_ui` has no test directory, so `passesActionsOnly` is verified only by manual checking and the log replay above. It is a pure function and would be straightforward to test if you would like a web_ui test setup added — but that felt like a separate change.

### Changelog
```
### Changes
- Instance console filter is now a labelled Game/Instance control instead of a single-label toggle, and Factorio's output in the log consoles is prefixed with `[server]` like every other log level. #853

### Fixes
- Instance console no longer hides the Factorio server's replies to console commands, or Factorio's own errors, when filtering to game activity. #853
```
