### PR TITLE
Restore pagination on the instance save list

### DIFF
--- a/packages/web_ui/src/components/SavesList.tsx
+++ b/packages/web_ui/src/components/SavesList.tsx
@@ -206,7 +206,7 @@ export default function SavesList(props: { instance: lib.InstanceDetails }) {
 	let [starting, setStarting] = useState(false);
 	let [uploadingFiles, setUploadingFiles] = useState<File[]>([]);
 	const tableState = useTableQueryState<lib.SaveDetails>({
-		namespace: "save", defaultSortKey: "mtimeMs", defaultSortOrder: "descend",
+		namespace: "save", defaultSortKey: "mtimeMs", defaultSortOrder: "descend", pagination: { defaultPageSize: 10 },
 	});
 
 	let hostOffline = ["unassigned", "unknown"].includes(props.instance.status!);


### PR DESCRIPTION
Fixes #967

#930 switched `SavesList` to `useTableQueryState`, which returns `pagination: false` unless a pagination config is passed. `SavesList` did not pass one, so the saves table (which previously relied on antd's default 10-per-page pagination) rendered every save on a single page with no controls.

This passes `pagination: { defaultPageSize: 10 }` to the hook, restoring the previous behaviour and additionally persisting the current page/page size in the URL like the users table. The other tables converted in #930 all had `pagination={false}` before, so they are unaffected.

### Changelog
```
### Fixes
- Restored pagination on the instance save list. #967
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
