### PR TITLE
Add integration tests for the plugin system

### DIFF
--- a/test/file/test_plugin/control.js
+++ b/test/file/test_plugin/control.js
@@ -1,0 +1,26 @@
+"use strict";
+const { Command, CommandTree } = require("@clusterio/lib");
+const { BaseCtlPlugin } = require("@clusterio/ctl");
+
+const testPluginCommands = new CommandTree({
+	name: "test-plugin", description: "Test plugin commands",
+});
+testPluginCommands.add(new Command({
+	definition: ["echo <message>", "Print the message given to it", (yargs) => {
+		yargs.positional("message", { describe: "message to print", type: "string" });
+	}],
+	handler: async function(args, control) {
+		// eslint-disable-next-line no-console
+		console.log(args.message);
+	},
+}));
+
+class CtlPlugin extends BaseCtlPlugin {
+	async addCommands(rootCommand) {
+		rootCommand.add(testPluginCommands);
+	}
+}
+
+module.exports = {
+	CtlPlugin,
+};

--- a/test/file/test_plugin/controller.js
+++ b/test/file/test_plugin/controller.js
@@ -1,0 +1,21 @@
+"use strict";
+const { BaseControllerPlugin } = require("@clusterio/controller");
+
+const { ControllerEcho, HostEcho } = require("./messages");
+
+class ControllerPlugin extends BaseControllerPlugin {
+	async init() {
+		this.logger.info("test_plugin controller loaded");
+		this.controller.handle(ControllerEcho, this.handleControllerEcho.bind(this));
+	}
+
+	async handleControllerEcho(request) {
+		this.logger.info(`test_plugin controller echo ${request.text}`);
+		this.broadcastEventToHosts(new HostEcho(request.text));
+		return request.text;
+	}
+}
+
+module.exports = {
+	ControllerPlugin,
+};

--- a/test/file/test_plugin/host.js
+++ b/test/file/test_plugin/host.js
@@ -1,0 +1,26 @@
+"use strict";
+const { BaseHostPlugin } = require("@clusterio/host");
+
+const { HostEcho, HostEchoReceived } = require("./messages");
+
+class HostPlugin extends BaseHostPlugin {
+	async init() {
+		this.logger.info("test_plugin host loaded");
+		this.receivedEchoes = new Set();
+		this.host.handle(HostEcho, this.handleHostEcho.bind(this));
+		this.host.handle(HostEchoReceived, this.handleHostEchoReceived.bind(this));
+	}
+
+	async handleHostEcho(event) {
+		this.logger.info(`test_plugin host echo ${event.text}`);
+		this.receivedEchoes.add(event.text);
+	}
+
+	async handleHostEchoReceived(request) {
+		return this.receivedEchoes.has(request.text);
+	}
+}
+
+module.exports = {
+	HostPlugin,
+};

--- a/test/file/test_plugin/index.js
+++ b/test/file/test_plugin/index.js
@@ -1,0 +1,24 @@
+"use strict";
+// Plugin exercising the plugin system in the integration tests, see #342.
+// Written as plain JavaScript so that it does not need to be built.
+
+const { ControllerEcho, HostEcho, HostEchoReceived } = require("./messages");
+
+module.exports = {
+	plugin: {
+		name: "test_plugin",
+		title: "Test Plugin",
+		description: "Plugin used to test the plugin system.",
+
+		controllerEntrypoint: "controller",
+		hostEntrypoint: "host",
+		instanceEntrypoint: "instance",
+		ctlEntrypoint: "control",
+
+		messages: [
+			ControllerEcho,
+			HostEcho,
+			HostEchoReceived,
+		],
+	},
+};

--- a/test/file/test_plugin/instance.js
+++ b/test/file/test_plugin/instance.js
@@ -1,0 +1,12 @@
+"use strict";
+const { BaseInstancePlugin } = require("@clusterio/host");
+
+class InstancePlugin extends BaseInstancePlugin {
+	async init() {
+		this.logger.info("test_plugin instance loaded");
+	}
+}
+
+module.exports = {
+	InstancePlugin,
+};

