### PR TITLE
Reload the web interface when the controller's plugins change

### DIFF
--- a/packages/web_ui/src/bootstrap.tsx
+++ b/packages/web_ui/src/bootstrap.tsx
@@ -11,6 +11,7 @@ import InputRole from "./components/InputRole";
 import InputModPack from "./components/InputModPack";
 import { InputTargetVersion, InputPartialVersion, InputFullVersion } from "./components/InputVersion";
 import { Control, ControlConnector } from "./util/websocket";
+import { fetchPluginSet, pluginSetFingerprint } from "./util/pluginSet";
 
 const { ConsoleTransport, WebConsoleFormat, logger } = lib;
 
@@ -29,16 +30,16 @@ async function loadScript(url: string) {
 	return result;
 }
 
-async function loadPluginInfos(): Promise<lib.PluginWebpackEnvInfo[]> {
-	let response = await fetch(`${webRoot}api/plugins`);
+async function loadPluginInfos(): Promise<[lib.PluginWebpackEnvInfo[], string]> {
 	let pluginList: lib.PluginWebApi[];
-	if (response.ok) {
-		pluginList = await response.json();
+	try {
+		pluginList = await fetchPluginSet();
 
-	} else {
-		logger.error("Failed to get plugin data, running without plugins");
+	} catch (err: any) {
+		logger.error(`Failed to get plugin data, running without plugins: ${err.message}`);
 		pluginList = [];
 	}
+	const fingerprint = pluginSetFingerprint(pluginList);
 
 	let pluginInfos: lib.PluginWebpackEnvInfo[] = [];
 	await __webpack_init_sharing__("default");
@@ -73,7 +74,7 @@ async function loadPluginInfos(): Promise<lib.PluginWebpackEnvInfo[]> {
 			}
 		}
 	}
-	return pluginInfos;
+	return [pluginInfos, fingerprint];
 }
 
 async function loadPlugins(pluginInfos: lib.PluginWebpackEnvInfo[], control: Control) {
@@ -132,13 +133,14 @@ export default async function bootstrap() {
 		level: "verbose",
 		format: new WebConsoleFormat(),
 	}));
-	let pluginInfos = await loadPluginInfos();
+	let [pluginInfos, pluginFingerprint] = await loadPluginInfos();
 	lib.registerPluginMessages(pluginInfos);
 	lib.addPluginConfigFields(pluginInfos);
 
 	let wsUrl = new URL(webRoot, document.location.href);
 	let controlConnector = new ControlConnector(wsUrl.href, 120);
 	let control = new Control(controlConnector, new Map(pluginInfos.map(p => [p.name, p])));
+	control.pluginFingerprint = pluginFingerprint;
 	control.plugins = await loadPlugins(pluginInfos, control);
 	control.inputComponents = inputComponentsFromPlugins(control.plugins);
 

--- a/packages/web_ui/src/bootstrap.tsx
+++ b/packages/web_ui/src/bootstrap.tsx
@@ -11,6 +11,7 @@ import InputRole from "./components/InputRole";
 import InputModPack from "./components/InputModPack";
 import { InputTargetVersion, InputPartialVersion, InputFullVersion } from "./components/InputVersion";
 import { Control, ControlConnector } from "./util/websocket";
+import { loadedPluginSetKey } from "./util/pluginSet";
 
 const { ConsoleTransport, WebConsoleFormat, logger } = lib;
 
@@ -29,7 +30,7 @@ async function loadScript(url: string) {
 	return result;
 }
 
-async function loadPluginInfos(): Promise<lib.PluginWebpackEnvInfo[]> {
+async function loadPluginInfos(): Promise<[lib.PluginWebpackEnvInfo[], string]> {
 	let response = await fetch(`${webRoot}api/plugins`);
 	let pluginList: lib.PluginWebApi[];
 	if (response.ok) {
@@ -39,6 +40,7 @@ async function loadPluginInfos(): Promise<lib.PluginWebpackEnvInfo[]> {
 		logger.error("Failed to get plugin data, running without plugins");
 		pluginList = [];
 	}
+	let pluginSetKey = loadedPluginSetKey(pluginList);
 
 	let pluginInfos: lib.PluginWebpackEnvInfo[] = [];
 	await __webpack_init_sharing__("default");
@@ -73,7 +75,7 @@ async function loadPluginInfos(): Promise<lib.PluginWebpackEnvInfo[]> {
 			}
 		}
 	}
-	return pluginInfos;
+	return [pluginInfos, pluginSetKey];
 }
 
 async function loadPlugins(pluginInfos: lib.PluginWebpackEnvInfo[], control: Control) {
@@ -132,13 +134,13 @@ export default async function bootstrap() {
 		level: "verbose",
 		format: new WebConsoleFormat(),
 	}));
