### PR TITLE
Sync shortcut toggles and game view settings in inventory_sync

### DIFF
--- a/plugins/inventory_sync/messages.ts
+++ b/plugins/inventory_sync/messages.ts
@@ -13,6 +13,7 @@ export type IpcPlayerData = {
 	cheat_mode: boolean,
 	flashlight: boolean,
 	shortcuts?: Record<string, boolean>,
+	game_view_settings?: Record<string, boolean>,
 	ticks_to_respawn?: number,
 	character?: any,
 	inventories?: any,

--- a/plugins/inventory_sync/messages.ts
+++ b/plugins/inventory_sync/messages.ts
@@ -12,6 +12,7 @@ export type IpcPlayerData = {
 	force: string,
 	cheat_mode: boolean,
 	flashlight: boolean,
+	shortcuts?: Record<string, boolean>,
 	ticks_to_respawn?: number,
 	character?: any,
 	inventories?: any,

--- a/plugins/inventory_sync/module/define_game_view_settings.lua
+++ b/plugins/inventory_sync/module/define_game_view_settings.lua
@@ -1,0 +1,30 @@
+local compat = require("modules/clusterio/compat")
+
+local keys = {
+	"show_alert_gui",
+	"show_controller_gui",
+	"show_crafting_queue",
+	"show_entity_info",
+	"show_entity_tooltip",
+	"show_hotkey_suggestions",
+	"show_map_view_options",
+	"show_minimap",
+	"show_quickbar",
+	"show_rail_block_visualisation",
+	"show_research_info",
+	"show_shortcut_bar",
+	"show_side_menu",
+	"show_tool_bar",
+	"update_entity_selection",
+}
+
+if compat.version_ge("2.0.22") then
+	keys[#keys + 1] = "show_surface_list"
+end
+
+if compat.version_ge("2.1.7") then
+	keys[#keys + 1] = "hide_tall_entities"
+	keys[#keys + 1] = "show_pins_gui"
+end
+
+return keys

--- a/plugins/inventory_sync/module/define_player_stat_keys.lua
+++ b/plugins/inventory_sync/module/define_player_stat_keys.lua
@@ -15,6 +15,7 @@ local keys = {
 	"character_trash_slot_count_bonus",
 	"character_maximum_following_robot_count_bonus",
 	"character_health_bonus",
+	"allow_dispatching_robots",
 }
 
 if compat.version_le("1.1.110") then

--- a/plugins/inventory_sync/module/serialize.lua
+++ b/plugins/inventory_sync/module/serialize.lua
@@ -602,19 +602,12 @@ end
 --- @field crafting_queue table?
 --- @field recipe_notifications string?
 
---- Toggle shortcuts whose state is stored on the player and not covered by any other synced data
-local synced_shortcuts = {
-	"toggle-personal-roboport",
-	"toggle-equipment-movement-bonus",
-}
-
 --- @param player LuaPlayer
 --- @return table<string, boolean>
 function serialize.serialize_shortcuts(player)
-	local shortcut_prototypes = compat.prototypes.shortcut
 	local shortcuts = {}
-	for _, name in ipairs(synced_shortcuts) do
-		if shortcut_prototypes[name] then
+	for name, prototype in pairs(compat.prototypes.shortcut) do
+		if prototype.toggleable then
 			shortcuts[name] = player.is_shortcut_toggled(name)
 		end
 	end
@@ -626,7 +619,8 @@ end
 function serialize.deserialize_shortcuts(player, serialized)
 	local shortcut_prototypes = compat.prototypes.shortcut
 	for name, toggled in pairs(serialized) do
-		if shortcut_prototypes[name] then
+		local prototype = shortcut_prototypes[name]
+		if prototype and prototype.toggleable then
 			player.set_shortcut_toggled(name, toggled)
 		end
 	end

--- a/plugins/inventory_sync/module/serialize.lua
+++ b/plugins/inventory_sync/module/serialize.lua
@@ -592,6 +592,7 @@ end
 --- @field force string
 --- @field cheat_mode boolean
 --- @field flashlight boolean
+--- @field shortcuts table<string, boolean>?
 --- @field ticks_to_respawn number
 --- @field character table<string, any>?
 --- @field inventories table<string, table>?
@@ -600,6 +601,36 @@ end
 --- @field personal_logistic_slots table?
 --- @field crafting_queue table?
 --- @field recipe_notifications string?
+
+--- Toggle shortcuts whose state is stored on the player and not covered by any other synced data
+local synced_shortcuts = {
+	"toggle-personal-roboport",
+	"toggle-equipment-movement-bonus",
+}
+
+--- @param player LuaPlayer
+--- @return table<string, boolean>
+function serialize.serialize_shortcuts(player)
+	local shortcut_prototypes = compat.prototypes.shortcut
+	local shortcuts = {}
+	for _, name in ipairs(synced_shortcuts) do
+		if shortcut_prototypes[name] then
+			shortcuts[name] = player.is_shortcut_toggled(name)
+		end
+	end
+	return shortcuts
+end
+
+--- @param player LuaPlayer
+--- @param serialized table<string, boolean>
+function serialize.deserialize_shortcuts(player, serialized)
+	local shortcut_prototypes = compat.prototypes.shortcut
+	for name, toggled in pairs(serialized) do
+		if shortcut_prototypes[name] then
+			player.set_shortcut_toggled(name, toggled)
+		end
+	end
+end
 
 --- @param player LuaPlayer
 --- @param failed_deserialization FailedDeserializationPlayerData
@@ -616,6 +647,7 @@ function serialize.serialize_player(player, failed_deserialization)
 		force = player.force.name,
 		cheat_mode = player.cheat_mode,
 		flashlight = player.is_flashlight_enabled(),
+		shortcuts = serialize.serialize_shortcuts(player),
 		ticks_to_respawn = player.ticks_to_respawn,
 	}
 
@@ -789,6 +821,9 @@ function serialize.deserialize_player(player, serialized)
 		player.enable_flashlight()
 	else
 		player.disable_flashlight()
+	end
+	if serialized.shortcuts then
+		serialize.deserialize_shortcuts(player, serialized.shortcuts)
 	end
 
 	-- Deserialize character

--- a/plugins/inventory_sync/module/serialize.lua
+++ b/plugins/inventory_sync/module/serialize.lua
@@ -2,6 +2,7 @@ local compat = require("modules/clusterio/compat")
 local clusterio_serialize = require("modules/clusterio/serialize")
 local character_inventories = require("modules/inventory_sync/define_player_inventories")
 local character_stat_keys = require("modules/inventory_sync/define_player_stat_keys")
+local game_view_settings_keys = require("modules/inventory_sync/define_game_view_settings")
 local serialize = {}
 
 local v2_logistic_api = compat.version_ge("2.0.0")
@@ -52,6 +53,8 @@ end
 --   character_maximum_following_robot_count_bonus
 --   character_health_bonus
 --   character_personal_logistic_requests_enabled
+--   allow_dispatching_robots
+--   inhibit_movement_bonus (optional, from the armor equipment grid)
 --   inventories: table of character inventory name to inventory content
 function serialize.serialize_character(character)
 	local serialized = { }
@@ -64,6 +67,12 @@ function serialize.serialize_character(character)
 	-- Serialize character inventories
 	serialized.inventories = serialize.serialize_inventories(character, character_inventories)
 
+	-- Serialize armor grid state
+	local grid = character.grid
+	if grid then
+		serialized.inhibit_movement_bonus = grid.inhibit_movement_bonus
+	end
+
 	return serialized
 end
 
@@ -75,6 +84,12 @@ function serialize.deserialize_character(character, serialized)
 
 	-- Deserialize character inventories
 	serialize.deserialize_inventories(character, serialized.inventories, character_inventories)
+
+	-- Deserialize armor grid state, the grid exists after the armor inventory is restored
+	local grid = character.grid
+	if grid and serialized.inhibit_movement_bonus ~= nil then
+		grid.inhibit_movement_bonus = serialized.inhibit_movement_bonus
+	end
 end
 
 -- Personal logistic slots is a table mapping string indexes to a table with the following fields:
@@ -593,6 +608,7 @@ end
 --- @field cheat_mode boolean
 --- @field flashlight boolean
 --- @field shortcuts table<string, boolean>?
+--- @field game_view_settings table<string, boolean>?
 --- @field ticks_to_respawn number
 --- @field character table<string, any>?
 --- @field inventories table<string, table>?
@@ -627,6 +643,28 @@ function serialize.deserialize_shortcuts(player, serialized)
 end
 
 --- @param player LuaPlayer
+--- @return table<string, boolean>
+function serialize.serialize_game_view_settings(player)
+	local settings = player.game_view_settings
+	local serialized = {}
+	for _, key in pairs(game_view_settings_keys) do
+		serialized[key] = settings[key]
+	end
+	return serialized
+end
+
+--- @param player LuaPlayer
+--- @param serialized table<string, boolean>
+function serialize.deserialize_game_view_settings(player, serialized)
+	local settings = player.game_view_settings
+	for _, key in pairs(game_view_settings_keys) do
+		if serialized[key] ~= nil then
+			settings[key] = serialized[key]
+		end
+	end
+end
+
+--- @param player LuaPlayer
 --- @param failed_deserialization FailedDeserializationPlayerData
 --- @return SerializedPlayerData
 function serialize.serialize_player(player, failed_deserialization)
@@ -642,6 +680,7 @@ function serialize.serialize_player(player, failed_deserialization)
 		cheat_mode = player.cheat_mode,
 		flashlight = player.is_flashlight_enabled(),
 		shortcuts = serialize.serialize_shortcuts(player),
+		game_view_settings = serialize.serialize_game_view_settings(player),
 		ticks_to_respawn = player.ticks_to_respawn,
 	}
 
@@ -818,6 +857,9 @@ function serialize.deserialize_player(player, serialized)
 	end
 	if serialized.shortcuts then
 		serialize.deserialize_shortcuts(player, serialized.shortcuts)
+	end
+	if serialized.game_view_settings then
+		serialize.deserialize_game_view_settings(player, serialized.game_view_settings)
 	end
 
 	-- Deserialize character


### PR DESCRIPTION
Fixes #898. The personal roboport and equipment movement bonus toggles reset on every instance switch because their state was never part of the serialized player data. The built-in shortcuts do not set `toggleable` in their prototypes and `set_shortcut_toggled` only affects custom Lua shortcuts, so the fix syncs the state behind them instead: `allow_dispatching_robots` on the character (added to the character stat keys), `inhibit_movement_bonus` on the character's armor grid (restored after the armor inventory so the grid exists), and every field of `game_view_settings`, which covers alt mode (`show_entity_info`) and tall entity visibility (`hide_tall_entities`).

The game view settings key list is version gated: `show_surface_list` from 2.0.22, `hide_tall_entities` and `show_pins_gui` from 2.1.7. On restore only keys present in both the record and the target version are written, so records from another Factorio version are a no-op for the rest. `map_view_settings` is write-only in the API, so there is nothing to read on the source instance and it is left out.

Shortcuts with `toggleable` set are still synced through `is_shortcut_toggled` and `set_shortcut_toggled` for mods that define Lua shortcuts. Records without the new fields deserialize as before.

Lua lint: 0 findings over 28 files with the CI config. `tsc --noEmit` on the plugin passes.

### Changelog
```
### Fixes
- Fixed inventory_sync not preserving the personal roboport toggle, the equipment movement bonus toggle, game view settings such as alt mode, and toggleable mod shortcuts between instances. #898
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
