### PR TITLE
Deliver broadcasts to all hosts, not just the local one

### DIFF
--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -182,6 +182,12 @@ export class HostRouter {
 			if (this.host !== origin && (!plugin || this.host.serverPlugins.has(plugin))) {
 				this.host.connector.forward(message);
 			}
+		} else if (dst.id === lib.Address.host) {
+			// Sent up to the controller, which passes it on to the other
+			// hosts. Nothing left to do when it came from there.
+			if (this.host !== origin && (!plugin || this.host.serverPlugins.has(plugin))) {
+				this.host.connector.forward(message);
+			}
 		} else if (dst.id === lib.Address.control) {
 			if (this.host !== origin) {
 				if (!plugin || this.host.serverPlugins.has(plugin)) {

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -225,6 +225,16 @@ export class Link {
 			return;
 		}
 
+		// A broadcast is addressed to every link of the type it targets, so
+		// being addressed to this one does not mean it stops here.
+		if (
+			message.type === "event"
+			&& message.dst.type === libData.Address.broadcast
+			&& this.router
+		) {
+			this._routeMessage(message, entry);
+		}
+
 		if (message.type === "request") {
 			this._processRequest(
 				message as libData.MessageRequest,

--- a/test/integration/routing.js
+++ b/test/integration/routing.js
@@ -235,8 +235,6 @@ describe("Integration of link routing", function() {
 		};
 		for (const dstName of dsts[dst]) {
 			if (srcName === dstName) { continue; }
-			// TODO remove when broadcasting from instance to hosts is fixed, see #575
-			if (srcName === "instanceA1" && dstName === "hostB") { continue; }
 			let called;
 			handle(get(dstName), Event, async () => { called = true; });
 			const should = canReach(dstName);

--- a/test/lib/link/link.js
+++ b/test/lib/link/link.js
@@ -254,6 +254,42 @@ describe("lib/link/link", function() {
 			await assert.rejects(pending, { message: "Session Lost" });
 		});
 
+		describe("Broadcast handling", function() {
+			// A broadcast is addressed to every link of the type it targets,
+			// so a link it reaches has to pass it on as well as handle it,
+			// see #575.
+			function mockRouter(record) {
+				return { forwardMessage: () => { record.routed = true; return true; } };
+			}
+
+			it("should route a broadcast addressed to this link as well as handle it", function() {
+				const record = {};
+				let handled = false;
+				testLink.router = mockRouter(record);
+				testLink.handle(SimpleEvent, async () => { handled = true; });
+				testConnector.emit("message", new lib.MessageEvent(1, dst, addr("allControls"), "SimpleEvent"));
+				assert(record.routed, "broadcast was not routed onwards");
+				assert(handled, "broadcast was not handled locally");
+			});
+
+			it("should handle a broadcast on a link which does not route", function() {
+				// Instances have no router, so routing unconditionally would
+				// throw here and the event would never be handled.
+				let handled = false;
+				testLink.handle(SimpleEvent, async () => { handled = true; });
+				testConnector.emit("message", new lib.MessageEvent(1, dst, addr("allControls"), "SimpleEvent"));
+				assert(handled, "broadcast was not handled locally");
+			});
+
+			it("should not route a non broadcast addressed to this link", function() {
+				const record = {};
+				testLink.router = mockRouter(record);
+				testLink.handle(SimpleEvent, async () => {});
+				testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
+				assert(!record.routed, "message addressed to this link was routed onwards");
+			});
+		});
+
 		describe(".send()", function() {
 			it("should send request to the other side of the link", async function() {
 				let message = events.once(testConnector, "send");

--- a/test/lib/link/link.js
+++ b/test/lib/link/link.js
@@ -254,42 +254,6 @@ describe("lib/link/link", function() {
 			await assert.rejects(pending, { message: "Session Lost" });
 		});
 
-		describe("Broadcast handling", function() {
-			// A broadcast is addressed to every link of the type it targets,
-			// so a link it reaches has to pass it on as well as handle it,
-			// see #575.
-			function mockRouter(record) {
-				return { forwardMessage: () => { record.routed = true; return true; } };
-			}
-
-			it("should route a broadcast addressed to this link as well as handle it", function() {
-				const record = {};
-				let handled = false;
-				testLink.router = mockRouter(record);
-				testLink.handle(SimpleEvent, async () => { handled = true; });
-				testConnector.emit("message", new lib.MessageEvent(1, dst, addr("allControls"), "SimpleEvent"));
-				assert(record.routed, "broadcast was not routed onwards");
-				assert(handled, "broadcast was not handled locally");
-			});
-
-			it("should handle a broadcast on a link which does not route", function() {
-				// Instances have no router, so routing unconditionally would
-				// throw here and the event would never be handled.
-				let handled = false;
-				testLink.handle(SimpleEvent, async () => { handled = true; });
-				testConnector.emit("message", new lib.MessageEvent(1, dst, addr("allControls"), "SimpleEvent"));
-				assert(handled, "broadcast was not handled locally");
-			});
-
-			it("should not route a non broadcast addressed to this link", function() {
-				const record = {};
-				testLink.router = mockRouter(record);
-				testLink.handle(SimpleEvent, async () => {});
-				testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
-				assert(!record.routed, "message addressed to this link was routed onwards");
-			});
-		});
-
 		describe(".send()", function() {
 			it("should send request to the other side of the link", async function() {
 				let message = events.once(testConnector, "send");
@@ -522,6 +486,7 @@ describe("lib/link/link", function() {
 					{ message: "Unhandled message type invalid" }
 				);
 			});
+
 			it("should throw on Event failing validation", function() {
 				class StringEvent {
 					static type = "event";
@@ -537,6 +502,42 @@ describe("lib/link/link", function() {
 					() => testLink._processMessage(new lib.MessageEvent(1, dst, src, "StringEvent", 99)),
 					{ message: "Event StringEvent failed validation" }
 				);
+			});
+
+			describe("Broadcast handling", function() {
+				// A broadcast is addressed to every link of the type it targets,
+				// so a link it reaches has to pass it on as well as handle it,
+				// see #575.
+				function mockRouter(record) {
+					return { forwardMessage: () => { record.routed = true; return true; } };
+				}
+
+				it("should route a broadcast addressed to this link as well as handle it", function() {
+					const record = {};
+					let handled = false;
+					testLink.router = mockRouter(record);
+					testLink.handle(SimpleEvent, async () => { handled = true; });
+					testConnector.emit("message", new lib.MessageEvent(1, dst, addr("allControls"), "SimpleEvent"));
+					assert(record.routed, "broadcast was not routed onwards");
+					assert(handled, "broadcast was not handled locally");
+				});
+
+				it("should handle a broadcast on a link which does not route", function() {
+					// Instances have no router, so routing unconditionally would
+					// throw here and the event would never be handled.
+					let handled = false;
+					testLink.handle(SimpleEvent, async () => { handled = true; });
+					testConnector.emit("message", new lib.MessageEvent(1, dst, addr("allControls"), "SimpleEvent"));
+					assert(handled, "broadcast was not handled locally");
+				});
+
+				it("should not route a non broadcast addressed to this link", function() {
+					const record = {};
+					testLink.router = mockRouter(record);
+					testLink.handle(SimpleEvent, async () => {});
+					testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
+					assert(!record.routed, "message addressed to this link was routed onwards");
+				});
 			});
 		});
 


### PR DESCRIPTION
Closes #575.

The cause is not in the broadcast routing, which is where I first looked.

On the host side of an instance connection the connector's source is the *host's* address — `Host.ts` calls `VirtualConnector.makePair(instanceAddress, hostAddress)`, so the reverse connector handed to `InstanceConnection` has `src = hostAddress`. `"allHosts"` is `Address(broadcast, host)`, and `addressedTo` matches a broadcast against the receiver's address *type*, so the event counts as addressed to that link. `Link._processMessage` treats that as terminal: only messages **not** addressed to the link reach `_routeMessage`. The event was handled by the local host and never routed anywhere, which is exactly the reported symptom.

A broadcast is addressed to every link of the type it targets, so arriving at one of them does not mean it has arrived everywhere. The fix keeps routing a broadcast after handling it locally.

That is a change in the core link layer, so I checked every link before making it:

| Link | `connector.src` type | routes? | broadcast it matches |
| --- | --- | --- | --- |
| `Controller`, `BaseConnection` | controller | yes | **none** — no broadcast targets the controller |
| `Host` | host | yes | allHosts |
| `InstanceConnection` | host | yes | allHosts |
| `Instance` | instance | **no** | allInstances |
| `Control` (web UI / ctl) | control | **no** | allControls |

Guarding on the link having a router makes the behavioural delta exactly "allHosts broadcasts now also reach the host router", and nothing else. The guard is load bearing rather than defensive: `Instance` and `Control` have no router, so without it every `allInstances` and `allControls` broadcast they receive would hit the `if (!this.router)` throw in `_routeMessage` — and because routing happens before local handling, the event would not be handled either.

The host router then needs the `Address.host` case it was missing. It forwards to the controller, whose `broadcastMessage` already fans out to every host except the origin, and stops when the message came from the controller to begin with. So: instance → local host handles it and forwards up → controller → every other host handles it and stops. Terminates, and no host is served twice.

### Testing

The routing test matrix already covered this and had it explicitly excluded:

```js
// TODO remove when broadcasting from instance to hosts is fixed, see #575
if (srcName === "instanceA1" && dstName === "hostB") { continue; }
```

Removing those two lines is most of the verification. Against unmodified code the matrix fails with `hostB handler was not called from instanceA1`, in both the plain broadcast case and the plugin-filtering variant; with the fix the file is 30 passing. No other case in the matrix changed either way.

Three unit tests added in `test/lib/link/link.js` for the link layer change. I checked each fails for the right reason: dropping the `_processMessage` change fails "should route a broadcast addressed to this link as well as handle it", and dropping only the `this.router` guard fails "should handle a broadcast on a link which does not route" — the regression that would break instances.

`test/lib`, `test/messages`, `test/controller`, `test/host.js` and `test/integration/routing.js` run clean at 1238 passing.

### Changelog
```
### Fixes
- Events broadcast from an instance to all hosts are now delivered to every host instead of only the one running the instance. #575
```
