### PR TITLE
Add save copying and start options when creating an instance

### DIFF
--- a/docs/managing-a-cluster.md
+++ b/docs/managing-a-cluster.md
@@ -65,6 +65,12 @@ Terminates the running Factorio server without giving it a chance to save or cle
 
 Note: This may cause loss of data.
 
+### Save game
+
+    ctl> instance save-game <name>
+
+Saves the running game of the instance to the save it was started from and waits for the save to finish.
+
 ### Extract players from instance
 
     ctl> instance extract-players <name>

--- a/packages/ctl/src/commands_instance.ts
+++ b/packages/ctl/src/commands_instance.ts
@@ -447,6 +447,16 @@ instanceCommands.add(new lib.Command({
 }));
 
 instanceCommands.add(new lib.Command({
+	definition: ["save-game <instance>", "Save the running game of an instance", (yargs) => {
+		yargs.positional("instance", { describe: "Instance to save the game on", type: "string" });
+	}],
+	handler: async function(args: { instance: string }, control: Control) {
+		let instanceId = await lib.resolveInstance(control, args.instance);
+		await control.sendTo({ instanceId }, new lib.InstanceSaveGameRequest());
+	},
+}));
+
+instanceCommands.add(new lib.Command({
 	definition: ["extract-players <instance>", "Extract players from running save into the cluster.", (yargs) => {
 		yargs.positional("instance", { describe: "Instance to extract players and online time from", type: "string" });
 	}],

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -288,6 +288,7 @@ export default class Instance extends lib.Link {
 		this.handle(lib.InstanceLoadScenarioRequest, this.handleInstanceLoadScenarioRequest.bind(this));
 		this.handle(lib.InstanceSaveDetailsListRequest, this.handleInstanceSaveDetailsListRequest.bind(this));
 		this.handle(lib.InstanceCreateSaveRequest, this.handleInstanceCreateSaveRequest.bind(this));
+		this.handle(lib.InstanceSaveGameRequest, this.handleInstanceSaveGameRequest.bind(this));
 		this.handle(lib.InstanceExportDataRequest, this.handleInstanceExportDataRequest.bind(this));
 		this.handle(lib.InstanceRestartRequest, this.handleInstanceRestartRequest.bind(this));
 		this.handle(lib.InstanceStopRequest, this.handleInstanceStopRequest.bind(this));
@@ -1305,6 +1306,27 @@ end`.replace(/\r?\n/g, " ");
 		}
 		await this.sendSaveListUpdate();
 		this.logger.info("Successfully created save");
+	}
+
+	async handleInstanceSaveGameRequest() {
+		if (this._status !== "running") {
+			throw new lib.RequestError("Instance is not running");
+		}
+
+		const saved = new Promise<void>((resolve, reject) => {
+			const onSaved = () => {
+				this.server.off("exit", onExit);
+				resolve();
+			};
+			const onExit = () => {
+				this.server.off("save-finished", onSaved);
+				reject(new lib.RequestError("Instance stopped before the save finished"));
+			};
+			this.server.once("save-finished", onSaved);
+			this.server.once("exit", onExit);
+		});
+		await this.sendRcon("/server-save");
+		await saved;
 	}
 
 	async handleInstanceExportDataRequest() {

--- a/packages/lib/src/data/messages_instance.ts
+++ b/packages/lib/src/data/messages_instance.ts
@@ -388,6 +388,14 @@ export class InstanceCreateSaveRequest {
 	}
 }
 
+export class InstanceSaveGameRequest {
+	declare ["constructor"]: typeof InstanceSaveGameRequest;
+	static type = "request" as const;
+	static src = ["control", "controller"] as const;
+	static dst = "instance" as const;
+	static permission = "core.instance.save.create" as const;
+}
+
 export class InstanceRenameSaveRequest {
 	declare ["constructor"]: typeof InstanceRenameSaveRequest;
 	static type = "request" as const;

--- a/packages/lib/src/link/messages.ts
+++ b/packages/lib/src/link/messages.ts
@@ -72,6 +72,7 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	instance.InstanceSaveDetailsListRequest,
 	instance.InstanceSaveDetailsUpdatesEvent,
 	instance.InstanceCreateSaveRequest,
+	instance.InstanceSaveGameRequest,
 	instance.InstanceRenameSaveRequest,
 	instance.InstanceCopySaveRequest,
 	instance.InstanceDeleteSaveRequest,

--- a/packages/web_ui/src/components/InstancesPage.tsx
+++ b/packages/web_ui/src/components/InstancesPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button, Form, Input, Modal, Select, Space, Tooltip } from "antd";
+import { Button, Checkbox, Form, Input, Modal, Select, Space, Tooltip } from "antd";
 
 import * as lib from "@clusterio/lib";
 
@@ -10,14 +10,27 @@ import PageHeader from "./PageHeader";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
 import { useInstances } from "../model/instance";
+import { useSaves } from "../model/saves";
 import InstanceList from "./InstanceList";
 import { notifyErrorHandler } from "../util/notify";
+
+type SaveMode = "none" | "copy" | "save_and_copy";
 
 function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances>[0] }) {
 	let control = useContext(ControlContext);
 	let navigate = useNavigate();
 	let [open, setOpen] = useState(false);
+	let [creating, setCreating] = useState(false);
 	let [form] = Form.useForm();
+	let [saves] = useSaves();
+
+	const cloneId: number | undefined = Form.useWatch("instanceClone", form);
+	const saveMode: SaveMode = Form.useWatch("saveMode", form) ?? "none";
+	const source = cloneId !== undefined && cloneId >= 0 ? props.instances.get(cloneId) : undefined;
+	const sourceRunning = source?.status === "running";
+	const activeSave = source ? [...saves.values()].find(
+		save => save.instanceId === source.id && (sourceRunning ? save.loaded : save.loadByDefault)
+	) : undefined;
 
 	async function createInstance() {
 		let values = form.getFieldsValue();
@@ -25,19 +38,50 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 			form.setFields([{ name: "instanceName", errors: ["Name is required"] }]);
 			return;
 		}
+		const copySave = source !== undefined && saveMode !== "none";
+		if (copySave && !activeSave) {
+			form.setFields([{ name: "saveMode", errors: ["The source instance has no save to copy"] }]);
+			return;
+		}
+		if (copySave && source.assignedHost === undefined) {
+			form.setFields([{ name: "saveMode", errors: ["The source instance is not assigned to a host"] }]);
+			return;
+		}
 
 		let instanceConfig = new lib.InstanceConfig("control");
 		instanceConfig.set("instance.name", values.instanceName);
+		const instanceId = instanceConfig.get("instance.id");
 
-		await control.send(new lib.InstanceCreateRequest(
-			instanceConfig.toRemote("controller", [
-				"instance.id", "instance.name",
-			]),
-			values.instanceClone >= 0 ? values.instanceClone : undefined,
-		));
+		setCreating(true);
+		let created = false;
+		try {
+			await control.send(new lib.InstanceCreateRequest(
+				instanceConfig.toRemote("controller", [
+					"instance.id", "instance.name",
+				]),
+				source?.id,
+			));
+			created = true;
 
-		setOpen(false);
-		navigate(`/instances/${instanceConfig.get("instance.id")}/view`);
+			if (copySave) {
+				await control.send(new lib.InstanceAssignRequest(instanceId, source.assignedHost));
+				if (saveMode === "save_and_copy") {
+					await control.sendTo({ instanceId: source.id }, new lib.InstanceSaveGameRequest());
+				}
+				const saveName = await control.send(new lib.InstanceTransferSaveRequest(
+					source.id, activeSave!.name, instanceId, activeSave!.name, true,
+				));
+				if (values.startAfter) {
+					await control.sendTo({ instanceId }, new lib.InstanceStartRequest(saveName));
+				}
+			}
+		} finally {
+			setCreating(false);
+			if (created) {
+				setOpen(false);
+				navigate(`/instances/${instanceId}/view`);
+			}
+		}
 	}
 
 	return <>
@@ -51,24 +95,56 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 			title="Create Instance"
 			okText="Create"
 			open={open}
+			confirmLoading={creating}
 			onOk={() => { createInstance().catch(notifyErrorHandler("Error creating instance")); }}
 			onCancel={() => { setOpen(false); }}
 			destroyOnHidden
 		>
-			<Form form={form}>
+			<Form form={form} initialValues={{ instanceClone: -1, saveMode: "none", startAfter: false }}>
 				<Form.Item name="instanceName" label="Name">
 					<Input />
 				</Form.Item>
-				<Tooltip title="Perform a one time copy of an existing config (assigned host is not copied)">
+				<Tooltip
+					title="Perform a one time copy of an existing config (the host is only copied along with a save)"
+				>
 					<Form.Item name="instanceClone" label="Copy Config">
 						<Select
-							defaultValue={-1}
 							options={[{ id: -1, name: "Default Config" }, ...props.instances.values()]
 								.map(i => ({ value: i.id, label: i.name }))
 							}
 						/>
 					</Form.Item>
 				</Tooltip>
+				{source && <>
+					<Form.Item
+						name="saveMode"
+						label="Copy Save"
+						extra={
+							saveMode !== "none" ? "The new instance is assigned to the host of the source" : undefined
+						}
+					>
+						<Select
+							options={[
+								{ value: "none", label: "None" },
+								{
+									value: "copy",
+									label: activeSave ? `Copy ${activeSave.name}` : "Copy active save",
+									disabled: !activeSave,
+								},
+								{
+									value: "save_and_copy",
+									label: activeSave
+										? `Save the running game and copy ${activeSave.name}`
+										: "Save and copy",
+									disabled: !sourceRunning || !activeSave,
+								},
+							]}
+						/>
+					</Form.Item>
+					<Form.Item name="startAfter" valuePropName="checked">
+						<Checkbox disabled={saveMode === "none"}>Start after creation</Checkbox>
+					</Form.Item>
+				</>}
 			</Form>
 		</Modal>
 	</>;

--- a/packages/web_ui/src/components/InstancesPage.tsx
+++ b/packages/web_ui/src/components/InstancesPage.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Button, Checkbox, Form, Input, Modal, Select, Space, Tooltip } from "antd";
+import { Button, Checkbox, Form, Input, Modal, Select, Space, Tooltip, Typography } from "antd";
 
 import * as lib from "@clusterio/lib";
 
@@ -9,28 +9,45 @@ import ControlContext from "./ControlContext";
 import PageHeader from "./PageHeader";
 import PageLayout from "./PageLayout";
 import PluginExtra from "./PluginExtra";
-import { useInstances } from "../model/instance";
+import { useHosts } from "../model/host";
+import { useInstanceConfig, useInstances } from "../model/instance";
 import { useSaves } from "../model/saves";
 import InstanceList from "./InstanceList";
 import { notifyErrorHandler } from "../util/notify";
 
 type SaveMode = "none" | "copy" | "save_and_copy";
 
+const strcmp = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }).compare;
+
 function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances>[0] }) {
 	let control = useContext(ControlContext);
+	let account = useAccount();
 	let navigate = useNavigate();
 	let [open, setOpen] = useState(false);
 	let [creating, setCreating] = useState(false);
 	let [form] = Form.useForm();
+	let [hosts] = useHosts();
 	let [saves] = useSaves();
 
+	const canAssign = account.hasPermission("core.instance.assign");
 	const cloneId: number | undefined = Form.useWatch("instanceClone", form);
+	const host: number | string | undefined = Form.useWatch("host", form);
 	const saveMode: SaveMode = Form.useWatch("saveMode", form) ?? "none";
+	const hostId = typeof host === "number" ? host : undefined;
 	const source = cloneId !== undefined && cloneId >= 0 ? props.instances.get(cloneId) : undefined;
 	const sourceRunning = source?.status === "running";
 	const activeSave = source ? [...saves.values()].find(
 		save => save.instanceId === source.id && (sourceRunning ? save.loaded : save.loadByDefault)
 	) : undefined;
+	const sourceConfig = useInstanceConfig(source?.id);
+	const sourceSettings = sourceConfig?.["factorio.settings"] as Record<string, unknown> | undefined;
+	const sourceServerName = typeof sourceSettings?.name === "string" ? sourceSettings.name : undefined;
+
+	useEffect(() => {
+		if (open && sourceServerName !== undefined) {
+			form.setFieldValue("serverName", sourceServerName);
+		}
+	}, [open, sourceServerName]);
 
 	async function createInstance() {
 		let values = form.getFieldsValue();
@@ -38,7 +55,7 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 			form.setFields([{ name: "instanceName", errors: ["Name is required"] }]);
 			return;
 		}
-		const copySave = source !== undefined && saveMode !== "none";
+		const copySave = source !== undefined && hostId !== undefined && saveMode !== "none";
 		if (copySave && !activeSave) {
 			form.setFields([{ name: "saveMode", errors: ["The source instance has no save to copy"] }]);
 			return;
@@ -50,30 +67,41 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 
 		let instanceConfig = new lib.InstanceConfig("control");
 		instanceConfig.set("instance.name", values.instanceName);
+		const fields: (keyof lib.InstanceConfigFields)[] = ["instance.id", "instance.name"];
+		if (source && sourceSettings) {
+			if (!values.serverName) {
+				form.setFields([{ name: "serverName", errors: ["Server name is required"] }]);
+				return;
+			}
+			instanceConfig.set("factorio.settings", { ...sourceSettings, name: values.serverName });
+			fields.push("factorio.settings");
+		}
 		const instanceId = instanceConfig.get("instance.id");
 
 		setCreating(true);
 		let created = false;
 		try {
 			await control.send(new lib.InstanceCreateRequest(
-				instanceConfig.toRemote("controller", [
-					"instance.id", "instance.name",
-				]),
+				instanceConfig.toRemote("controller", fields),
 				source?.id,
 			));
 			created = true;
 
+			if (hostId !== undefined) {
+				await control.send(new lib.InstanceAssignRequest(instanceId, hostId));
+			}
+
+			let saveName: string | undefined;
 			if (copySave) {
-				await control.send(new lib.InstanceAssignRequest(instanceId, source.assignedHost));
 				if (saveMode === "save_and_copy") {
 					await control.sendTo({ instanceId: source.id }, new lib.InstanceSaveGameRequest());
 				}
-				const saveName = await control.send(new lib.InstanceTransferSaveRequest(
+				saveName = await control.send(new lib.InstanceTransferSaveRequest(
 					source.id, activeSave!.name, instanceId, activeSave!.name, true,
 				));
-				if (values.startAfter) {
-					await control.sendTo({ instanceId }, new lib.InstanceStartRequest(saveName));
-				}
+			}
+			if (values.startAfter && hostId !== undefined) {
+				await control.sendTo({ instanceId }, new lib.InstanceStartRequest(saveName));
 			}
 		} finally {
 			setCreating(false);
@@ -100,13 +128,30 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 			onCancel={() => { setOpen(false); }}
 			destroyOnHidden
 		>
-			<Form form={form} initialValues={{ instanceClone: -1, saveMode: "none", startAfter: false }}>
+			<Form
+				form={form}
+				initialValues={{ host: "null", instanceClone: -1, saveMode: "none", startAfter: false }}
+			>
 				<Form.Item name="instanceName" label="Name">
 					<Input />
 				</Form.Item>
-				<Tooltip
-					title="Perform a one time copy of an existing config (the host is only copied along with a save)"
-				>
+				{canAssign && <Form.Item name="host" label="Host">
+					<Select showSearch optionFilterProp="name">
+						<Select.Option value={"null"}>
+							<Typography.Text italic>Unassigned</Typography.Text>
+						</Select.Option>
+						{[...hosts.values()].sort((a, b) => strcmp(a.name, b.name)).map(h => <Select.Option
+							key={h.id}
+							value={h.id}
+							name={h.name}
+							disabled={!h.connected}
+						>
+							{h.name}
+							{!h.connected && " (offline)"}
+						</Select.Option>)}
+					</Select>
+				</Form.Item>}
+				<Tooltip title="Perform a one time copy of the config of an existing instance">
 					<Form.Item name="instanceClone" label="Copy Config">
 						<Select
 							options={[{ id: -1, name: "Default Config" }, ...props.instances.values()]
@@ -115,36 +160,35 @@ function CreateInstanceButton(props: { instances: ReturnType<typeof useInstances
 						/>
 					</Form.Item>
 				</Tooltip>
-				{source && <>
-					<Form.Item
-						name="saveMode"
-						label="Copy Save"
-						extra={
-							saveMode !== "none" ? "The new instance is assigned to the host of the source" : undefined
-						}
-					>
-						<Select
-							options={[
-								{ value: "none", label: "None" },
-								{
-									value: "copy",
-									label: activeSave ? `Copy ${activeSave.name}` : "Copy active save",
-									disabled: !activeSave,
-								},
-								{
-									value: "save_and_copy",
-									label: activeSave
-										? `Save the running game and copy ${activeSave.name}`
-										: "Save and copy",
-									disabled: !sourceRunning || !activeSave,
-								},
-							]}
-						/>
+				{source && sourceSettings && <Tooltip title="Name of the server as shown in the in-game server browser">
+					<Form.Item name="serverName" label="Server Name">
+						<Input />
 					</Form.Item>
-					<Form.Item name="startAfter" valuePropName="checked">
-						<Checkbox disabled={saveMode === "none"}>Start after creation</Checkbox>
-					</Form.Item>
-				</>}
+				</Tooltip>}
+				{source && hostId !== undefined && <Form.Item name="saveMode" label="Copy Save">
+					<Select
+						options={[
+							{ value: "none", label: "None" },
+							{
+								value: "copy",
+								label: activeSave ? `Copy ${activeSave.name}` : "Copy active save",
+								disabled: !activeSave,
+							},
+							{
+								value: "save_and_copy",
+								label: "Save the running game and copy it",
+								disabled: !sourceRunning || !activeSave,
+							},
+						]}
+					/>
+				</Form.Item>}
+				{hostId !== undefined && <Form.Item
+					name="startAfter"
+					valuePropName="checked"
+					extra={saveMode === "none" ? "A new save is created if none is copied" : undefined}
+				>
+					<Checkbox>Start after creation</Checkbox>
+				</Form.Item>}
 			</Form>
 		</Modal>
 	</>;

--- a/packages/web_ui/src/model/instance.ts
+++ b/packages/web_ui/src/model/instance.ts
@@ -19,10 +19,17 @@ export function useInstanceConfig(id?: number) {
 	const [config, setConfig] = useState(undefined as undefined | Static<typeof Config.jsonSchema>);
 
 	useEffect(() => {
-		if (id) {
-			control.send(new InstanceConfigGetRequest(id))
-				.then(conf => setConfig(conf));
+		setConfig(undefined);
+		if (id === undefined) {
+			return undefined;
 		}
+
+		// Responses for a previous id must not overwrite the current one.
+		let current = true;
+		control.send(new InstanceConfigGetRequest(id))
+			.then(conf => { if (current) { setConfig(conf); } })
+			.catch(() => {}); // Config is optional, the caller falls back to not having it
+		return () => { current = false; };
 	}, [id]);
 
 	return config;

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -914,6 +914,20 @@ describe("Integration of Clusterio", function() {
 				}
 				assert(received, "InstanceSaveDetailsUpdatesEvent not sent");
 			});
+			it("should save the running game with save-game", async function() {
+				slowTest(this);
+				getControl().saveUpdates = [];
+				await execCtl("instance save-game test");
+				let received = false;
+				for (let x = 0; x < 10; x++) {
+					if (getControl().saveUpdates.length) {
+						received = true;
+						break;
+					}
+					await wait(100);
+				}
+				assert(received, "InstanceSaveDetailsUpdatesEvent not sent");
+			});
 			it("should prevent execution of script commands when disabled", async function() {
 				slowTest(this);
 				await execCtl("instance send-rcon test /c");


### PR DESCRIPTION
Closes #405. Creating an instance now offers a host, a server name, save copying and a start option.

The host dropdown shows for accounts with `core.instance.assign` and defaults to unassigned. Picking a host adds "Start after creation"; when no save is copied the instance creates a new one on first run. "Copy Config" is independent of the host, and when it points at an instance a "Server Name" field appears, prefilled with the source's `factorio.settings.name`, so the clone does not turn up in the server browser under the name of the source. With both a host and a config source set, "Copy Save" can copy the active save of the source (the loaded save if it is running, otherwise the save that would load by default) or first save the running game and then copy it. Source and target no longer have to share a host, the controller proxies the transfer. The modal shows a loading state while the steps run and navigates to the new instance once it has been created, even if a later step fails, so the error notification points at an instance that exists.

Saving a running game had no request before, so this adds `InstanceSaveGameRequest`. The host handler sends `/server-save` over RCON and resolves when the server reports the save finished, or rejects if the server exits first. It reuses the `core.instance.save.create` permission. The request is also exposed as `clusterioctl instance save-game <instance>` with a docs entry and an integration test next to the existing `/server-save` one.

Not included: a "save game" button on the saves list for running instances. The request makes that a small follow-up if wanted.

Verified with `pnpm test` (1671 passing, the port 8080 timeout is local to my machine and the one other failure passes when run on its own) and the full lint. The modal itself I drove in a browser against a controller and host: each field appears and disappears as described, creating with a changed server name gives an instance on the chosen host with the new `factorio.settings.name` and the rest of the settings intact, and copying a save with "Start after creation" ticked ends with the new instance running on the copied save.

### Changelog
```
### Features
- Added host, server name, save copy and start options to the create instance dialog in the web UI. #405
- Added `InstanceSaveGameRequest` and `clusterioctl instance save-game` to save the running game of an instance. #405
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