-	let pluginInfos = await loadPluginInfos();
+	let [pluginInfos, pluginSetKey] = await loadPluginInfos();
 	lib.registerPluginMessages(pluginInfos);
 	lib.addPluginConfigFields(pluginInfos);
 
 	let wsUrl = new URL(webRoot, document.location.href);
 	let controlConnector = new ControlConnector(wsUrl.href, 120);
-	let control = new Control(controlConnector, new Map(pluginInfos.map(p => [p.name, p])));
+	let control = new Control(controlConnector, new Map(pluginInfos.map(p => [p.name, p])), pluginSetKey);
 	control.plugins = await loadPlugins(pluginInfos, control);
 	control.inputComponents = inputComponentsFromPlugins(control.plugins);
 

--- a/packages/web_ui/src/components/App.tsx
+++ b/packages/web_ui/src/components/App.tsx
@@ -9,8 +9,9 @@ import ErrorBoundary from "./ErrorBoundary";
 import SiteLayout from "./SiteLayout";
 import ControlContext from "./ControlContext";
 import LoginForm from "./LoginForm";
+import { fetchPluginSet, pluginSetFingerprint } from "../util/pluginSet";
 
-import { Card, ConfigProvider, Spin, Typography, theme } from "antd";
+import { Button, Card, ConfigProvider, Spin, Typography, theme } from "antd";
 
 const { Paragraph } = Typography;
 
@@ -28,11 +29,28 @@ function ErrorCard(props: ErrorProps) {
 }
 
 
+function PluginsChangedCard() {
+	return <div className="login-container">
+		<Card>
+			<h1>Reload required</h1>
+			<Paragraph>
+				The plugins the controller is running have changed since this page was opened. Plugin code,
+				messages and config fields are loaded once when the page starts and cannot be swapped out
+				while it runs, so this page is now out of step with the controller and has been stopped to
+				keep it from acting on plugins that are no longer there.
+			</Paragraph>
+			<Button type="primary" onClick={() => window.location.reload()}>Reload</Button>
+		</Card>
+	</div>;
+}
+
+
 type AppProps = {
 	control: Control;
 };
 export default function App(props: AppProps) {
 	let [connected, setConnected] = useState(false);
+	let [pluginsChanged, setPluginsChanged] = useState(false);
 	let [token, setToken] = useState(localStorage.getItem("controller_token") || null);
 	let connector = props.control.connector;
 
@@ -73,6 +91,29 @@ export default function App(props: AppProps) {
 		};
 	}, [token, props.control]);
 
