### PR TITLE
Stop addressing subscription events to a request id

### DIFF
--- a/packages/lib/src/data/messages_core.ts
+++ b/packages/lib/src/data/messages_core.ts
@@ -115,6 +115,24 @@ export class Address {
 	}
 
 	/**
+	 * Returns this address with any request id removed
+	 *
+	 * A request id identifies one request in flight and is set on the
+	 * source address of a request so that its response can be matched back
+	 * up with it.  It is meaningless on anything else, so an address taken
+	 * from a request has to be stripped of it before it is used as the
+	 * destination of an event.
+	 *
+	 * @returns this address without a request id.
+	 */
+	withoutRequestId() {
+		if (this.requestId === undefined) {
+			return this;
+		}
+		return new Address(this.type, this.id);
+	}
+
+	/**
 	 * Returns true if this address targets the given destination
 	 * @param dst - Destination to check
 	 * @returns true if this address is addressed to the given destination

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -345,6 +345,9 @@ export class SubscriptionController {
 		}
 		const addressIndex = src.addressIndex();
 		const subscriber = eventData.subscriptions.get(addressIndex);
+		// src is the source of a request and carries its request id, which
+		// has no meaning on the events sent back to the subscriber.
+		const subscriberDst = src.withoutRequestId();
 		switch (request.action) {
 			case "unsubscribe":
 				if (!subscriber) {
@@ -358,7 +361,9 @@ export class SubscriptionController {
 
 			case "subscribe":
 				if (!subscriber) {
-					eventData.subscriptions.set(addressIndex, { link: link, dst: src, filters: request.filters });
+					eventData.subscriptions.set(
+						addressIndex, { link: link, dst: subscriberDst, filters: request.filters }
+					);
 				} else {
 					subscriber.filters.union(request.filters);
 				}
@@ -371,7 +376,9 @@ export class SubscriptionController {
 					}
 					eventData.subscriptions.delete(addressIndex);
 				} else if (!subscriber) {
-					eventData.subscriptions.set(addressIndex, { link: link, dst: src, filters: request.filters });
+					eventData.subscriptions.set(
+						addressIndex, { link: link, dst: subscriberDst, filters: request.filters }
+					);
 				} else {
 					subscriber.filters = request.filters;
 				}
@@ -384,7 +391,7 @@ export class SubscriptionController {
 		if (eventData.subscriptionUpdate) {
 			const eventReplay = await eventData.subscriptionUpdate(request, src, dst);
 			if (eventReplay) {
-				link.sendTo(src, eventReplay);
+				link.sendTo(subscriberDst, eventReplay);
 				return true;
 			}
 		}

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -238,7 +238,7 @@ export class SubscriptionRequest {
 
 type Subscriber = {
 	link: Link,
-	dst: Address,
+	address: Address,
 	filters: SubscriptionFilters,
 }
 
@@ -296,7 +296,7 @@ export class SubscriptionController {
 				continue;
 			}
 			if (subscriber.filters.intersects(broadcastFilters)) {
-				subscriber.link.sendTo(subscriber.dst, event);
+				subscriber.link.sendTo(subscriber.address, event);
 			}
 		}
 	}
@@ -343,11 +343,9 @@ export class SubscriptionController {
 		if (!eventData) {
 			throw new Error(`Event ${request.eventName} is not a registered as subscribable`);
 		}
-		const addressIndex = src.addressIndex();
-		const subscriber = eventData.subscriptions.get(addressIndex);
-		// src is the source of a request and carries its request id, which
-		// has no meaning on the events sent back to the subscriber.
-		const subscriberDst = src.withoutRequestId();
+		const index = src.addressIndex();
+		const address = src.withoutRequestId();
+		const subscriber = eventData.subscriptions.get(index);
 		switch (request.action) {
 			case "unsubscribe":
 				if (!subscriber) {
@@ -355,15 +353,13 @@ export class SubscriptionController {
 				}
 				subscriber.filters.subtract(request.filters);
 				if (subscriber.filters.isEmpty()) {
-					eventData.subscriptions.delete(addressIndex);
+					eventData.subscriptions.delete(index);
 				}
 				break;
 
 			case "subscribe":
 				if (!subscriber) {
-					eventData.subscriptions.set(
-						addressIndex, { link: link, dst: subscriberDst, filters: request.filters }
-					);
+					eventData.subscriptions.set(index, { link, address, filters: request.filters });
 				} else {
 					subscriber.filters.union(request.filters);
 				}
@@ -374,11 +370,9 @@ export class SubscriptionController {
 					if (!subscriber) {
 						return false;
 					}
-					eventData.subscriptions.delete(addressIndex);
+					eventData.subscriptions.delete(index);
 				} else if (!subscriber) {
-					eventData.subscriptions.set(
-						addressIndex, { link: link, dst: subscriberDst, filters: request.filters }
-					);
+					eventData.subscriptions.set(index, { link, address, filters: request.filters });
 				} else {
 					subscriber.filters = request.filters;
 				}
@@ -391,7 +385,7 @@ export class SubscriptionController {
 		if (eventData.subscriptionUpdate) {
 			const eventReplay = await eventData.subscriptionUpdate(request, src, dst);
 			if (eventReplay) {
-				link.sendTo(subscriberDst, eventReplay);
+				link.sendTo(address, eventReplay);
 				return true;
 			}
 		}

--- a/test/lib/data/messages_core.js
+++ b/test/lib/data/messages_core.js
@@ -16,6 +16,33 @@ describe("lib/data/messages_core", function() {
 		const instanceBr = new Address(Address.broadcast, Address.instance);
 		const controlBr = new Address(Address.broadcast, Address.control);
 
+		describe(".withoutRequestId()", () => {
+			it("returns the same instance when requestId is undefined", () => {
+				const address = new Address(1, 2);
+
+				assert.strictEqual(address.withoutRequestId(), address);
+			});
+
+			it("returns a new instance when requestId is present", () => {
+				const address = new Address(1, 2, 123);
+
+				const result = address.withoutRequestId();
+
+				assert.notStrictEqual(result, address);
+				assert.deepEqual(result, new Address(1, 2));
+			});
+
+			it("does not modify the original address", () => {
+				const address = new Address(1, 2, 123);
+
+				address.withoutRequestId();
+
+				assert.equal(address.type, 1);
+				assert.equal(address.id, 2);
+				assert.equal(address.requestId, 123);
+			});
+		});
+
 		it("Should correctly resolve addressedTo", function() {
 			assert(controller.addressedTo(controller));
 			assert(!controller.addressedTo(host1));

--- a/test/lib/subscriptions.test.js
+++ b/test/lib/subscriptions.test.js
@@ -520,6 +520,72 @@ describe("lib/subscriptions", function() {
 			});
 		});
 
+		describe("subscriber addressing", function() {
+			// A subscribe arrives as a request, so the source address it is
+			// handled with carries the request id used to route the response
+			// back to the caller. That id identifies one request in flight and
+			// means nothing on an event, see #847. These use a controller of
+			// their own because a subscription is only ever addressed when it
+			// is first created, and the shared one is already subscribed.
+			const connectorData = connectorSetupDate[0];
+
+			function requestSource(requestId) {
+				return new lib.Address(connectorData.dst.type, connectorData.dst.id, requestId);
+			}
+
+			function lastSentMessage() {
+				return getLink(connectorData.id).connector.sentMessages.at(-1);
+			}
+
+			it("should strip the request id from broadcast events", async function() {
+				const ownSubscriptions = new lib.SubscriptionController(mockController);
+				ownSubscriptions.handle(RegisteredEvent);
+				await ownSubscriptions.handleRequest(
+					getLink(connectorData.id),
+					new lib.SubscriptionRequest(RegisteredEvent.name, "subscribe"),
+					requestSource(213), connectorData.src
+				);
+
+				ownSubscriptions.broadcast(new RegisteredEvent());
+				await onceConnectorSend(connectorData.id);
+
+				assert.equal(lastSentMessage().name, RegisteredEvent.name);
+				assert.equal(lastSentMessage().dst.requestId, undefined, "event addressed to a request id");
+				assert.deepEqual(lastSentMessage().dst.toJSON(), connectorData.dst.toJSON());
+			});
+
+			it("should strip the request id from the replayed event", async function() {
+				const ownSubscriptions = new lib.SubscriptionController(mockController);
+				ownSubscriptions.handle(RegisteredEvent, async () => new RegisteredEvent());
+				await ownSubscriptions.handleRequest(
+					getLink(connectorData.id),
+					new lib.SubscriptionRequest(RegisteredEvent.name, "subscribe"),
+					requestSource(417), connectorData.src
+				);
+
+				assert.equal(lastSentMessage().name, RegisteredEvent.name);
+				assert.equal(lastSentMessage().dst.requestId, undefined, "replay addressed to a request id");
+				assert.deepEqual(lastSentMessage().dst.toJSON(), connectorData.dst.toJSON());
+			});
+
+			it("should strip the request id when replacing filters creates the subscription", async function() {
+				const ownSubscriptions = new lib.SubscriptionController(mockController);
+				ownSubscriptions.handle(RegisteredEvent);
+				await ownSubscriptions.handleRequest(
+					getLink(connectorData.id),
+					new lib.SubscriptionRequest(RegisteredEvent.name, "replace", 0, "foo"),
+					requestSource(918), connectorData.src
+				);
+
+				ownSubscriptions.broadcast(new RegisteredEvent(), "foo");
+				await onceConnectorSend(connectorData.id);
+
+				assert.equal(lastSentMessage().name, RegisteredEvent.name);
+				assert.equal(lastSentMessage().dst.requestId, undefined, "event addressed to a request id");
+				assert.deepEqual(lastSentMessage().dst.toJSON(), connectorData.dst.toJSON());
+			});
+		});
+
 		describe(".unsubscribeLink() / .unsubscribeAddress()", function() {
 			beforeEach(function() {
 				subscriptions.handle(RegisteredEvent);

--- a/test/lib/subscriptions.test.js
+++ b/test/lib/subscriptions.test.js
@@ -520,72 +520,6 @@ describe("lib/subscriptions", function() {
 			});
 		});
 
-		describe("subscriber addressing", function() {
-			// A subscribe arrives as a request, so the source address it is
-			// handled with carries the request id used to route the response
-			// back to the caller. That id identifies one request in flight and
-			// means nothing on an event, see #847. These use a controller of
-			// their own because a subscription is only ever addressed when it
-			// is first created, and the shared one is already subscribed.
-			const connectorData = connectorSetupDate[0];
-
-			function requestSource(requestId) {
-				return new lib.Address(connectorData.dst.type, connectorData.dst.id, requestId);
-			}
-
-			function lastSentMessage() {
-				return getLink(connectorData.id).connector.sentMessages.at(-1);
-			}
-
-			it("should strip the request id from broadcast events", async function() {
-				const ownSubscriptions = new lib.SubscriptionController(mockController);
-				ownSubscriptions.handle(RegisteredEvent);
-				await ownSubscriptions.handleRequest(
-					getLink(connectorData.id),
-					new lib.SubscriptionRequest(RegisteredEvent.name, "subscribe"),
-					requestSource(213), connectorData.src
-				);
-
-				ownSubscriptions.broadcast(new RegisteredEvent());
-				await onceConnectorSend(connectorData.id);
-
-				assert.equal(lastSentMessage().name, RegisteredEvent.name);
-				assert.equal(lastSentMessage().dst.requestId, undefined, "event addressed to a request id");
-				assert.deepEqual(lastSentMessage().dst.toJSON(), connectorData.dst.toJSON());
-			});
-
-			it("should strip the request id from the replayed event", async function() {
-				const ownSubscriptions = new lib.SubscriptionController(mockController);
-				ownSubscriptions.handle(RegisteredEvent, async () => new RegisteredEvent());
-				await ownSubscriptions.handleRequest(
-					getLink(connectorData.id),
-					new lib.SubscriptionRequest(RegisteredEvent.name, "subscribe"),
-					requestSource(417), connectorData.src
-				);
-
-				assert.equal(lastSentMessage().name, RegisteredEvent.name);
-				assert.equal(lastSentMessage().dst.requestId, undefined, "replay addressed to a request id");
-				assert.deepEqual(lastSentMessage().dst.toJSON(), connectorData.dst.toJSON());
-			});
-
-			it("should strip the request id when replacing filters creates the subscription", async function() {
-				const ownSubscriptions = new lib.SubscriptionController(mockController);
-				ownSubscriptions.handle(RegisteredEvent);
-				await ownSubscriptions.handleRequest(
-					getLink(connectorData.id),
-					new lib.SubscriptionRequest(RegisteredEvent.name, "replace", 0, "foo"),
-					requestSource(918), connectorData.src
-				);
-
-				ownSubscriptions.broadcast(new RegisteredEvent(), "foo");
-				await onceConnectorSend(connectorData.id);
-
-				assert.equal(lastSentMessage().name, RegisteredEvent.name);
-				assert.equal(lastSentMessage().dst.requestId, undefined, "event addressed to a request id");
-				assert.deepEqual(lastSentMessage().dst.toJSON(), connectorData.dst.toJSON());
-			});
-		});
-
 		describe(".unsubscribeLink() / .unsubscribeAddress()", function() {
 			beforeEach(function() {
 				subscriptions.handle(RegisteredEvent);
@@ -678,6 +612,71 @@ describe("lib/subscriptions", function() {
 				await assert.rejects(subscriptions.handleRequest(
 					getLink(0), request, connectorSetupDate[0].dst, connectorSetupDate[0].src
 				), /unreachable case: invalid action/);
+			});
+
+			describe("addressing", function() {
+				// A subscribe arrives as a request, so the source address it is
+				// handled with carries the request id which should not be persisted
+				const connectorData = connectorSetupDate[0];
+
+				function requestSource(requestId) {
+					return new lib.Address(connectorData.dst.type, connectorData.dst.id, requestId);
+				}
+
+				function lastSentMessage() {
+					return getLink(connectorData.id).connector.sentMessages.at(-1);
+				}
+
+				it("should strip the request id from broadcast events", async function() {
+					const ownSubscriptions = new lib.SubscriptionController(mockController);
+					ownSubscriptions.handle(RegisteredEvent);
+					await ownSubscriptions.handleRequest(
+						getLink(connectorData.id),
+						new lib.SubscriptionRequest(RegisteredEvent.name, "subscribe"),
+						requestSource(213), connectorData.src
+					);
+
+					ownSubscriptions.broadcast(new RegisteredEvent());
+					await onceConnectorSend(connectorData.id);
+
+					const message = lastSentMessage();
+					assert.equal(message.name, RegisteredEvent.name);
+					assert.equal(message.dst.requestId, undefined, "event addressed to a request id");
+					assert.deepEqual(message.dst.toJSON(), connectorData.dst.toJSON());
+				});
+
+				it("should strip the request id from the replayed event", async function() {
+					const ownSubscriptions = new lib.SubscriptionController(mockController);
+					ownSubscriptions.handle(RegisteredEvent, async () => new RegisteredEvent());
+					await ownSubscriptions.handleRequest(
+						getLink(connectorData.id),
+						new lib.SubscriptionRequest(RegisteredEvent.name, "subscribe"),
+						requestSource(417), connectorData.src
+					);
+
+					const message = lastSentMessage();
+					assert.equal(message.name, RegisteredEvent.name);
+					assert.equal(message.dst.requestId, undefined, "replay addressed to a request id");
+					assert.deepEqual(message.dst.toJSON(), connectorData.dst.toJSON());
+				});
+
+				it("should strip the request id when replacing filters creates the subscription", async function() {
+					const ownSubscriptions = new lib.SubscriptionController(mockController);
+					ownSubscriptions.handle(RegisteredEvent);
+					await ownSubscriptions.handleRequest(
+						getLink(connectorData.id),
+						new lib.SubscriptionRequest(RegisteredEvent.name, "replace", 0, "foo"),
+						requestSource(918), connectorData.src
+					);
+
+					ownSubscriptions.broadcast(new RegisteredEvent(), "foo");
+					await onceConnectorSend(connectorData.id);
+
+					const message = lastSentMessage();
+					assert.equal(message.name, RegisteredEvent.name);
+					assert.equal(message.dst.requestId, undefined, "event addressed to a request id");
+					assert.deepEqual(message.dst.toJSON(), connectorData.dst.toJSON());
+				});
 			});
 
 			describe("subscribe", function() {


### PR DESCRIPTION
Closes #847.

A subscribe arrives as a request, so the `src` address `SubscriptionController.handleRequest` is called with carries the request id used to route the response back to the caller. That address was stored verbatim as the subscription's destination:

```ts
eventData.subscriptions.set(addressIndex, { link, dst: src, filters: request.filters });
//                                               ^^^ keeps the request id forever
...
link.sendTo(src, eventReplay);   // the replay event goes to it too
```

So every event broadcast to that subscriber, and the replay event sent when the subscription is created, went out addressed to a request that had long since been answered — the `"dst":[3,3,213]` in your WS dump.

A request id identifies one request in flight and has no meaning on an event. `link.ts` keys response routing off it (`_forwardedRequests.delete(message.dst.requestIndex())` when a message is not addressed to the receiver), so events carrying one get put through paths meant for response traffic.

The fix strips the request id when taking the destination from the request that created the subscription, via a new `Address.withoutRequestId()` since the same stripped address is wanted in three places.

**One correction to your diagnosis:** you pointed at line 219, but `subscriptions.ts` was rewritten in the batch that landed with alpha.27 — the sites are now 361, 374 and 387.

**Good news on the blast radius:** the subscription map is keyed on `addressIndex()`, which is `` `${type}:${id}` `` and already excludes the request id. So resubscribing never created duplicate entries and no subscription state was corrupted; the only thing wrong was the address events were sent to.

### Testing

Three tests added under a new `subscriber addressing` block, covering the destination stored on `subscribe`, the destination stored when `replace` creates the subscription, and the replay event. Each asserts the sent message's `dst` has no `requestId` and equals the plain subscriber address.

They need their own `SubscriptionController`: a subscription is only addressed when it is first created, and the existing `.broadcast()` setup has already subscribed at the same `addressIndex`, so a request made against it takes the "subscriber already exists" branch that only updates filters. My first attempt at these tests passed against unfixed code for exactly that reason — worth knowing if you extend them.

Confirmed all three fail against unmodified `subscriptions.ts` and pass with the fix. Full `test/lib` and `test/messages` run clean at 1020 passing.

### Changelog
```
### Fixes
- Events sent to subscribers are no longer addressed to the request id of the request that created the subscription. #847
```
