### PR TITLE
Support enemy_expansion.build_base_unit_dispatch_cooldown in exchange strings

### DIFF
--- a/packages/lib/src/factorio/exchange_string.ts
+++ b/packages/lib/src/factorio/exchange_string.ts
@@ -5,16 +5,12 @@ class MapReaderState {
 	last_position = { x: 0, y: 0 };
 	/** Version of Factorio the string was created with */
 	version = [0, 0, 0, 0];
-	/** True when a version greater than 2.0.0 is detected */
-	gt_v2_0 = false;
-	/** True when a version greater than 2.1.0 is detected */
-	gt_v2_1 = false;
 	constructor(
 		public buf: Buffer
 	) { }
 
 	/** True when the version is at least the given major.minor.patch */
-	atLeast(major: number, minor: number, patch = 0) {
+	versionAtLeast(major: number, minor: number, patch = 0) {
 		const [vMajor, vMinor, vPatch] = this.version;
 		if (vMajor !== major) { return vMajor > major; }
 		if (vMinor !== minor) { return vMinor > minor; }
@@ -173,7 +169,7 @@ function readBoundingBox(state: MapReaderState) {
 }
 
 function readCliffSettings(state: MapReaderState) {
-	return state.gt_v2_0 ? {
+	return state.versionAtLeast(2, 0) ? {
 		name: readString(state),
 		control: readString(state), // v2
 		cliff_elevation_0: readFloat(state),
@@ -198,7 +194,7 @@ function readTerritorySettings(state: MapReaderState) {
 }
 
 function readMapGenSettings(state: MapReaderState) {
-	return state.gt_v2_0 ? {
+	return state.versionAtLeast(2, 0) ? {
 		autoplace_controls: Object.fromEntries(readDict(state, readString, readFrequencySizeRichness)),
 		autoplace_settings: Object.fromEntries(readDict(state, readString, readAutoplaceSetting)),
 		default_enable_all_autoplace_controls: readBool(state),
@@ -274,7 +270,7 @@ function readEnemyEvolution(state: MapReaderState) {
 }
 
 function readEnemyExpansion(state: MapReaderState) {
-	return state.gt_v2_1 ? {
+	return state.versionAtLeast(2, 1) ? {
 		enabled: readOptional(state, readBool),
 		max_expansion_distance: readOptional(state, readUInt32),
 		min_expansion_distance: readOptional(state, readUInt32), // v2.1
@@ -290,7 +286,7 @@ function readEnemyExpansion(state: MapReaderState) {
 		evolution_group_size_factor: readOptional(state, readDouble), // v2.1
 		min_expansion_cooldown: readOptional(state, readUInt32),
 		max_expansion_cooldown: readOptional(state, readUInt32),
-		...state.atLeast(2, 1, 13) ? {
+		...state.versionAtLeast(2, 1, 13) ? {
 			build_base_unit_dispatch_cooldown: readOptional(state, readUInt32), // v2.1.13
 		} : {},
 	} : {
@@ -367,7 +363,7 @@ function readPathFinder(state: MapReaderState) {
 }
 
 function readDifficultySettings(state: MapReaderState) {
-	return state.gt_v2_0 ? {
+	return state.versionAtLeast(2, 0) ? {
 		technology_price_multiplier: readDouble(state),
 		spoil_time_modifier: readDouble(state), // v2
 	} : {
@@ -386,7 +382,7 @@ function readAsteroids(state: MapReaderState) {
 }
 
 function readMapSettings(state: MapReaderState) {
-	if (state.gt_v2_1) {
+	if (state.versionAtLeast(2, 1)) {
 		return {
 			pollution: readPollution(state),
 			// steering removed v2.1
@@ -398,7 +394,7 @@ function readMapSettings(state: MapReaderState) {
 			difficulty_settings: readDifficultySettings(state),
 			asteroids: readAsteroids(state), // v2
 		};
-	} else if (state.gt_v2_0) {
+	} else if (state.versionAtLeast(2, 0)) {
 		return {
 			pollution: readPollution(state),
 			steering: readSteering(state),
@@ -473,8 +469,6 @@ export function readMapExchangeString(exchangeString: string) {
 	try {
 		const version = readVersion(state);
 		state.version = version;
-		state.gt_v2_0 = state.atLeast(2, 0);
-		state.gt_v2_1 = state.atLeast(2, 1);
 		data = {
 			version: version,
 			unknown: readUInt8(state),

--- a/packages/lib/src/factorio/exchange_string.ts
+++ b/packages/lib/src/factorio/exchange_string.ts
@@ -3,14 +3,23 @@ import zlib from "zlib";
 class MapReaderState {
 	pos = 0;
 	last_position = { x: 0, y: 0 };
+	/** Version of Factorio the string was created with */
+	version = [0, 0, 0, 0];
 	/** True when a version greater than 2.0.0 is detected */
 	gt_v2_0 = false;
 	/** True when a version greater than 2.1.0 is detected */
 	gt_v2_1 = false;
-	// If more versions are required then we should expose version directly
 	constructor(
 		public buf: Buffer
 	) { }
+
+	/** True when the version is at least the given major.minor.patch */
+	atLeast(major: number, minor: number, patch = 0) {
+		const [vMajor, vMinor, vPatch] = this.version;
+		if (vMajor !== major) { return vMajor > major; }
+		if (vMinor !== minor) { return vMinor > minor; }
+		return vPatch >= patch;
+	}
 }
 
 function readUInt8(state: MapReaderState) {
@@ -281,6 +290,9 @@ function readEnemyExpansion(state: MapReaderState) {
 		evolution_group_size_factor: readOptional(state, readDouble), // v2.1
 		min_expansion_cooldown: readOptional(state, readUInt32),
 		max_expansion_cooldown: readOptional(state, readUInt32),
+		...state.atLeast(2, 1, 13) ? {
+			build_base_unit_dispatch_cooldown: readOptional(state, readUInt32), // v2.1.13
+		} : {},
 	} : {
 		enabled: readOptional(state, readBool),
 		max_expansion_distance: readOptional(state, readUInt32),
@@ -460,8 +472,9 @@ export function readMapExchangeString(exchangeString: string) {
 
 	try {
 		const version = readVersion(state);
-		state.gt_v2_0 = version[0] >= 2;
-		state.gt_v2_1 = version[0] >= 2 && version[1] >= 1;
+		state.version = version;
+		state.gt_v2_0 = state.atLeast(2, 0);
+		state.gt_v2_1 = state.atLeast(2, 1);
 		data = {
 			version: version,
 			unknown: readUInt8(state),

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -1208,10 +1208,14 @@ describe("Integration of Clusterio", function() {
 
 				await execCtl("instance start 44");
 				const instance = (await getInstances()).get(44);
-				const isV2 = lib.integerPartialVersion(instance.factorioVersion) > lib.integerPartialVersion("2.0");
-				const isV2_1 = lib.integerPartialVersion(instance.factorioVersion) > lib.integerPartialVersion("2.1");
+				const version = lib.integerPartialVersion(instance.factorioVersion);
+				const isV2 = version > lib.integerPartialVersion("2.0");
+				const isV2_1 = version > lib.integerPartialVersion("2.1");
+				const isV2_1_13 = version >= lib.integerPartialVersion("2.1.13");
 				let exchangeString = testStrings.modified;
-				if (isV2_1) {
+				if (isV2_1_13) {
+					exchangeString = testStrings.modified_v2_1_13;
+				} else if (isV2_1) {
 					exchangeString = testStrings.modified_v2_1;
 				} else if (isV2) {
 					exchangeString = testStrings.modified_v2;

--- a/test/lib/factorio/exchange_string.js
+++ b/test/lib/factorio/exchange_string.js
@@ -69,6 +69,16 @@ describe("lib/factorio/exchange_string", function() {
 			});
 		});
 
+		it("should parse post v2.1.13 strings", function() {
+			assert.deepEqual(lib.readMapExchangeString(testStrings.modified_v2_1_13), {
+				version: [2, 1, 14, 1],
+				unknown: 0,
+				map_gen_settings: testSettings.modified_v2_1_map_gen_settings,
+				map_settings: testSettings.modified_v2_1_13_map_settings,
+				checksum: 272054359,
+			});
+		});
+
 		it("should handle malformed strings", function() {
 			assert.throws(
 				() => lib.readMapExchangeString("<<blah>>"),

--- a/test/lib/factorio/test_settings.js
+++ b/test/lib/factorio/test_settings.js
@@ -615,6 +615,14 @@ const modified_v2_1_map_settings = {
 	},
 };
 
+const modified_v2_1_13_map_settings = {
+	...modified_v2_1_map_settings,
+	"enemy_expansion": {
+		...modified_v2_1_map_settings.enemy_expansion,
+		"build_base_unit_dispatch_cooldown": 1234,
+	},
+};
+
 const modified_space_age_map_gen_settings = {
 	autoplace_controls: {
 		"aquilo_crude_oil": { frequency: 1, size: 1, richness: 1 },
@@ -703,5 +711,6 @@ module.exports = {
 	modified_v2_map_settings,
 	modified_v2_1_map_gen_settings,
 	modified_v2_1_map_settings,
+	modified_v2_1_13_map_settings,
 	modified_space_age_map_gen_settings,
 };

--- a/test/lib/factorio/test_strings.js
+++ b/test/lib/factorio/test_strings.js
@@ -86,10 +86,27 @@ Gx0+5gy4RUpPimXd3JJg0hSVAZVaD42oXlGs+OdLeL8NIjXUO043NJp
 38bydxUydeQi4j66kCmzxzUMyYTVaPneF1Uj+vlxQH+ZT82gl0Du2he
 Y+lJ/JEpK/WZNmBM/mgXgnKlfCACLzljjH+s/hYo=<<<`;
 
+const modified_v2_1_13 = `
+>>>eNp1U89rE0EUftMmNYm15hAFRWoOPYiQEKKgFMmOXsSDB0HwJHGy
+mejSzU47u1utHszBgwdBkF70olcrehHvAS/2JvUfqNSDvbVSpAehzsv
+sTNYEH7zHt9/7/YadAAIzSmE64wrmA/QcowVXLC5yWRGSA4Cl866M27
+wiPD/F0gIPeHel0mIhBlOA/sCV86QIdIW+rTAdsHjZC5uu73U66Y5ZK
+dyFMM0cDyMmIy+422SSs2ZXeGEUY7VUUhiJIGmaMJHkPHy3tuYobSBz
+OJYs8OKunqSHvI68zyIucQ8TCeTjr9vrvSezgHrwGMoHB6gKbao4VCA
+9HU0UmUi26IogksKfZ/GD+ZbHwnylVq3XUI6lXR3Jl2IeuCu5erX2r9
+ssN5J+csw/rFGrnhtInvt8mUWeCI5a1PTZAg+zyZGhfFnpFXs4Qsij0
+oer3x+uOkSvUKUJ2E+Yfssw1xLw4j39nytjXHDegB1HNdm9t/X00/5e
+g/x5u7txvXXHITd/FJfCs9sN5TyCx5xEM2WRzt00U+XoKKPAq5co2w7
+JYkZpmFakZGd1AkjtxhSQjYziizPKvHmmTPmUDWuYoiVKOgP57RB9yS
+0Dvo1NMEfJJWw1i+YLmuywM1C1jwbPKaGnjffEMETl1yE9Qxu/9C7rp
+u3nVP+RQebGLpzeY4SxwbkUKGDDtjU/J9P3/nrIfNHXdPAWgFF7JHkZ
+0L+YLmXPjcc3XoAz1D69BVjk1sULxb83nuUA<<<`;
+
 module.exports = {
 	default: default_,
 	modified,
 	modified_v2,
 	modified_v2_1,
+	modified_v2_1_13,
 	modified_space_age,
 };


### PR DESCRIPTION
Factorio 2.1.13 added `build_base_unit_dispatch_cooldown` to `enemy_expansion` in the map exchange string, and rejects map settings JSON that lacks the key. This made `readMapExchangeString` fail with "data after end" on 2.1.13+ strings and broke `instance load-scenario --map-exchange-string` on current Factorio (the `load-scenario` integration test failed on 2.1.14 with `Key "build_base_unit_dispatch_cooldown" not found in property tree at ROOT.enemy_expansion`).

To pin down position, type and version I generated real exchange strings from headless 2.1.7, 2.1.8, 2.1.12, 2.1.13 and 2.1.14 (created a map from the existing modified 2.1 settings and read `game.get_map_exchange_string()` over RCON) and diffed the inflated buffers using a distinctive value. The new field is an optional `uint32` that comes directly after `max_expansion_cooldown`, i.e. the last field of `enemy_expansion`; everything after it realigns exactly. It is present in 2.1.13 (which also rejects settings without the key) and absent in 2.1.12, so the reader gates it on `>= 2.1.13`.

The reader state now keeps the full version with an `atLeast(major, minor, patch)` helper, replacing the TODO comment about exposing the version once finer gating was needed; `gt_v2_0`/`gt_v2_1` are derived from it. Adds a `modified_v2_1_13` fixture string generated with 2.1.14 (same settings as `modified_v2_1` plus `build_base_unit_dispatch_cooldown: 1234`), a unit test asserting the full decoded output, and makes the `load-scenario` integration test use the new string on 2.1.13+.

Verified the decoded JSON matches the existing modified 2.1 settings apart from the new key on 2.1.13/2.1.14 while older strings decode unchanged, and the `load-scenario` and `instance kill` integration tests pass again on 2.1.14.

### Changelog
```
### Fixes
- Fixed reading map exchange strings from Factorio 2.1.13 and later, which broke `instance load-scenario --map-exchange-string` on current Factorio. #977
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
