### PR TITLE
Handle create_character failures in inventory sync

### DIFF
--- a/plugins/inventory_sync/module/inventory_sync.lua
+++ b/plugins/inventory_sync/module/inventory_sync.lua
@@ -314,15 +314,20 @@ function inventory_sync.sync_player(acquire_response)
 end
 
 function inventory_sync.finish_download(player, finished_record)
+	local script_data = get_script_data()
+	script_data.finished_downloads[player.name] = nil
+	local player_record = script_data.players[player.name]
+
 	local status, result = xpcall(inventory_sync.deserialize_player, debug.traceback, player, finished_record)
 	if not status then
 		log("ERROR: Deserializing player " .. player.name .. " failed: " .. result)
 		player.print("ERROR: Deserializing player data failed: " .. result)
+		-- Treat this as a temporary inventory so the incomplete state is not uploaded over the synced data
+		player_record.dirty = true
+		player_record.sync = false
+		return
 	end
-	local script_data = get_script_data()
-	script_data.finished_downloads[player.name] = nil
 
-	local player_record = script_data.players[player.name]
 	player_record.dirty = true
 	player_record.sync = true
 	player_record.generation = finished_record.generation
@@ -380,6 +385,8 @@ inventory_sync.events[defines.events.on_pre_player_left_game] = function(event)
 	end
 
 	if not player_record.dirty or not player_record.sync then
+		-- Nothing to upload, release the acquisition so other instances are not blocked
+		clusterio_api.send_json("inventory_sync_release", { player_name = player.name })
 		return
 	end
 

--- a/plugins/inventory_sync/module/serialize.lua
+++ b/plugins/inventory_sync/module/serialize.lua
@@ -7,6 +7,8 @@ local serialize = {}
 local v2_logistic_api = compat.version_ge("2.0.0")
 local v2_storage_api = compat.version_ge("2.0.0")
 local v2_remote_controller = compat.version_ge("2.0.0")
+local v2_space_platform = compat.version_ge("2.0.0")
+local v2_exit_remote_view = compat.version_ge("2.0.56")
 local recipe_notifications_api = compat.version_ge("2.0.67")
 local v2_0_quick_bar_api = compat.version_ge("2.0.0")
 local v2_1_quick_bar_api = compat.version_ge("2.1.0")
@@ -666,6 +668,23 @@ function serialize.serialize_player(player, failed_deserialization)
 	return serialized
 end
 
+--- Find a surface characters can exist on, used when the player is on a space platform surface
+--- @param platform LuaSpacePlatform
+--- @return LuaSurface
+local function find_planet_surface(platform)
+	local location = platform.space_location
+	local planet = location and game.planets[location.name]
+	if planet and planet.surface then
+		return planet.surface
+	end
+	for _, surface in pairs(game.surfaces) do
+		if not surface.platform then
+			return surface
+		end
+	end
+	error("No surface found which can hold a character")
+end
+
 --- Ensure a player has a character, works from any controller type
 --- @param player LuaPlayer
 --- @return LuaEntity
@@ -676,13 +695,32 @@ local function ensure_character(player)
 		return character
 	end
 
+	-- Exit remote view before switching controllers, this can fail if the player is on a platform
+	if v2_exit_remote_view and player.controller_type == defines.controllers.remote then
+		player.exit_remote_view()
+	end
+
 	-- Switch to god controller if create_character would fail
 	if player.controller_type ~= defines.controllers.god then
 		player.set_controller{ type = defines.controllers.god }
 	end
 
+	-- Characters can not be created on platform surfaces, restore_position will move them back into the hub
+	local surface = player.surface
+	if v2_space_platform and surface.platform then
+		local planet_surface = find_planet_surface(surface.platform)
+		player.teleport(player.force.get_spawn_position(planet_surface), planet_surface)
+	end
+
 	-- Create and return the character
-	assert(player.create_character(), "Failed to create character")
+	if not player.create_character() then
+		error(string.format(
+			"Failed to create character (controller: %s, physical: %s, surface: %s, connected: %s, driving: %s)",
+			controller_to_name[player.controller_type],
+			v2_remote_controller and controller_to_name[player.physical_controller_type] or "n/a",
+			player.surface.name, tostring(player.connected), tostring(player.driving)
+		))
+	end
 	return player.character
 end
 


### PR DESCRIPTION
Follow-up to #912. `ensure_character` in `serialize.lua` asserted on `player.create_character()` returning `false` with no context, so the report gives us nothing to go on. This PR adds the context and hardens the two paths I think are the most likely cause. **I could not reproduce the original failure** (needs a connected client in the right state), so this is a best-effort fix for review rather than a confirmed one.

**Analysis of the report** (line numbers match `1af672aa` / alpha.25): the downloaded record had `controller = "character"`, the player was online 43 ticks after joining, had no character (destroyed by `initiate_inventory_download`), was switched to god, and the engine still refused `create_character()`. Being in remote view on the *source* server does not matter since only `physical_controller_type` is serialized. What does fit is the player's physical body on the *destination* being inside a space platform hub (or a rocket): such players are permanently in remote view (`exit_remote_view` "will fail if the player is in a rocket or in a platform"), the character in the hub gets destroyed on download start, and the god controller then sits on the platform surface where a character can not be created. `restore_position` already knows how to `enter_space_platform`, but that runs after `ensure_character`.

Changes:
- `ensure_character`: call `exit_remote_view()` (2.0.56+) explicitly instead of relying on `set_controller` side effects, teleport the god controller to the platform's planet surface (or the first non-platform surface) before `create_character`, and raise a descriptive error (controller, physical controller, surface, connected, driving) instead of a bare assert so the next report is actionable.
- `finish_download`: on deserialization failure set `sync = false, dirty = true` (same as the "Use temporary inventory" button) instead of `sync = true`. Previously the player was left in god mode with nothing deserialized but still marked as synced, so their next leave uploaded an empty god inventory over their real data — that is the actual damage in #912.
- `on_pre_player_left_game`: send `inventory_sync_release` when there is nothing to upload, otherwise a player in the temporary-inventory state stays acquired by this instance and shows as "busy" everywhere else until the instance stops. This also affects the existing abort-dialog path.

Not verified in game; would appreciate someone with a Space Age cluster testing the platform case (join a server where you left while physically on a platform).

### Changelog
```
### Fixes
- Inventory sync no longer uploads an empty inventory over the stored one after a failed download. #912
- Inventory sync now releases players who leave while using a temporary inventory, instead of showing them as busy until the instance stops. #975
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