+	// A controller that restarts to pick up a plugin being installed, enabled
+	// or disabled comes back serving a different set than this page loaded
+	// against, and entering recovery mode disables them all. The session does
+	// not survive that, so every new session is an opportunity to check.
+	useEffect(() => {
+		let cancelled = false;
+		function onConnect() {
+			fetchPluginSet().then(plugins => {
+				if (!cancelled && pluginSetFingerprint(plugins) !== props.control.pluginFingerprint) {
+					setPluginsChanged(true);
+				}
+			}).catch(err => {
+				logger.error(`Unable to check the controller's plugins:\n${err.stack}`);
+			});
+		}
+
+		connector.on("connect", onConnect);
+		return () => {
+			cancelled = true;
+			connector.off("connect", onConnect);
+		};
+	}, [props.control]);
+
 	useEffect(() => {
 		if (token && !connected) {
 			if (props.control.loggingOut) {
@@ -86,7 +127,10 @@ export default function App(props: AppProps) {
 	}, [token, connected]);
 
 	let page;
-	if (connected) {
+	if (pluginsChanged) {
+		page = <PluginsChangedCard />;
+
+	} else if (connected) {
 		page = <SiteLayout/>;
 
 	} else if (token) {

--- a/packages/web_ui/src/components/App.tsx
+++ b/packages/web_ui/src/components/App.tsx
@@ -9,8 +9,9 @@ import ErrorBoundary from "./ErrorBoundary";
 import SiteLayout from "./SiteLayout";
 import ControlContext from "./ControlContext";
 import LoginForm from "./LoginForm";
+import { pluginSetKey } from "../util/pluginSet";
 
-import { Card, ConfigProvider, Spin, Typography, theme } from "antd";
+import { Button, Card, ConfigProvider, Spin, Typography, theme } from "antd";
 
 const { Paragraph } = Typography;
 
@@ -28,11 +29,28 @@ function ErrorCard(props: ErrorProps) {
 }
 
 
+function PluginsChangedCard() {
+	return <div className="login-container">
+		<Card>
+			<h1>Reload required</h1>
+			<Paragraph>
+				The plugins the controller is running have changed since this page was opened. Plugin code,
+				messages and config fields are loaded once when the page starts and cannot be swapped out
+				while it runs, so this page has been stopped to keep it from acting on plugins that are no
+				longer there.
+			</Paragraph>
+			<Button type="primary" onClick={() => window.location.reload()}>Reload</Button>
+		</Card>
+	</div>;
+}
+
+
 type AppProps = {
 	control: Control;
 };
 export default function App(props: AppProps) {
 	let [connected, setConnected] = useState(false);
+	let [pluginsChanged, setPluginsChanged] = useState(false);
 	let [token, setToken] = useState(localStorage.getItem("controller_token") || null);
 	let connector = props.control.connector;
 
@@ -73,6 +91,22 @@ export default function App(props: AppProps) {
 		};
 	}, [token, props.control]);
 
+	// The controller reports the plugins it is running in the handshake it
+	// sends on every connection, so restarting it to install, enable or
+	// disable a plugin, or into recovery mode, is caught on reconnect.
+	useEffect(() => {
+		function onHello(data: any) {
+			if (pluginSetKey(data.plugins) !== props.control.pluginSetKey) {
+				setPluginsChanged(true);
+			}
+		}
+
+		connector.on("hello", onHello);
+		return () => {
+			connector.off("hello", onHello);
+		};
+	}, [props.control]);
+
 	useEffect(() => {
 		if (token && !connected) {
 			if (props.control.loggingOut) {
@@ -86,7 +120,10 @@ export default function App(props: AppProps) {
 	}, [token, connected]);
 
 	let page;
-	if (connected) {
+	if (pluginsChanged) {
+		page = <PluginsChangedCard />;
+
+	} else if (connected) {
 		page = <SiteLayout/>;
 
 	} else if (token) {

--- a/packages/web_ui/src/components/App.tsx
+++ b/packages/web_ui/src/components/App.tsx
@@ -34,10 +34,8 @@ function PluginsChangedCard() {
 		<Card>
 			<h1>Reload required</h1>
 			<Paragraph>
-				The plugins the controller is running have changed since this page was opened. Plugin code,
-				messages and config fields are loaded once when the page starts and cannot be swapped out
-				while it runs, so this page has been stopped to keep it from acting on plugins that are no
-				longer there.
+				The plugins the controller is running have changed since this page was opened.
+				So the page has been closed and must be reloaded to continue functioning as expected.
 			</Paragraph>
 			<Button type="primary" onClick={() => window.location.reload()}>Reload</Button>
 		</Card>
@@ -91,9 +89,8 @@ export default function App(props: AppProps) {
 		};
 	}, [token, props.control]);
 
-	// The controller reports the plugins it is running in the handshake it
-	// sends on every connection, so restarting it to install, enable or
-	// disable a plugin, or into recovery mode, is caught on reconnect.
+	// The controller reports the plugins it is running in the handshake
+	// This is used to detect when plugins change and a restart is required
 	useEffect(() => {
 		function onHello(data: any) {
 			if (pluginSetKey(data.plugins) !== props.control.pluginSetKey) {

--- a/packages/web_ui/src/components/PluginsPage.tsx
+++ b/packages/web_ui/src/components/PluginsPage.tsx
@@ -88,6 +88,14 @@ export default function PluginsPage() {
 						if (!plugin.meta.enabled) {
 							return <><InfoCircleFilled style={{ color: "#1668dc" }} /> Disabled on controller</>;
 						}
+						// Plugins are loaded once when the page starts, so one the
+						// controller has picked up since then was never attempted
+						// rather than attempted and failed. A plugin the controller
+						// cannot serve at all is excluded before it gets that far,
+						// and is a real error.
+						if (!plugin.meta.web.error && !control.pluginInfos.has(plugin.meta.name)) {
+							return <><InfoCircleFilled style={{ color: "#1668dc" }} /> Reload page to load</>;
+						}
 						if (!plugin.package) {
 							return <><CloseCircleFilled style={{ color: "#dc4446" }} /> Error loading module</>;
 						}

--- a/packages/web_ui/src/components/PluginsPage.tsx
+++ b/packages/web_ui/src/components/PluginsPage.tsx
@@ -88,11 +88,6 @@ export default function PluginsPage() {
 						if (!plugin.meta.enabled) {
 							return <><InfoCircleFilled style={{ color: "#1668dc" }} /> Disabled on controller</>;
 						}
-						// Plugins are loaded once when the page starts, so one the
-						// controller has picked up since then was never attempted
-						// rather than attempted and failed. A plugin the controller
-						// cannot serve at all is excluded before it gets that far,
-						// and is a real error.
 						if (!plugin.meta.web.error && !control.pluginInfos.has(plugin.meta.name)) {
 							return <><InfoCircleFilled style={{ color: "#1668dc" }} /> Reload page to load</>;
 						}
@@ -100,7 +95,7 @@ export default function PluginsPage() {
 							return <><CloseCircleFilled style={{ color: "#dc4446" }} /> Error loading module</>;
 						}
 						if (plugin.package.version !== plugin.meta.version) {
-							return "Version missmatched";
+							return <><CloseCircleFilled style={{ color: "#dc4446" }} /> Version mis-matched</>;
 						}
 						return plugin.package.version;
 					},

--- a/packages/web_ui/src/util/pluginSet.ts
+++ b/packages/web_ui/src/util/pluginSet.ts
@@ -1,0 +1,40 @@
+import type { PluginWebApi } from "@clusterio/lib";
+
+/**
+ * Fetch the set of plugins the controller is currently serving
+ *
+ * @returns plugin list as reported by the controller.
+ * @throws Error if the controller did not answer with a plugin list.
+ */
+export async function fetchPluginSet(): Promise<PluginWebApi[]> {
+	const response = await fetch(`${webRoot}api/plugins`);
+	if (!response.ok) {
+		throw new Error(`Plugin list request failed: ${response.status} ${response.statusText}`);
+	}
+	return await response.json();
+}
+
+/**
+ * Summarise a plugin set as a comparable value
+ *
+ * Produces a value that differs whenever the web interface would have
+ * loaded something else had it been started against this plugin set: a
+ * plugin appearing or disappearing, being enabled or disabled, or its
+ * code changing.  The entry point is included because it is content
+ * hashed, so it also covers a plugin being updated in place without its
+ * version changing.
+ *
+ * The web interface loads plugin code, registers their messages and adds
+ * their config fields once during startup and has no way to undo any of
+ * it, so a change here can only be resolved by reloading the page.
+ *
+ * @param plugins - plugin set to summarise.
+ * @returns value comparable with === against another summary.
+ */
+export function pluginSetFingerprint(plugins: PluginWebApi[]) {
+	return JSON.stringify(
+		plugins
+			.map(plugin => [plugin.name, plugin.version, plugin.enabled, plugin.web.main ?? null])
+			.sort((a, b) => String(a[0]).localeCompare(String(b[0])))
+	);
+}

--- a/packages/web_ui/src/util/pluginSet.ts
+++ b/packages/web_ui/src/util/pluginSet.ts
@@ -1,0 +1,26 @@
+import type { PluginWebApi } from "@clusterio/lib";
+
+/**
+ * Canonical key for a set of plugins loaded on the controller
+ *
+ * @param plugins - name to version mapping of loaded plugins.
+ * @returns value comparable with === against another key.
+ */
+export function pluginSetKey(plugins: Record<string, string>) {
+	return JSON.stringify(Object.entries(plugins).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+/**
+ * Canonical key for the plugins loaded when this page was started
+ *
+ * @param pluginList - plugin list as served by /api/plugins.
+ * @returns value comparable with === against a key from the handshake.
+ */
+export function loadedPluginSetKey(pluginList: PluginWebApi[]) {
+	// The handshake reports the plugins the controller is running, so
+	// compare against loaded rather than enabled, which also takes the
+	// config into account and only applies from the next restart.
+	return pluginSetKey(Object.fromEntries(
+		pluginList.filter(plugin => plugin.loaded).map(plugin => [plugin.name, plugin.version])
+	));
+}

--- a/packages/web_ui/src/util/pluginSet.ts
+++ b/packages/web_ui/src/util/pluginSet.ts
@@ -1,7 +1,8 @@
 import type { PluginWebApi } from "@clusterio/lib";
 
 /**
- * Canonical key for a set of plugins loaded on the controller
+ * Canonical key for a set of plugins loaded on the controller.
+ * It is assumed that all plugins provided are currently loaded.
  *
  * @param plugins - name to version mapping of loaded plugins.
  * @returns value comparable with === against another key.
@@ -17,9 +18,6 @@ export function pluginSetKey(plugins: Record<string, string>) {
  * @returns value comparable with === against a key from the handshake.
  */
 export function loadedPluginSetKey(pluginList: PluginWebApi[]) {
-	// The handshake reports the plugins the controller is running, so
-	// compare against loaded rather than enabled, which also takes the
-	// config into account and only applies from the next restart.
 	return pluginSetKey(Object.fromEntries(
 		pluginList.filter(plugin => plugin.loaded).map(plugin => [plugin.name, plugin.version])
 	));

--- a/packages/web_ui/src/util/websocket.ts
+++ b/packages/web_ui/src/util/websocket.ts
@@ -54,6 +54,12 @@ export class Control extends lib.Link {
 	/** Plugins loaded in the web interface */
 	public plugins = new Map<string, BaseWebPlugin>();
 	public inputComponents: Record<string, InputComponent> = {};
+	/**
+	 * Summary of the plugin set this interface was loaded against, see
+	 * pluginSetFingerprint.  Compared against the controller's current set
+	 * on reconnect to detect that a reload is needed.
+	 */
+	public pluginFingerprint: string = "";
 
 	/** Updates not handled by the subscription service */
 	accountUpdateHandlers: accountHandler[] = [];

--- a/packages/web_ui/src/util/websocket.ts
+++ b/packages/web_ui/src/util/websocket.ts
@@ -80,6 +80,8 @@ export class Control extends lib.Link {
 	constructor(
 		connector: ControlConnector,
 		public pluginInfos = new Map<string, lib.PluginWebpackEnvInfo>(),
+		/** Key of the plugin set this interface was loaded against */
+		public pluginSetKey = "",
 	) {
 		super(connector);
 


### PR DESCRIPTION
Closes #804. Closes #729.

The web interface loads plugin bundles, calls `registerPluginMessages` and `addPluginConfigFields` once in `bootstrap()`, and has no way to undo any of it. When the controller is restarted to pick up a plugin being installed, enabled or disabled, open pages reconnect to it and carry on as though the old set were still loaded, sending messages the controller no longer handles. Starting the controller in recovery mode has the same effect from the other direction: `Controller.ts` force-disables every plugin, and since only `registerHost` refuses connections in recovery mode, control connections are still accepted — so the browser connects happily to a controller running none of the plugins it loaded.

The controller already states the plugins it is running in the `hello` handshake, built from `controller.plugins` in `WsServer.handleConnection` and sent on every WebSocket connection. Hosts have used this for a long time — `Host` keeps it as `serverPlugins` and consults it to decide which events to forward and which instance plugins to load — and the web interface was the only client ignoring it. The first commit compares it against the set the page loaded, and on a mismatch stops rendering and asks to be reloaded rather than acting on plugins that are no longer there.

Since the handshake is sent on every connection, this does not rest on a session never surviving a controller restart, and it needs no protocol change, no new endpoint, and no extra request on reconnect.

The comparison is against `loaded` rather than `enabled`, taken from the `/api/plugins` response bootstrap already fetches. `enabled` is `loaded && config.get(load_plugin)`, so a `load_plugin` change that has not been restarted into yet would otherwise latch a mismatch the page could never clear.

A plugin rebuilt in place without its version changing is not covered here, since the handshake reports names and versions. That is the web asset fingerprint discussed in the thread below, which follows as a separate PR once this lands.

The second commit fixes #729, which is the same situation seen from the plugin list. That page reported "Error loading module" for anything without a loaded package, which includes a plugin the controller picked up after the page was opened — nothing had been attempted for it, so reporting a failure was wrong, and the remedy is a reload rather than an investigation. Note that a plugin the controller cannot serve at all is dropped during startup *before* it reaches the loaded plugin map, so absence from that map alone does not mean "new"; the web error is checked first and still reports as an error. The first commit makes that state hard to reach in practice, since the reload card intercepts it before the plugin list can be opened, but the label is wrong on its own terms and the check is three lines.

### Testing

Against a running dev cluster of 14 plugins, reading the plugin set off the handshake on each restart:

| Controller | plugins reported | reload card |
| --- | --- | --- |
| baseline | 14 | — |
| restarted, nothing changed | 14 | **no** card, reconnected silently |
| restarted into `--recovery` | 0 | card shown |
| Reload clicked | 14 | re-bootstraps to the normal UI |

The second row is the one that matters — without it the third would only be showing that any reconnect prompts a reload.

`packages/web_ui` still has no test directory, so this is covered by the runs above. The follow-up PR puts its fingerprint in `packages/controller`, where it is unit tested.

### Changelog
```
### Fixes
- Web interface now asks to be reloaded when the controller's plugins change, instead of continuing against plugins that are no longer loaded. #804
- Plugin list no longer reports a plugin added since the page was opened as having failed to load. #729
```
