### PR TITLE
fix: preserve InvalidMessage validation errors in async handlers

### DIFF
--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -736,6 +736,9 @@ export class FactorioServer extends events.EventEmitter<FactorioServerEvents> {
 	handle<Event>(eventName: string, handler: (event: Event) => Promise<void>) {
 		this.on(`ipc-${eventName}`, (event) => handler(event).catch((err: Error) => {
 			this._logger.error(`Error handling ipc event:\n${err.stack ?? err.message}`);
+			if (err instanceof lib.InvalidMessage && err.errors) {
+				this._logger.error(JSON.stringify(err.errors, null, "\t"));
+			}
 		}));
 	}
 

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -213,13 +213,9 @@ export class Link {
 			let handler = this._eventSnoopers.get((entry as EventEntry).Event)!;
 			let event = message as libData.MessageEvent;
 			handler((entry as EventEntry).eventFromJSON(event.data), event.src, event.dst).catch((err: Error) => {
-				if (err instanceof libErrors.InvalidMessage) {
-					logger.error(err.message);
-					if (err.errors) {
-						logger.error(JSON.stringify(err.errors, null, "\t"));
-					}
-				} else {
-					logger.error(`Unexpected error snooping ${event.name}:\n${err.stack}`);
+				logger.error(`Unexpected error snooping ${event.name}:\n${err.stack ?? err.message}`);
+				if (err instanceof libErrors.InvalidMessage && err.errors) {
+					logger.error(JSON.stringify(err.errors, null, "\t"));
 				}
 			});
 		}
@@ -489,13 +485,9 @@ export class Link {
 		handler(
 			entry.eventFromJSON(message.data), message.src, message.dst
 		).catch((err: Error) => {
-			if (err instanceof libErrors.InvalidMessage) {
-				logger.error(err.message);
-				if (err.errors) {
-					logger.error(JSON.stringify(err.errors, null, "\t"));
-				}
-			} else {
-				logger.error(`Unexpected error handling ${message.name}:\n${err.stack}`);
+			logger.error(`Unexpected error handling ${message.name}:\n${err.stack ?? err.message}`);
+			if (err instanceof libErrors.InvalidMessage && err.errors) {
+				logger.error(JSON.stringify(err.errors, null, "\t"));
 			}
 		});
 	}

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -213,7 +213,14 @@ export class Link {
 			let handler = this._eventSnoopers.get((entry as EventEntry).Event)!;
 			let event = message as libData.MessageEvent;
 			handler((entry as EventEntry).eventFromJSON(event.data), event.src, event.dst).catch((err: Error) => {
-				logger.error(`Unexpected error snooping ${event.name}:\n${err.stack}`);
+				if (err instanceof libErrors.InvalidMessage) {
+					logger.error(err.message);
+					if (err.errors) {
+						logger.error(JSON.stringify(err.errors, null, "\t"));
+					}
+				} else {
+					logger.error(`Unexpected error snooping ${event.name}:\n${err.stack}`);
+				}
 			});
 		}
 
@@ -482,7 +489,14 @@ export class Link {
 		handler(
 			entry.eventFromJSON(message.data), message.src, message.dst
 		).catch((err: Error) => {
-			logger.error(`Unexpected error handling ${message.name}:\n${err.stack}`);
+			if (err instanceof libErrors.InvalidMessage) {
+				logger.error(err.message);
+				if (err.errors) {
+					logger.error(JSON.stringify(err.errors, null, "\t"));
+				}
+			} else {
+				logger.error(`Unexpected error handling ${message.name}:\n${err.stack}`);
+			}
 		});
 	}
 

--- a/test/host/server.js
+++ b/test/host/server.js
@@ -311,6 +311,37 @@ describe("host/server", function() {
 			});
 		});
 
+		describe(".handle()", function() {
+			it("should log validation errors from ipc handlers", async function() {
+				let logs = [];
+				let ipcServer = new hostServer.FactorioServer(
+					path.join("test", "file", "factorio"), writePath,
+					{ logger: { error: message => logs.push(message) } }
+				);
+				class ValidationRequest {
+					static jsonSchema = { type: "number" };
+					static fromJSON(json) { return json; }
+				}
+				let requestFromJSON = lib.Link.requestFromJSON(ValidationRequest, "ValidationRequest");
+				let error;
+				try {
+					requestFromJSON("not a number");
+				} catch (err) {
+					error = err;
+				}
+				assert(error instanceof lib.InvalidMessage);
+				assert(error.errors);
+
+				ipcServer.handle("validation", async () => { throw error; });
+				ipcServer.emit("ipc-validation", {});
+				await new Promise(resolve => setImmediate(resolve));
+
+				assert.equal(logs.length, 2);
+				assert.match(logs[0], /Error handling ipc event:\nError: Request ValidationRequest failed validation/);
+				assert.equal(logs[1], JSON.stringify(error.errors, null, "\t"));
+			});
+		});
+
 		describe(".stop()", function() {
 			it("should handle server quitting on its own during stop", async function() {
 				server.shutdownTimeoutMs = 20;

--- a/test/lib/link/link.js
+++ b/test/lib/link/link.js
@@ -413,6 +413,21 @@ describe("lib/link/link", function() {
 				testLink.handle(SimpleEvent, async () => { throwSimple("Error"); });
 				testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
 			});
+			it("should log InvalidMessage from event handler", async function() {
+				let logs = [];
+				const originalError = lib.logger.error;
+				lib.logger.error = msg => { logs.push(msg); };
+				try {
+					let error = new lib.InvalidMessage("failed", [{ message: "bad" }]);
+					error.stack = "failed stack";
+					testLink.handle(SimpleEvent, async () => { throw error; });
+					testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
+					await new Promise(resolve => setImmediate(resolve));
+					assert.deepEqual(logs, ["Unexpected error handling SimpleEvent:\nfailed stack", '[\n\t{\n\t\t"message": "bad"\n\t}\n]']);
+				} finally {
+					lib.logger.error = originalError;
+				}
+			});
 			it("should throw on unknown type", function() {
 				assert.throws(
 					() => testLink.handle({ name: "Bad", type: "bad" }),
@@ -594,6 +609,21 @@ describe("lib/link/link", function() {
 			it("should log errors from snoop handler", function() {
 				testLink.snoopEvent(SimpleEvent, async () => { throwSimple("Error"); });
 				testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
+			});
+			it("should log InvalidMessage from snoop handler", async function() {
+				let logs = [];
+				const originalError = lib.logger.error;
+				lib.logger.error = msg => { logs.push(msg); };
+				try {
+					let error = new lib.InvalidMessage("failed", [{ message: "bad" }]);
+					error.stack = "failed stack";
+					testLink.snoopEvent(SimpleEvent, async () => { throw error; });
+					testConnector.emit("message", new lib.MessageEvent(1, dst, src, "SimpleEvent"));
+					await new Promise(resolve => setImmediate(resolve));
+					assert.deepEqual(logs, ["Unexpected error snooping SimpleEvent:\nfailed stack", '[\n\t{\n\t\t"message": "bad"\n\t}\n]']);
+				} finally {
+					lib.logger.error = originalError;
+				}
 			});
 			it("should throw on double registration", function() {
 				testLink.snoopEvent(SimpleEvent);


### PR DESCRIPTION
## Summary

Preserve detailed schema validation errors when InvalidMessage is handled by IPC and asynchronous link event handlers.

## Changes

- Log InvalidMessage.errors from FactorioServer IPC handlers.
- Log InvalidMessage.errors from link event and snooper handlers.
- Add a regression test covering request validation errors and IPC logging.

## Testing

- `git diff --check`
- `node --check test/host/server.js`
- VS Code TypeScript diagnostics for edited files
- Focused Mocha and full test suite could not run because dependencies and local build tools are not installed.

## Related Issue

Closes #986