--- a/test/file/test_plugin/messages.js
+++ b/test/file/test_plugin/messages.js
@@ -1,0 +1,63 @@
+"use strict";
+const { JsonBoolean, JsonString } = require("@clusterio/lib");
+
+// Sent from ctl to the controller, which answers with the text it was given
+// and broadcasts a HostEcho to the hosts.
+class ControllerEcho {
+	static type = "request";
+	static src = "control";
+	static dst = "controller";
+	static plugin = "test_plugin";
+	static permission = null;
+	static Response = JsonString;
+
+	constructor(text) {
+		this.text = text;
+	}
+
+	static jsonSchema = { type: "string" };
+	toJSON() { return this.text; }
+	static fromJSON(json) { return new this(json); }
+}
+
+// Broadcast from the controller to the hosts by broadcastEventToHosts.
+class HostEcho {
+	static type = "event";
+	static src = "controller";
+	static dst = "host";
+	static plugin = "test_plugin";
+	static permission = null;
+
+	constructor(text) {
+		this.text = text;
+	}
+
+	static jsonSchema = { type: "string" };
+	toJSON() { return this.text; }
+	static fromJSON(json) { return new this(json); }
+}
+
+// Sent from ctl to a host, which answers with whether it received the given
+// text via a HostEcho.
+class HostEchoReceived {
+	static type = "request";
+	static src = "control";
+	static dst = "host";
+	static plugin = "test_plugin";
+	static permission = null;
+	static Response = JsonBoolean;
+
+	constructor(text) {
+		this.text = text;
+	}
+
+	static jsonSchema = { type: "string" };
+	toJSON() { return this.text; }
+	static fromJSON(json) { return new this(json); }
+}
+
+module.exports = {
+	ControllerEcho,
+	HostEcho,
+	HostEchoReceived,
+};

--- a/test/file/test_plugin/package.json
+++ b/test/file/test_plugin/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "test_plugin",
+	"version": "0.0.1",
+	"description": "Plugin used to test the plugin system, see #342",
+	"private": true,
+	"main": "index.js",
+	"keywords": [
+		"clusterio-plugin"
+	]
+}

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -16,6 +16,7 @@ const {
 	spawnNode, instancesDir, factorioDir, databaseDir, controllerConfigPath,
 	requiresFactorio, hasFactorio,
 } = require("./index");
+const { ControllerEcho, HostEchoReceived } = require("../file/test_plugin/messages");
 
 
 /** @returns {Promise<Map<number, lib.InstanceDetails>>} */
@@ -383,6 +384,64 @@ describe("Integration of Clusterio", function() {
 					await stopAltHost(hostProcessB);
 				}
 			});
