### PR TITLE
Forget a forwarded request that could not be sent

### DIFF
--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -566,8 +566,18 @@ export class Link {
 			src: message.src,
 			dst: message.dst,
 		};
-		this._forwardedRequests.set(message.src.requestIndex(), pending);
-		this.connector.forward(message);
+		const requestIndex = message.src.requestIndex();
+		this._forwardedRequests.set(requestIndex, pending);
+		try {
+			this.connector.forward(message);
+		} catch (err) {
+			// The request never left, so nothing will answer it. Callers
+			// respond with the error themselves, and leaving it recorded here
+			// would have it answered a second time when pending requests are
+			// cleared.
+			this._forwardedRequests.delete(requestIndex);
+			throw err;
+		}
 	}
 
 	sendEvent<T>(event: Event<T>, dst: libData.Address) {

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -571,10 +571,7 @@ export class Link {
 		try {
 			this.connector.forward(message);
 		} catch (err) {
-			// The request never left, so nothing will answer it. Callers
-			// respond with the error themselves, and leaving it recorded here
-			// would have it answered a second time when pending requests are
-			// cleared.
+			// Clean up pending request as there will be no response
 			this._forwardedRequests.delete(requestIndex);
 			throw err;
 		}

--- a/test/lib/link/link.js
+++ b/test/lib/link/link.js
@@ -504,6 +504,48 @@ describe("lib/link/link", function() {
 			});
 		});
 
+		describe(".forwardRequest()", function() {
+			// A request is recorded so that its response can be sent back the
+			// way it came. If it never left there is nothing to send back, and
+			// leaving it recorded has it answered twice, see #650.
+			function forwardingSetup() {
+				const originConnector = new mock.MockConnector(dst, src);
+				const origin = new lib.Link(originConnector);
+				const nextHopConnector = new mock.MockConnector(src, dst);
+				const nextHop = new lib.Link(nextHopConnector);
+				const message = new lib.MessageRequest(1, src, dst, "SimpleRequest");
+				return { origin, originConnector, nextHop, nextHopConnector, message };
+			}
+
+			it("should record a request it forwarded", function() {
+				const { origin, nextHop, nextHopConnector, message } = forwardingSetup();
+				nextHop.forwardRequest(message, origin);
+				assert.equal(nextHop.pendingRequestCount, 1);
+				assert.equal(nextHopConnector.sentMessages.length, 1);
+			});
+
+			it("should not record a request it failed to forward", function() {
+				const { origin, nextHop, nextHopConnector, message } = forwardingSetup();
+				nextHopConnector.send = () => throwSimple("Session Closed");
+
+				assert.throws(() => nextHop.forwardRequest(message, origin), { message: "Session Closed" });
+				assert.equal(nextHop.pendingRequestCount, 0, "failed forward was left pending");
+			});
+
+			it("should not answer a request it failed to forward a second time", function() {
+				const { origin, originConnector, nextHop, nextHopConnector, message } = forwardingSetup();
+				nextHopConnector.send = () => throwSimple("Session Closed");
+
+				// Routers answer the origin themselves when forwarding throws.
+				assert.throws(() => nextHop.forwardRequest(message, origin), { message: "Session Closed" });
+				originConnector.sendResponseError(new lib.ResponseError("Session Closed"), message.src);
+				const answers = originConnector.sentMessages.length;
+
+				nextHop._clearPendingRequests(new lib.SessionLost("Session Lost"));
+				assert.equal(originConnector.sentMessages.length, answers, "request was answered twice");
+			});
+		});
+
 		describe(".snoopEvent()", function() {
 			it("should snoop an event", function() {
 				let handled = false;


### PR DESCRIPTION
Closes #650.

`forwardRequest` records a request so its response can be sent back the way it came, but recorded it *before* handing the message to the connector:

```ts
this._forwardedRequests.set(message.src.requestIndex(), pending);
this.connector.forward(message);   // throws when the session to the next hop is gone
```

When the forward throws the record stays behind for a request that never left. Routers answer the origin themselves in that case — `Host.sendMessage` catches and calls `sendResponseError` — so the request is already accounted for. The leftover record then has it answered a *second* time when `_clearPendingRequests` runs on disconnect, which is the duplicate response and the "Received response N without a pending request" warning described in the issue.

The fix removes the record when the forward throws. Doing it in `forwardRequest` rather than in the routers covers both callers: `Host.ts:226`, which catches and responds, and `ControllerRouter.ts:85`, which does not catch at all and would otherwise have no opportunity to clean up.

### This is happening in CI today

While looking at an unrelated failure I pulled the integration test log from a recent run on this repo, and it contains exactly the predicted signature:

```
controller: Error: Session Closed
controller: Error: No session
[error] Received response 5 without a pending request
[error] Received response 6 without a pending request
alt-host: TypeError: Cannot read properties of undefined (reading 'addressedTo')
```

So this is not only reproducible by the plugin recipe in the issue — it is firing during the integration tests whenever the controller is killed while a host has requests in flight.

### Testing

Three tests under a new `.forwardRequest()` block:

- a successful forward is still recorded and sent (control case, passes either way)
- a forward that throws leaves nothing pending
- a forward that throws is not answered a second time by `_clearPendingRequests`

Confirmed the two failure-path tests fail against the unmodified function and pass with the fix, while the control case passes in both. `test/lib`, `test/messages`, `test/controller` and `test/host.js` run clean at 1211 passing.

### Changelog
```
### Fixes
- Requests that could not be forwarded to the next hop are no longer answered a second time when the link disconnects. #650
```
