### PR TITLE
Silence the deprecation warning on install

### DIFF
--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -118,12 +118,15 @@ async function safeOutputFile(file, data, options={}) {
 }
 
 async function execFile(cmd, args) {
-	const escaped = args.map(escapeArg);
-	logger.verbose(`executing ${cmd} ${escaped.join(" ")}`);
+	// Arguments are escaped here and joined into the command rather than
+	// passed to execFile. With shell: true it would only concatenate them by
+	// space without escaping anything, which is what it is deprecated for
+	// (DEP0190) as it gives the impression the arguments are made safe.
+	const command = [cmd, ...args.map(escapeArg)].join(" ");
+	logger.verbose(`executing ${command}`);
 	return new Promise((resolve, reject) => {
 		let child = child_process.execFile(
-			cmd,
-			escaped,
+			command,
 			{
 				shell: true,
 

--- a/packages/create/create.js
+++ b/packages/create/create.js
@@ -118,10 +118,6 @@ async function safeOutputFile(file, data, options={}) {
 }
 
 async function execFile(cmd, args) {
-	// Arguments are escaped here and joined into the command rather than
-	// passed to execFile. With shell: true it would only concatenate them by
-	// space without escaping anything, which is what it is deprecated for
-	// (DEP0190) as it gives the impression the arguments are made safe.
 	const command = [cmd, ...args.map(escapeArg)].join(" ");
 	logger.verbose(`executing ${command}`);
 	return new Promise((resolve, reject) => {

--- a/test/create/escape_arg.js
+++ b/test/create/escape_arg.js
@@ -8,10 +8,12 @@ const { escapeArg } = require("../../packages/create/escape_arg");
 const execFile = util.promisify(child_process.execFile);
 
 async function exec(file, args) {
+	// Escape the arguments and join them into the command the same way
+	// create.js does, rather than passing them to execFile which would only
+	// concatenate them by space without escaping (DEP0190).
+	const command = [file, ...args.map(escapeArg)].join(" ");
 	const { stdout, stderr } = await execFile(
-		file,
-		args.map(escapeArg),
-
+		command,
 		{ shell: true, cwd: __dirname, env: { ...process.env, pct: "%"} }
 	);
 	return { stdout: JSON.parse(stdout), stderr };

--- a/test/create/escape_arg.js
+++ b/test/create/escape_arg.js
@@ -8,9 +8,6 @@ const { escapeArg } = require("../../packages/create/escape_arg");
 const execFile = util.promisify(child_process.execFile);
 
 async function exec(file, args) {
-	// Escape the arguments and join them into the command the same way
-	// create.js does, rather than passing them to execFile which would only
-	// concatenate them by space without escaping (DEP0190).
 	const command = [file, ...args.map(escapeArg)].join(" ");
 	const { stdout, stderr } = await execFile(
 		command,


### PR DESCRIPTION
Closes #851.

`create.js` called `execFile` with `shell: true` and an array of arguments, which Node deprecates in DEP0190 — with `shell: true` it concatenates the arguments by space without escaping anything, so passing an array gives the misleading impression they have been made safe. The warning was printed on every install.

As the issue notes, the arguments here are already escaped by `escapeArg`, so the fix is to join them into the command rather than hand them to `execFile` to concatenate. What actually gets run is unchanged.

I also pointed `test/create/escape_arg.js` at the same form. It was using the deprecated pattern too, which meant it emitted the warning itself and — more importantly — was no longer exercising the shape the installer uses.

### Testing

The escaping test round-trips several hundred adversarial strings (backslashes in every arrangement, embedded quotes, `%OS%`, `!OS!`, every control character below 128, emoji) through the shell and back, asserting they arrive intact. Those all still pass with the concatenated form, which is what confirms the escaping is unaffected rather than merely believed to be.

Before and after on the test suite itself:

```
BEFORE  (node:…) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true…
        2 passing
AFTER   2 passing
```

Separately verified in isolation that the two forms produce byte-identical output (`"hello a b\n"` for `echo hello "a b"`) and that only the old one warns.

Note I could not exercise the installer end to end here, so this rests on the escaping test plus the equivalence check above.

### Changelog
```
### Fixes
- Deprecation warning DEP0190 is no longer printed when installing. #851
```