+		});
+	});
+
+	describe("plugin system", function() {
+		// Exercised with test/file/test_plugin, which is a plugin that exists
+		// only to be loaded by these tests, see #342.
+		async function pluginDetails(address) {
+			const plugins = await getControl().sendTo(address, new lib.PluginListRequest());
+			const details = plugins.find(plugin => plugin.name === "test_plugin");
+			assert(details, `test_plugin missing from the plugin list of ${JSON.stringify(address)}`);
+			return details;
+		}
+
+		it("should load the plugin on the controller", async function() {
+			const details = await pluginDetails("controller");
+			assert(details.enabled, "test_plugin is not enabled on the controller");
+			assert(details.loaded, "test_plugin is not loaded on the controller");
+		});
+
+		it("should load the plugin on the host", async function() {
+			const details = await pluginDetails({ hostId: 4 });
+			assert(details.enabled, "test_plugin is not enabled on the host");
+			assert(details.loaded, "test_plugin is not loaded on the host");
+		});
+
+		it("should report the plugin's title and version", async function() {
+			const details = await pluginDetails("controller");
+			assert.equal(details.title, "Test Plugin");
+			assert.equal(details.version, "0.0.1");
+		});
+
+		it("should add the plugin's command to clusterioctl", async function() {
+			const { stdout } = await execCtlProcess("test-plugin echo works");
+			assert(stdout.includes("works"), `plugin command did not print its message, got ${stdout}`);
+		});
+
+		it("should route a plugin request from control to the controller", async function() {
+			const response = await getControl().sendTo("controller", new ControllerEcho("to-controller"));
+			assert.equal(response, "to-controller");
+		});
+
+		it("should route a plugin request from control to a host", async function() {
+			const received = await getControl().sendTo({ hostId: 4 }, new HostEchoReceived("never-broadcast"));
+			assert.equal(received, false);
+		});
+
+		it("should deliver a plugin event sent with broadcastEventToHosts", async function() {
+			await getControl().sendTo("controller", new ControllerEcho("to-hosts"));
+
+			// The broadcast is sent without waiting for the hosts to receive it.
+			let received = false;
+			for (let attempt = 0; attempt < 100 && !received; attempt++) {
+				received = await getControl().sendTo({ hostId: 4 }, new HostEchoReceived("to-hosts"));
+				if (!received) {
+					await lib.wait(20);
+				}
+			}
+			assert(received, "host did not receive the event broadcast to it");
 		});
 	});
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -350,6 +350,7 @@ before(async function() {
 	await execController("config set controller.tls_private_key ../../test/file/tls/key.pem");
 
 	console.log("Setting Controller Plugins");
+	await execCtlProcess("plugin add ../../test/file/test_plugin");
 	await execCtlProcess("plugin add ../../plugins/global_chat");
 	await execCtlProcess("plugin add ../../plugins/research_sync");
 	await execCtlProcess("plugin add ../../plugins/statistics_exporter");


### PR DESCRIPTION
Part of #342, and a step towards #721. It does not close either, see below.

Nothing currently covers whether plugins load at all, or whether the messages they declare are routed. The integration tests only ever loaded the first party plugins, so what coverage exists comes incidentally from testing those — which is also the coupling #721 is about.

This adds a plugin under `test/file/test_plugin` that exists purely to be loaded by the tests. It is plain JavaScript rather than TypeScript so it needs no build step: the loader `require`s the entry point and reads the version from `package.json`, so nothing about it has to be compiled first.

Working through the checklist in #342, this covers:

- [x] Create a test plugin in test/files
- [x] Add it to be loaded in test/integration/index.js
- [x] Add a clusterioctl command to it and test that it's present
- [x] Add a control-controller request and test that it works
- [x] Add a controller-host event and test that `broadcastEventToHosts` works
- [x] Add a control-host request and test that it works
- [ ] Add a control-instance request and test it on a running instance
- [ ] Add a Lua module and check it is present with an rcon command
- [ ] Add a request producing log statements at controller, host and instance level and verify tagging

The last three all need a running instance. I left them out deliberately rather than submitting something I could not verify: the instance-dependent integration tests do not pass in my environment, so I would be guessing at whether those tests were correct. The plugin already declares an `instanceEntrypoint`, so the follow-up has somewhere to hang.

Worth noting the three tested message paths chain into one another rather than being independent: ctl sends `ControllerEcho` to the controller, the controller answers *and* calls `broadcastEventToHosts` with a `HostEcho`, and ctl then asks the host over `HostEchoReceived` whether it arrived. So the broadcast assertion fails if any link in that chain is broken, not just the broadcast itself.

### Testing

The 7 new tests pass. For regressions I compared full `test/integration/clusterio.js` runs before and after: 152 passing / 25 failing before, 159 passing / 25 failing after — exactly the 7 new tests, with the same pre-existing failures either side.

Those 25 are instance-dependent tests timing out in my environment and are unrelated to this change; they fail identically on an unmodified checkout. I mention the numbers because "all green" is not something I can honestly claim locally — the relevant fact is that the failure set is unchanged.

### On #721

This does not close it. Core CI still loads the first party plugins in `test/integration/index.js`. What it changes is that the plugin *system* no longer depends on them for coverage, which is the piece #721 would otherwise have to build first. Removing the first party plugins from core CI is a separate change, and one I would rather do with your view on where their tests should live.

### Changelog
None. Test only change.
