### PR TITLE
Download Factorio in host tests to temp/test instead of test/file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist/
 node_modules
 
 /factorio*
+/test/file/factorioDownload/
 /instances
 /mods
 /database

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ dist/
 node_modules
 
 /factorio*
-/test/file/factorioDownload/
 /instances
 /mods
 /database

--- a/test/host/server.js
+++ b/test/host/server.js
@@ -483,7 +483,7 @@ describe("host/server", function() {
 					this.skip();
 				}
 
-				server._factorioDir = path.join("test", "file", "factorioDownload");
+				server._factorioDir = path.join("temp", "test", "factorioDownload");
 				server._targetVersion = "latest";
 				global.fetch = _fetch;
 				await fs.rm(server._factorioDir, { force: true, recursive: true, maxRetries: 10 });


### PR DESCRIPTION
The live-API download test in `test/host/server.js` writes a full headless Factorio install (~140 MB) to `test/file/factorioDownload` and never removes it, so it shows up as untracked files after running the test suite. This moves the download to `temp/test/factorioDownload`, which is already gitignored and where the other tests keep their generated data.

### Changelog
None. Test only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
