### PR TITLE
Filter server-specific tags from global chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Many thanks to the following for contributing to this release:
 
 ### Changes
 
+- Global chat now filters server-specific GPS, blueprint, train, and train-stop rich-text tags before relaying messages between instances. [#593](<https://github.com/clusterio/clusterio/issues/593>)
 - Reworked the site layout into a fixed sidebar with a top bar. [#924](<https://github.com/clusterio/clusterio/pull/924>)
 - The builtin "recycler" mod is now included correctly as builtin. [#925](<https://github.com/clusterio/clusterio/issues/925>)
 - Mod `info.json` versions (a mod's version and its `factorio_version`) are now parsed leniently, matching how the game reads them, instead of being validated against a fixed list of Factorio versions. [#941](<https://github.com/clusterio/clusterio/pull/941>)

--- a/plugins/global_chat/instance.ts
+++ b/plugins/global_chat/instance.ts
@@ -3,13 +3,13 @@ import { BaseInstancePlugin } from "@clusterio/host";
 import { ChatEvent } from "./messages";
 
 /**
- * Removes gps and train tags from messags
+ * Removes server-specific tags from messages.
  *
  * @param content - string to strip tags from.
  * @returns stripped string.
  */
 function removeTags(content: string): string {
-	return content.replace(/(\[gps=-?\d+,-?\d+\]|\[train=\d+\])/g, "");
+	return content.replace(/\[(?:gps|special-item|train|train-stop)=\S*?\]/gm, "");
 }
 
 export class InstancePlugin extends BaseInstancePlugin {

--- a/plugins/global_chat/test/plugin.js
+++ b/plugins/global_chat/test/plugin.js
@@ -15,10 +15,22 @@ describe("global_chat plugin", function() {
 			assert.equal(instance._removeTags("string"), "string");
 		});
 		it("should strip out gps tag", function() {
-			assert.equal(instance._removeTags("Look at [gps=12,-4]"), "Look at ");
+			assert.equal(instance._removeTags("Look at [gps=12,-4,nauvis]"), "Look at ");
+		});
+		it("should strip out special item tag", function() {
+			assert.equal(instance._removeTags("Blueprint [special-item=0eNqV...]"), "Blueprint ");
 		});
 		it("should strip out train tag", function() {
 			assert.equal(instance._removeTags("Train [train=1235]"), "Train ");
+		});
+		it("should strip out train stop tag", function() {
+			assert.equal(instance._removeTags("Stop [train-stop=42]"), "Stop ");
+		});
+		it("should preserve portable rich text tags", function() {
+			assert.equal(
+				instance._removeTags("[gps=12,-4][img=item.iron-plate] [item=iron-plate]"),
+				"[img=item.iron-plate] [item=iron-plate]",
+			);
 		});
 	});
 
@@ -37,6 +49,14 @@ describe("global_chat plugin", function() {
 				assert.deepEqual(
 					instancePlugin.instance.server.rconCommands,
 					["/sc game.print('[test] User: message')"],
+				);
+			});
+			it("should filter server-specific tags from received chat", async function() {
+				instancePlugin.instance.server.rconCommands = [];
+				await instancePlugin.handleChatEvent(new ChatEvent("test", "Train [train=1235]"));
+				assert.deepEqual(
+					instancePlugin.instance.server.rconCommands,
+					["/sc game.print('[test] Train ')"],
 				);
 			});
 		});


### PR DESCRIPTION
Filters rich-text tags whose targets are local to a Factorio server before global chat relays a message to another instance.

The matcher is limited to the four families identified in #593 (`gps`, `special-item`, `train`, and `train-stop`). It uses a non-greedy payload match so adjacent portable tags such as `img` and `item` remain intact.

Tests cover every requested tag family, adjacent portable tags, and the final sanitized RCON command.

Verification:

- `pnpm build`
- focused global-chat suite with normal plugin-message registration (10 passed)
- focused matcher suite without bootstrap (6 passed)
- `pnpm lint` (0 errors; 4 existing unused-disable warnings outside this change)
- `git diff --check`

`pnpm test` was also attempted. The suite builds successfully, then its integration bootstrap stops at `ENOENT: no such file or directory, scandir 'factorio'` because no local Factorio installation directory is available.

Closes #593.

### Changelog
```
### Changes
- Global chat now filters server-specific GPS, blueprint, train, and train-stop rich-text tags before relaying messages between instances. #593
```
