### PR TITLE
Allow disabling player online autosave slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Many thanks to the following for contributing to this release:
 
 ### Fixes
 
+- Allow player online autosave slots to be disabled while autosaves are enabled. [#966](<https://github.com/clusterio/clusterio/issues/966>)
 - Silenced two Ant Design console warnings in the Web UI: the deprecated Modal `destroyOnClose` prop, and a duplicate-value warning from the instance version selector. [#940](<https://github.com/clusterio/clusterio/pull/940>)
 - Surface the mod portal's own error when downloading mods for an unsupported Factorio version. [#941](<https://github.com/clusterio/clusterio/pull/941>)
 - Instances always create their config file on assignment preventing duplicate folder creation. [#945](<https://github.com/clusterio/clusterio/pull/945>)

--- a/packages/lib/src/config/definitions.ts
+++ b/packages/lib/src/config/definitions.ts
@@ -575,7 +575,7 @@ export class InstanceConfig extends classes.Config<InstanceConfigFields> {
 			validator: function(value, config) {
 				const factorioSettings = config.get("factorio.settings");
 				const autosaveSlots = factorioSettings.autosave_slots;
-				if (typeof autosaveSlots === "number" && value < autosaveSlots) {
+				if (value !== 0 && typeof autosaveSlots === "number" && value < autosaveSlots) {
 					throw new Error("Value cannot be less than the number of autosave slots");
 				}
 			},

--- a/test/lib/config/validators.test.js
+++ b/test/lib/config/validators.test.js
@@ -227,6 +227,15 @@ describe("lib/config/definitions/validators", function() {
 					/Value cannot be less than the number of autosave slots/
 				);
 			});
+			it("should allow disabling player online autosaves", function() {
+				const config = new InstanceConfig("controller", {
+					"factorio.settings": {
+						autosave_slots: 5,
+					},
+				});
+
+				assert.doesNotThrow(() => config.set("factorio.player_online_autosave_slots", 0));
+			});
 			it("should allow when autosave_slots is not a number", function() {
 				const config = new InstanceConfig("controller", {
 					"factorio.settings": {


### PR DESCRIPTION
Treat `0` as the documented disabled value before comparing player online autosave slots with the regular autosave pool size. Values between `1` and the regular pool size remain invalid.

Added a regression test for disabling the player online pool while regular autosaves are enabled.

Closes #966

### Testing

- `pnpm run build`
- targeted validator suite (`3 passing`)
- `pnpm run lint` (0 errors; 4 pre-existing warnings)
- local fast suite (`1520 passing`, `129 pending`; 12 Factorio integration failures because a full Factorio installation is not present locally)

### Changelog
```
### Fixes
- Allow player online autosave slots to be disabled while autosaves are enabled. #966
```