### PR TITLE
Rename RequestError to ExpectedError

### DIFF
--- a/packages/controller/src/BaseConnection.ts
+++ b/packages/controller/src/BaseConnection.ts
@@ -63,7 +63,7 @@ export default class BaseConnection extends lib.Link {
 		let { id } = request;
 		let modPack = this._controller.modPacks.get(id);
 		if (!modPack) {
-			throw new lib.RequestError(`Mod pack with ID ${id} does not exist`);
+			throw new lib.ExpectedError(`Mod pack with ID ${id} does not exist`);
 		}
 		return modPack;
 	}
@@ -71,11 +71,11 @@ export default class BaseConnection extends lib.Link {
 	async handleModPackGetDefaultRequest(): Promise<lib.ModPack> {
 		let id = this._controller.config.get("controller.default_mod_pack_id");
 		if (id === null) {
-			throw new lib.RequestError("Default mod pack not set on controller");
+			throw new lib.ExpectedError("Default mod pack not set on controller");
 		}
 		let modPack = this._controller.modPacks.get(id);
 		if (!modPack) {
-			throw new lib.RequestError(`Default mod pack configured (${id}) does not exist`);
+			throw new lib.ExpectedError(`Default mod pack configured (${id}) does not exist`);
 		}
 		return modPack;
 	}
@@ -84,10 +84,10 @@ export default class BaseConnection extends lib.Link {
 		let filename = lib.ModInfo.filename(mod.name, mod.version);
 		let modInfo = this._controller.modStore.files.get(filename);
 		if (!modInfo) {
-			throw new lib.RequestError(`Mod ${filename} does not exist on controller`);
+			throw new lib.ExpectedError(`Mod ${filename} does not exist on controller`);
 		}
 		if (mod.sha1 && mod.sha1 !== modInfo.sha1) {
-			throw new lib.RequestError(`Mod ${filename} checksum does not match controller's checksum`);
+			throw new lib.ExpectedError(`Mod ${filename} checksum does not match controller's checksum`);
 		}
 		return modInfo;
 	}

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -187,12 +187,12 @@ export default class ControlConnection extends BaseConnection {
 
 	async handleControllerRestartRequest() {
 		if (!this._controller.canRestart) {
-			throw new lib.RequestError("Cannot restart, controller does not have a process monitor to restart it.");
+			throw new lib.ExpectedError("Cannot restart, controller does not have a process monitor to restart it.");
 		}
 		const downgrade = await this._controller.checkRestartDowngrade();
 		if (downgrade) {
 			const { installedVersion, runningVersion } = downgrade;
-			throw new lib.RequestError(
+			throw new lib.ExpectedError(
 				`Cannot restart controller with installed Clusterio version ${installedVersion} because it ` +
 				`is older than running version ${runningVersion}. ` +
 				"Stop the controller before starting the older version manually."
@@ -293,7 +293,7 @@ export default class ControlConnection extends BaseConnection {
 		if (request.cloneFromId) {
 			const baseInstance = this._controller.instances.get(request.cloneFromId);
 			if (!baseInstance) {
-				throw new lib.RequestError(`Instance with ID ${request.cloneFromId} does not exist`);
+				throw new lib.ExpectedError(`Instance with ID ${request.cloneFromId} does not exist`);
 			}
 			instanceConfig.update(baseInstance.config.toJSON(), false);
 			instanceConfig.set("instance.assigned_host", null); // New instances are unassigned
@@ -313,12 +313,12 @@ export default class ControlConnection extends BaseConnection {
 
 	private static validateInstanceConfigSetField(fieldName: string) {
 		if (fieldName === "instance.assigned_host") {
-			throw new lib.RequestError("instance.assigned_host must be set through the assign-host interface");
+			throw new lib.ExpectedError("instance.assigned_host must be set through the assign-host interface");
 		}
 
 		if (fieldName === "instance.id") {
 			// XXX is this worth implementing?  It's race condition galore.
-			throw new lib.RequestError("Setting instance.id is not supported");
+			throw new lib.ExpectedError("Setting instance.id is not supported");
 		}
 	}
 
@@ -376,7 +376,7 @@ export default class ControlConnection extends BaseConnection {
 		let ready = new Promise<void>((resolve, reject) => {
 			stream.events.on("source", resolve);
 			stream.events.on("timeout", () => reject(
-				new lib.RequestError("Timed out establishing stream from host")
+				new lib.ExpectedError("Timed out establishing stream from host")
 			));
 		});
 		ready.catch(() => {});
@@ -393,17 +393,17 @@ export default class ControlConnection extends BaseConnection {
 
 	async handleInstanceTransferSaveRequest(request: lib.InstanceTransferSaveRequest) {
 		if (request.sourceInstanceId === request.targetInstanceId) {
-			throw new lib.RequestError("Source and target instance may not be the same");
+			throw new lib.ExpectedError("Source and target instance may not be the same");
 		}
 		let sourceInstance = this._controller.instances.getForRequest(request.sourceInstanceId);
 		let targetInstance = this._controller.instances.getForRequest(request.targetInstanceId);
 		let sourceHostId = sourceInstance.config.get("instance.assigned_host");
 		let targetHostId = targetInstance.config.get("instance.assigned_host");
 		if (sourceHostId === null) {
-			throw new lib.RequestError("Source instance is not assigned a host");
+			throw new lib.ExpectedError("Source instance is not assigned a host");
 		}
 		if (targetHostId === null) {
-			throw new lib.RequestError("Target instance is not assigned a host");
+			throw new lib.ExpectedError("Target instance is not assigned a host");
 		}
 
 		// Let host handle request if source and target is on the same host.
@@ -414,12 +414,12 @@ export default class ControlConnection extends BaseConnection {
 		// Check connectivity
 		let sourceHostConnection = this._controller.wsServer.hostConnections.get(sourceHostId);
 		if (!sourceHostConnection || sourceHostConnection.connector.closing) {
-			throw new lib.RequestError("Source host is not connected to the controller");
+			throw new lib.ExpectedError("Source host is not connected to the controller");
 		}
 
 		let targetHostConnection = this._controller.wsServer.hostConnections.get(targetHostId);
 		if (!targetHostConnection || targetHostConnection.connector.closing) {
-			throw new lib.RequestError("Target host is not connected to the controller");
+			throw new lib.ExpectedError("Target host is not connected to the controller");
 		}
 
 		// Create stream to proxy from target to source
@@ -428,7 +428,7 @@ export default class ControlConnection extends BaseConnection {
 			if (stream.source) {
 				stream.source.destroy();
 			}
-			stream.events.emit("error", new lib.RequestError("Timed out establishing transfer stream"));
+			stream.events.emit("error", new lib.ExpectedError("Timed out establishing transfer stream"));
 		});
 
 		// Ignore errors if not listening for them to avoid crash.
@@ -468,10 +468,10 @@ export default class ControlConnection extends BaseConnection {
 	async handleModPackCreateRequest(request: lib.ModPackCreateRequest) {
 		let modPack = request.modPack;
 		if (modPack.id === undefined) {
-			throw new lib.RequestError("Mod pack need an ID to be created");
+			throw new lib.ExpectedError("Mod pack need an ID to be created");
 		}
 		if (this._controller.modPacks.has(modPack.id)) {
-			throw new lib.RequestError(`Mod pack with ID ${modPack.id} already exist`);
+			throw new lib.ExpectedError(`Mod pack with ID ${modPack.id} already exist`);
 		}
 		this._controller.modPacks.set(modPack);
 	}
@@ -479,7 +479,7 @@ export default class ControlConnection extends BaseConnection {
 	async handleModPackUpdateRequest(request: lib.ModPackUpdateRequest) {
 		let modPack = request.modPack;
 		if (modPack.id === undefined || !this._controller.modPacks.has(modPack.id)) {
-			throw new lib.RequestError(`Mod pack with ID ${modPack.id} does not exist`);
+			throw new lib.ExpectedError(`Mod pack with ID ${modPack.id} does not exist`);
 		}
 		this._controller.modPacks.set(modPack);
 	}
@@ -488,7 +488,7 @@ export default class ControlConnection extends BaseConnection {
 		let { id } = request;
 		let modPack = this._controller.modPacks.getMutable(id);
 		if (!modPack) {
-			throw new lib.RequestError(`Mod pack with ID ${id} does not exist`);
+			throw new lib.ExpectedError(`Mod pack with ID ${id} does not exist`);
 		}
 		this._controller.modPacks.delete(modPack);
 	}
@@ -569,7 +569,7 @@ export default class ControlConnection extends BaseConnection {
 				author: (a:ModVersions, b:ModVersions) => strcmp(a.versions[0].author, b.versions[0].author),
 			};
 			if (!Object.prototype.hasOwnProperty.call(sorters, sort)) {
-				throw new lib.RequestError(`Invalid value for sort: ${sort}`);
+				throw new lib.ExpectedError(`Invalid value for sort: ${sort}`);
 			}
 			resultList.sort(sorters[sort as keyof typeof sorters]);
 			let order = request.sortOrder;
@@ -616,7 +616,7 @@ export default class ControlConnection extends BaseConnection {
 		} catch (error: any) {
 			logger.error(`Error fetching all mods from portal (${request.factorioVersion}): ${error}`);
 			// Propagate a user-friendly error back to the client
-			throw new lib.RequestError(`Portal mod fetch failed: ${error}`);
+			throw new lib.ExpectedError(`Portal mod fetch failed: ${error}`);
 		}
 	}
 
@@ -634,7 +634,7 @@ export default class ControlConnection extends BaseConnection {
 			const token = this._controller.config.get("controller.factorio_token");
 
 			if (!username || username === "" || !token || token === "") {
-				throw new lib.RequestError("Factorio credentials (username, token) not configured on the controller.");
+				throw new lib.ExpectedError("Factorio credentials (username, token) not configured on the controller.");
 			}
 
 			try {
@@ -645,7 +645,7 @@ export default class ControlConnection extends BaseConnection {
 				logger.error(`Error downloading mods from portal: ${error.message}`);
 				// Improve error message clarity
 				let errorMessage = "Mod portal download failed";
-				if (error instanceof lib.RequestError) {
+				if (error instanceof lib.ExpectedError) {
 					errorMessage += `: ${error.message}`;
 				} else if (error.message.includes("401") || error.message.includes("Unauthorized")) {
 					errorMessage += ": Authentication failed. Check Factorio username/token in controller config.";
@@ -654,7 +654,7 @@ export default class ControlConnection extends BaseConnection {
 				} else {
 					errorMessage += `: ${error.message}`;
 				}
-				throw new lib.RequestError(errorMessage);
+				throw new lib.ExpectedError(errorMessage);
 			}
 		}
 
@@ -664,7 +664,7 @@ export default class ControlConnection extends BaseConnection {
 		for (const mod of request.mods) {
 			const modInfo = installedMods.find(m => m.name === mod.name && mod.version.testVersion(m.version));
 			if (!modInfo) {
-				throw new lib.RequestError(`Failed to find mod ${mod.name} in store after download attempt.`);
+				throw new lib.ExpectedError(`Failed to find mod ${mod.name} in store after download attempt.`);
 			}
 			modInfos.push(modInfo);
 		}
@@ -698,7 +698,7 @@ export default class ControlConnection extends BaseConnection {
 				} catch (error: any) {
 					if (!error.message.includes("404") && !error.message.includes("Not Found")) {
 						logger.error(`Error fetching mod from portal: ${error.message}`);
-						throw new lib.RequestError(`Dependency resolution failed: ${error.message}`);
+						throw new lib.ExpectedError(`Dependency resolution failed: ${error.message}`);
 					} else {
 						releases = null;
 					}
@@ -927,7 +927,7 @@ export default class ControlConnection extends BaseConnection {
 		let { id, name, description, permissions } = request;
 		let role = this._controller.roles.getMutable(id);
 		if (!role) {
-			throw new lib.RequestError(`Role with ID ${id} does not exist`);
+			throw new lib.ExpectedError(`Role with ID ${id} does not exist`);
 		}
 
 		role.name = name;
@@ -939,7 +939,7 @@ export default class ControlConnection extends BaseConnection {
 	async handleRoleGrantDefaultPermissionsRequest(request: lib.RoleGrantDefaultPermissionsRequest) {
 		let role = this._controller.roles.get(request.id);
 		if (!role) {
-			throw new lib.RequestError(`Role with ID ${request.id} does not exist`);
+			throw new lib.ExpectedError(`Role with ID ${request.id} does not exist`);
 		}
 
 		role.grantDefaultPermissions();
@@ -951,7 +951,7 @@ export default class ControlConnection extends BaseConnection {
 
 		const role = this._controller.roles.get(id);
 		if (!role) {
-			throw new lib.RequestError(`Role with ID ${id} does not exist`);
+			throw new lib.ExpectedError(`Role with ID ${id} does not exist`);
 		}
 		this._controller.roles.delete(role);
 
@@ -966,7 +966,7 @@ export default class ControlConnection extends BaseConnection {
 		let name = request.name;
 		let user = this._controller.users.getByName(name);
 		if (!user) {
-			throw new lib.RequestError(`User ${name} does not exist`);
+			throw new lib.ExpectedError(`User ${name} does not exist`);
 		}
 
 		return user.toUserDetails();
@@ -983,7 +983,7 @@ export default class ControlConnection extends BaseConnection {
 	async handleUserRevokeTokenRequest(request: lib.UserRevokeTokenRequest) {
 		let user = this._controller.users.getByName(request.name);
 		if (!user) {
-			throw new lib.RequestError(`User '${request.name}' does not exist`);
+			throw new lib.ExpectedError(`User '${request.name}' does not exist`);
 		}
 		if (user.id !== this.user.id) {
 			this.user.checkPermission("core.user.revoke_other_token");
@@ -1000,12 +1000,12 @@ export default class ControlConnection extends BaseConnection {
 	async handleUserUpdateRolesRequest(request: lib.UserUpdateRolesRequest) {
 		let user = this._controller.users.getByName(request.name);
 		if (!user) {
-			throw new lib.RequestError(`User '${request.name}' does not exist`);
+			throw new lib.ExpectedError(`User '${request.name}' does not exist`);
 		}
 
 		for (let roleId of request.roles) {
 			if (!this._controller.roles.has(roleId)) {
-				throw new lib.RequestError(`Role with ID ${roleId} does not exist`);
+				throw new lib.ExpectedError(`Role with ID ${roleId} does not exist`);
 			}
 		}
 
@@ -1021,7 +1021,7 @@ export default class ControlConnection extends BaseConnection {
 				this.user.checkPermission("core.user.create");
 				user = this._controller.users.createUser(name);
 			} else {
-				throw new lib.RequestError(`User '${name}' does not exist`);
+				throw new lib.ExpectedError(`User '${name}' does not exist`);
 			}
 		}
 
@@ -1037,7 +1037,7 @@ export default class ControlConnection extends BaseConnection {
 				this.user.checkPermission("core.user.create");
 				user = this._controller.users.createUser(name);
 			} else {
-				throw new lib.RequestError(`User '${name}' does not exist`);
+				throw new lib.ExpectedError(`User '${name}' does not exist`);
 			}
 		}
 
@@ -1055,7 +1055,7 @@ export default class ControlConnection extends BaseConnection {
 				this.user.checkPermission("core.user.create");
 				user = this._controller.users.createUser(name);
 			} else {
-				throw new lib.RequestError(`User '${name}' does not exist`);
+				throw new lib.ExpectedError(`User '${name}' does not exist`);
 			}
 		}
 
@@ -1067,7 +1067,7 @@ export default class ControlConnection extends BaseConnection {
 		let name = request.name;
 		let user = this._controller.users.getByName(name);
 		if (!user) {
-			throw new lib.RequestError(`User '${name}' does not exist`);
+			throw new lib.ExpectedError(`User '${name}' does not exist`);
 		}
 
 		this._controller.users.deleteUser(user);
@@ -1288,21 +1288,21 @@ export default class ControlConnection extends BaseConnection {
 
 	async handleControllerUpdateRequest(request: lib.ControllerUpdateRequest) {
 		if (!this._controller.config.get("controller.allow_remote_updates")) {
-			throw new lib.RequestError("Remote updates are disabled on this machine");
+			throw new lib.ExpectedError("Remote updates are disabled on this machine");
 		}
 		return await lib.updatePackage("@clusterio/controller");
 	}
 
 	async handlePluginUpdateRequest(request: lib.PluginUpdateRequest) {
 		if (!this._controller.config.get("controller.allow_plugin_updates")) {
-			throw new lib.RequestError("Plugin updates are disabled on this machine");
+			throw new lib.ExpectedError("Plugin updates are disabled on this machine");
 		}
 		return await lib.handlePluginUpdate(request.pluginPackage, this._controller.pluginInfos);
 	}
 
 	async handlePluginInstallRequest(request: lib.PluginInstallRequest) {
 		if (!this._controller.config.get("controller.allow_plugin_install")) {
-			throw new lib.RequestError("Plugin installs are disabled on this machine");
+			throw new lib.ExpectedError("Plugin installs are disabled on this machine");
 		}
 		return await lib.handlePluginInstall(request.pluginPackage);
 	}

--- a/packages/controller/src/Controller.ts
+++ b/packages/controller/src/Controller.ts
@@ -1338,24 +1338,24 @@ export default class Controller {
 		} else if (dst.type === lib.Address.control) {
 			connection = this.wsServer.controlConnections.get(dst.id);
 			if (!connection) {
-				throw new lib.RequestError("Target control connection does not exist.");
+				throw new lib.ExpectedError("Target control connection does not exist.");
 			}
 
 		} else if (dst.type === lib.Address.instance) {
 			const instance = this.instances.getForRequest(dst.id);
 			let hostId = instance.config.get("instance.assigned_host");
 			if (hostId === null) {
-				throw new lib.RequestError("Instance is not assigned to a host");
+				throw new lib.ExpectedError("Instance is not assigned to a host");
 			}
 			connection = this.wsServer.hostConnections.get(hostId);
 			if (!connection) {
-				throw new lib.RequestError("Host containing instance is not connected");
+				throw new lib.ExpectedError("Host containing instance is not connected");
 			}
 
 		} else if (dst.type === lib.Address.host) {
 			connection = this.wsServer.hostConnections.get(dst.id);
 			if (!connection) {
-				throw new lib.RequestError("Host is not connected");
+				throw new lib.ExpectedError("Host is not connected");
 			}
 
 		} else {
@@ -1439,11 +1439,11 @@ export default class Controller {
 		let instance = this.instances.getForRequest(request.instanceId);
 		let hostId = instance.config.get("instance.assigned_host");
 		if (hostId === null) {
-			throw new lib.RequestError("Instance is not assigned to a host");
+			throw new lib.ExpectedError("Instance is not assigned to a host");
 		}
 		let connection = this.wsServer.hostConnections.get(hostId);
 		if (!connection) {
-			throw new lib.RequestError("Host containing instance is not connected");
+			throw new lib.ExpectedError("Host containing instance is not connected");
 		}
 		return await connection.send(request);
 	}

--- a/packages/controller/src/InstanceManager.ts
+++ b/packages/controller/src/InstanceManager.ts
@@ -65,12 +65,12 @@ export default class InstanceManager {
 	 *
 	 * @param instanceId - ID of instance to get.
 	 * @returns The instance record.
-	 * @throws {module:lib.RequestError} if the instance does not exist.
+	 * @throws {module:lib.ExpectedError} if the instance does not exist.
 	 */
 	getForRequest(instanceId: number): InstanceRecord {
 		const instance = this.records.get(instanceId);
 		if (!instance) {
-			throw new lib.RequestError(`Instance with ID ${instanceId} does not exist`);
+			throw new lib.ExpectedError(`Instance with ID ${instanceId} does not exist`);
 		}
 		return instance;
 	}
@@ -137,7 +137,7 @@ export default class InstanceManager {
 	 * @param instanceConfig - Config to base the newly created instance on.
 	 * @param _suppressChanges - When true, side effects are suppressed, caller takes ownership.
 	 * @returns The created instance record.
-	 * @throws {module:lib.RequestError} if an instance with the same ID already exists.
+	 * @throws {module:lib.ExpectedError} if an instance with the same ID already exists.
 	 */
 	async createInstance(
 		instanceConfig: lib.InstanceConfig,
@@ -145,7 +145,7 @@ export default class InstanceManager {
 	): Promise<InstanceRecord> {
 		const instanceId = instanceConfig.get("instance.id");
 		if (this.records.has(instanceId)) {
-			throw new lib.RequestError(`Instance with ID ${instanceId} already exists`);
+			throw new lib.ExpectedError(`Instance with ID ${instanceId} already exists`);
 		}
 
 		const controllerName = this._controller.config.get("controller.name");
@@ -184,8 +184,8 @@ export default class InstanceManager {
 	 * @param hostId - ID of host to assign the instance to. If undefined,
 	 * the instance will be unassigned.
 	 *
-	 * @throws {module:lib.RequestError} if the instance does not exist.
-	 * @throws {module:lib.RequestError} if the target host is not connected.
+	 * @throws {module:lib.ExpectedError} if the instance does not exist.
+	 * @throws {module:lib.ExpectedError} if the target host is not connected.
 	 */
 	async assignInstance(
 		instanceId: number,
@@ -203,7 +203,7 @@ export default class InstanceManager {
 		if (hostId !== null) {
 			newHostConnection = hostConnections.get(hostId);
 			if (!newHostConnection) {
-				throw new lib.RequestError("Target host is not connected to the controller");
+				throw new lib.ExpectedError("Target host is not connected to the controller");
 			}
 		}
 
@@ -251,7 +251,7 @@ export default class InstanceManager {
 	 *
 	 * @param instanceId - ID of instance to delete.
 	 *
-	 * @throws {module:lib.RequestError} if the instance does not exist.
+	 * @throws {module:lib.ExpectedError} if the instance does not exist.
 	 */
 	async deleteInstance(instanceId: number): Promise<void> {
 		const instance = this.getForRequest(instanceId);

--- a/packages/controller/src/routes.ts
+++ b/packages/controller/src/routes.ts
@@ -518,7 +518,7 @@ function checkModName(name: string) {
 	try {
 		lib.checkFilename(name);
 	} catch (err: any) {
-		throw new lib.RequestError(`Mod name ${err.message}`);
+		throw new lib.ExpectedError(`Mod name ${err.message}`);
 	}
 }
 

--- a/packages/ctl/ctl.ts
+++ b/packages/ctl/ctl.ts
@@ -324,7 +324,7 @@ async function startControl() {
 			logger.error(`Error running command: ${err.message}`);
 			process.exitCode = 1;
 
-		} else if (err instanceof lib.RequestError) {
+		} else if (err instanceof lib.ExpectedError) {
 			if (err.stack) {
 				logger.error(`Error sending request:\n${err.stack}`);
 			} else {

--- a/packages/host/src/Host.ts
+++ b/packages/host/src/Host.ts
@@ -23,7 +23,7 @@ function checkRequestSaveName(name: string) {
 	try {
 		lib.checkFilename(name);
 	} catch (err: any) {
-		throw new lib.RequestError(`Save name ${err.message}`);
+		throw new lib.ExpectedError(`Save name ${err.message}`);
 	}
 }
 
@@ -501,12 +501,12 @@ export default class Host extends lib.Link {
 
 	async handleHostRestartRequest() {
 		if (!this.canRestart) {
-			throw new lib.RequestError("Cannot restart, host does not have a process monitor to restart it.");
+			throw new lib.ExpectedError("Cannot restart, host does not have a process monitor to restart it.");
 		}
 		const downgrade = await this.checkRestartDowngrade();
 		if (downgrade) {
 			const { installedVersion, runningVersion } = downgrade;
-			throw new lib.RequestError(
+			throw new lib.ExpectedError(
 				`Cannot restart host with installed Clusterio version ${installedVersion} because it is older than ` +
 				`running version ${runningVersion}. Stop the host before starting the older version manually.`
 			);
@@ -523,7 +523,7 @@ export default class Host extends lib.Link {
 		if (fieldName === "host.id") {
 			// Changing host.id at runtime is not worth the effort to
 			// support and will break a lot of things if it is allowed.
-			throw new lib.RequestError("Setting 'host.id' while host is running is not supported");
+			throw new lib.ExpectedError("Setting 'host.id' while host is running is not supported");
 		}
 	}
 
@@ -768,7 +768,7 @@ export default class Host extends lib.Link {
 	getRequestInstance(instanceId: number) {
 		let instance = this.assignedInstances.get(instanceId);
 		if (!instance) {
-			throw new lib.RequestError(`Instance with ID ${instanceId} does not exist`);
+			throw new lib.ExpectedError(`Instance with ID ${instanceId} does not exist`);
 		}
 		return instance;
 	}
@@ -810,7 +810,7 @@ export default class Host extends lib.Link {
 			return assignedPort;
 		}
 		if (!availablePorts.size) {
-			throw new lib.RequestError("No available port left to assign from host.factorio_port_range");
+			throw new lib.ExpectedError("No available port left to assign from host.factorio_port_range");
 		}
 		const [newPort] = availablePorts;
 		instanceToAssign.config.set("factorio.host_assigned_game_port", newPort);
@@ -826,7 +826,7 @@ export default class Host extends lib.Link {
 	async _connectInstance(instanceId: number) {
 		let unloadedInstance = this.getRequestInstance(instanceId);
 		if (this.instanceConnections.has(instanceId)) {
-			throw new lib.RequestError(`Instance with ID ${instanceId} is running`);
+			throw new lib.ExpectedError(`Instance with ID ${instanceId} is running`);
 		}
 
 		let hostAddress = new lib.Address(lib.Address.host, this.config.get("host.id"));
@@ -978,10 +978,10 @@ export default class Host extends lib.Link {
 			await fs.unlink(path.join(instance.path, "saves", oldName));
 		} catch (err: any) {
 			if (err.code === "EEXIST") {
-				throw new lib.RequestError(`${newName} already exists`);
+				throw new lib.ExpectedError(`${newName} already exists`);
 			}
 			if (err.code === "ENOENT") {
-				throw new lib.RequestError(`${oldName} does not exist`);
+				throw new lib.ExpectedError(`${oldName} does not exist`);
 			}
 			throw err;
 		}
@@ -1001,7 +1001,7 @@ export default class Host extends lib.Link {
 			);
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				throw new lib.RequestError(`${source} does not exist`);
+				throw new lib.ExpectedError(`${source} does not exist`);
 			}
 			throw err;
 		}
@@ -1036,7 +1036,7 @@ export default class Host extends lib.Link {
 			}
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				throw new lib.RequestError(`${sourceName} does not exist`);
+				throw new lib.ExpectedError(`${sourceName} does not exist`);
 			}
 			throw err;
 		}
@@ -1067,7 +1067,7 @@ export default class Host extends lib.Link {
 			await fs.unlink(path.join(instance.path, "saves", name));
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				throw new lib.RequestError(`${name} does not exist`);
+				throw new lib.ExpectedError(`${name} does not exist`);
 			}
 			throw err;
 		}
@@ -1098,7 +1098,7 @@ export default class Host extends lib.Link {
 			content = (await fs.open(path.join(instance.path, "saves", name))).createReadStream();
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
-				throw new lib.RequestError(`${name} does not exist`);
+				throw new lib.ExpectedError(`${name} does not exist`);
 			}
 			throw err;
 		}
@@ -1117,12 +1117,12 @@ export default class Host extends lib.Link {
 	async handleInstanceDeleteInternalRequest(request: lib.InstanceDeleteInternalRequest) {
 		let instanceId = request.instanceId;
 		if (this.instanceConnections.has(instanceId)) {
-			throw new lib.RequestError(`Instance with ID ${instanceId} is running`);
+			throw new lib.ExpectedError(`Instance with ID ${instanceId} is running`);
 		}
 
 		let instance = this.discoveredInstances.get(instanceId);
 		if (!instance) {
-			throw new lib.RequestError(`Instance with ID ${instanceId} does not exist`);
+			throw new lib.ExpectedError(`Instance with ID ${instanceId} does not exist`);
 		}
 
 		this.discoveredInstances.delete(instanceId);
@@ -1132,21 +1132,21 @@ export default class Host extends lib.Link {
 
 	async handleHostUpdateRequest(request: lib.HostUpdateRequest) {
 		if (!this.config.get("host.allow_remote_updates")) {
-			throw new lib.RequestError("Remote updates are disabled on this machine");
+			throw new lib.ExpectedError("Remote updates are disabled on this machine");
 		}
 		return await lib.updatePackage("@clusterio/host");
 	}
 
 	async handlePluginUpdateRequest(request: lib.PluginUpdateRequest) {
 		if (!this.config.get("host.allow_plugin_updates")) {
-			throw new lib.RequestError("Plugin updates are disabled on this machine");
+			throw new lib.ExpectedError("Plugin updates are disabled on this machine");
 		}
 		return await lib.handlePluginUpdate(request.pluginPackage, this.pluginInfos);
 	}
 
 	async handlePluginInstallRequest(request: lib.PluginInstallRequest) {
 		if (!this.config.get("host.allow_plugin_install")) {
-			throw new lib.RequestError("Plugin installs are disabled on this machine");
+			throw new lib.ExpectedError("Plugin installs are disabled on this machine");
 		}
 		return await lib.handlePluginInstall(request.pluginPackage);
 	}

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -1249,7 +1249,7 @@ end`.replace(/\r?\n/g, " ");
 	async handleInstanceLoadScenarioRequest(request: lib.InstanceLoadScenarioRequest) {
 		if (this.config.get("factorio.enable_save_patching")) {
 			this.notifyExit();
-			throw new lib.RequestError("Load scenario cannot be used with save patching enabled");
+			throw new lib.ExpectedError("Load scenario cannot be used with save patching enabled");
 		}
 
 		try {
@@ -1310,7 +1310,7 @@ end`.replace(/\r?\n/g, " ");
 
 	async handleInstanceSaveGameRequest() {
 		if (this._status !== "running") {
-			throw new lib.RequestError("Instance is not running");
+			throw new lib.ExpectedError("Instance is not running");
 		}
 
 		const saved = new Promise<void>((resolve, reject) => {
@@ -1320,7 +1320,7 @@ end`.replace(/\r?\n/g, " ");
 			};
 			const onExit = () => {
 				this.server.off("save-finished", onSaved);
-				reject(new lib.RequestError("Instance stopped before the save finished"));
+				reject(new lib.ExpectedError("Instance stopped before the save finished"));
 			};
 			this.server.once("save-finished", onSaved);
 			this.server.once("exit", onExit);

--- a/packages/lib/src/config/classes.ts
+++ b/packages/lib/src/config/classes.ts
@@ -9,7 +9,7 @@ import * as libSchema from "../schema";
 import { StringEnum } from "../data/composites";
 import { safeOutputFile } from "../file_ops";
 import * as validators from "./validators";
-import { RequestError } from "../errors";
+import { ExpectedError } from "../errors";
 
 const ConfigLocation = StringEnum(["controller", "host", "control"]);
 export type ConfigLocation = Static<typeof ConfigLocation>;
@@ -22,7 +22,7 @@ export type ConfigLocation = Static<typeof ConfigLocation>;
  *
  * @extends Error
  */
-export class InvalidAccess extends RequestError { };
+export class InvalidAccess extends ExpectedError { };
 
 /**
  * Invalid Value exception
@@ -32,7 +32,7 @@ export class InvalidAccess extends RequestError { };
  *
  * @extends Error
  */
-export class InvalidValue extends RequestError { };
+export class InvalidValue extends ExpectedError { };
 
 /**
  * Invalid Field exception
@@ -42,7 +42,7 @@ export class InvalidValue extends RequestError { };
  *
  * @extends Error
  */
-export class InvalidField extends RequestError { };
+export class InvalidField extends ExpectedError { };
 
 
 const OldConfigGroupSchema = Type.Object({

--- a/packages/lib/src/errors.ts
+++ b/packages/lib/src/errors.ts
@@ -18,12 +18,17 @@ export class InstallationError extends Error {
 }
 
 /**
- * Thrown from requests sent when an error occured handling it
+ * Base class for errors that are part of normal program flow.
+ *
+ * Errors of this class are passed back to the requester without being
+ * logged as unexpected. Extend it for errors the caller is expected to
+ * handle, such as permission checks and validation failures. Also thrown
+ * from requests when the remote side responds with an error.
  */
-export class RequestError extends Error {
+export class ExpectedError extends Error {
 	constructor(
 		message: string,
-		public code = "RequestError",
+		public code = "ExpectedError",
 		public stack?: string,
 	) {
 		super(message);
@@ -31,13 +36,19 @@ export class RequestError extends Error {
 }
 
 /**
+ * @deprecated Use ExpectedError instead
+ */
+export const RequestError = ExpectedError;
+/** @deprecated Use ExpectedError instead */
+export type RequestError = ExpectedError;
+
+/**
  * Thrown when a permission check fails.
  *
- * Is a subclass of RequestError to prevent logging stack traces when
+ * Is a subclass of ExpectedError to prevent logging stack traces when
  * requests fail due to permission denied.
- *
  */
-export class PermissionError extends RequestError {
+export class PermissionError extends ExpectedError {
 	constructor(
 		message: string,
 		code = "PermissionError",
@@ -45,7 +56,6 @@ export class PermissionError extends RequestError {
 	) {
 		super(message, code, stack);
 	}
-
 }
 
 /**

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -426,7 +426,7 @@ export class Link {
 					if (err.errors) {
 						logger.error(JSON.stringify(err.errors, null, "\t"));
 					}
-				} else if (!(err instanceof libErrors.RequestError)) {
+				} else if (!(err instanceof libErrors.ExpectedError)) {
 					logger.error(`Unexpected error responding to ${message.name}:\n${err.stack}`);
 				}
 				try {
@@ -470,7 +470,7 @@ export class Link {
 		}
 
 		this._pendingRequests.delete(message.dst.requestId!);
-		pending.reject(new libErrors.RequestError(message.data.message, message.data.code, message.data.stack));
+		pending.reject(new libErrors.ExpectedError(message.data.message, message.data.code, message.data.stack));
 	}
 
 	_processEvent(message: libData.MessageEvent, entry: EventEntry) {

--- a/packages/lib/src/rce_ops.ts
+++ b/packages/lib/src/rce_ops.ts
@@ -2,7 +2,7 @@ import util from "util";
 import path from "path";
 import { exec } from "child_process";
 import { logger } from "./logging";
-import { RequestError } from "./errors";
+import { ExpectedError } from "./errors";
 import { PluginNodeEnvInfo } from "./plugin";
 const execAsync = util.promisify(exec);
 
@@ -29,7 +29,7 @@ export async function installPackage(name: string) {
 
 export async function handlePluginUpdate(pluginName: string, pluginInfos: PluginNodeEnvInfo[]) {
 	if (!pluginInfos.some(plugin => plugin.npmPackage === pluginName)) {
-		throw new RequestError(`Plugin ${pluginName} is not installed on this machine`);
+		throw new ExpectedError(`Plugin ${pluginName} is not installed on this machine`);
 	}
 
 	return await updatePackage(pluginName);
@@ -39,7 +39,7 @@ export async function handlePluginInstall(pluginName: string) {
 	if (pluginName.length > 214 || /[^a-zA-Z0-9\-_.+@\/]/.test(pluginName)) {
 		// https://docs.npmjs.com/cli/v11/configuring-npm/package-json#name
 		// https://www.npmjs.com/package/validate-npm-package-name
-		throw new RequestError(`Invalid plugin name: ${pluginName}`);
+		throw new ExpectedError(`Invalid plugin name: ${pluginName}`);
 	}
 
 	const packageName = encodeURI(pluginName);
@@ -47,7 +47,7 @@ export async function handlePluginInstall(pluginName: string) {
 		method: "HEAD",
 	});
 	if (!npmRequest.ok) {
-		throw new RequestError(`Unknown plugin: ${packageName}`);
+		throw new ExpectedError(`Unknown plugin: ${packageName}`);
 	}
 
 	return await installPackage(packageName);

--- a/packages/lib/src/subscriptions.ts
+++ b/packages/lib/src/subscriptions.ts
@@ -2,7 +2,7 @@ import { Type, Static } from "@sinclair/typebox";
 import { Link, Event, EventClass, RequestHandler, WebSocketBaseConnector } from "./link";
 import { Address, MessageRequest, IUser, JsonBoolean, StringEnum, AccountDetails } from "./data";
 import isDeepStrictEqual from "./is_deep_strict_equal";
-import { RequestError } from "./errors";
+import { ExpectedError } from "./errors";
 import { logger } from "./logging";
 
 export type SubscriptionRequestHandler<T> = RequestHandler<SubscriptionRequest, Event<T> | null>;
@@ -596,7 +596,7 @@ export class EventSubscriber<E, S = null> {
 				this._notify(null);
 			}
 		} catch (err: any) {
-			if (!(err instanceof RequestError) || err.code !== "SessionLost") {
+			if (!(err instanceof ExpectedError) || err.code !== "SessionLost") {
 				logger.error(`Unexpected error updating ${entry.name} subscription:\n${err.stack}`);
 			}
 			if (err instanceof Error) {

--- a/plugins/player_auth/controller.ts
+++ b/plugins/player_auth/controller.ts
@@ -207,7 +207,7 @@ export class ControllerPlugin extends BaseControllerPlugin {
 
 		let entry = this.players.get(player);
 		if (!entry || entry.expiresMs < Date.now()) {
-			throw new lib.RequestError("invalid player");
+			throw new lib.ExpectedError("invalid player");
 		}
 
 		entry.verifyCode = verifyCode;

--- a/plugins/player_auth/test/plugin.js
+++ b/plugins/player_auth/test/plugin.js
@@ -314,7 +314,7 @@ describe("player_auth", function() {
 						controllerPlugin.handleSetVerifyCodeRequest(
 							new SetVerifyCodeRequest("invalid", "invalid")
 						),
-						new lib.RequestError("invalid player")
+						new lib.ExpectedError("invalid player")
 					);
 				});
 				it("should throw if player code has expired", async function() {
@@ -324,7 +324,7 @@ describe("player_auth", function() {
 						controllerPlugin.handleSetVerifyCodeRequest(
 							new SetVerifyCodeRequest("expired", "expired")
 						),
-						new lib.RequestError("invalid player")
+						new lib.ExpectedError("invalid player")
 					);
 				});
 			});

--- a/test/controller/Controller.js
+++ b/test/controller/Controller.js
@@ -8,7 +8,7 @@ const http = require("node:http");
 const express = require("express");
 
 const {
-	ControllerConfig, Address, RequestError,
+	ControllerConfig, Address, ExpectedError,
 	InstanceConfig, SystemInfo, Role, ModPack,
 } = require("@clusterio/lib");
 
@@ -129,33 +129,33 @@ describe("controller/src/Controller", function() {
 			it("should error on invalid controller", function() {
 				assert.throws(
 					() => controller.sendRequest(new MockEvent(), Address.fromShorthand({ controlId: 99 })),
-					new RequestError("Target control connection does not exist.")
+					new ExpectedError("Target control connection does not exist.")
 				);
 			});
 			it("should error on invalid instance", function() {
 				assert.throws(
 					() => controller.sendRequest(new MockEvent(), Address.fromShorthand({ instanceId: 99 })),
-					new RequestError("Instance with ID 99 does not exist")
+					new ExpectedError("Instance with ID 99 does not exist")
 				);
 			});
 			it("should error on unassigned instance", function() {
 				mockInstanceConfig.set("instance.assigned_host", null);
 				assert.throws(
 					() => controller.sendRequest(new MockEvent(), Address.fromShorthand({ instanceId: 100 })),
-					new RequestError("Instance is not assigned to a host")
+					new ExpectedError("Instance is not assigned to a host")
 				);
 			});
 			it("should error on instance with disconnected host", function() {
 				mockInstanceConfig.set("instance.assigned_host", 99);
 				assert.throws(
 					() => controller.sendRequest(new MockEvent(), Address.fromShorthand({ instanceId: 100 })),
-					new RequestError("Host containing instance is not connected")
+					new ExpectedError("Host containing instance is not connected")
 				);
 			});
 			it("should error on invalid host", function() {
 				assert.throws(
 					() => controller.sendRequest(new MockEvent(), Address.fromShorthand({ hostId: 99 })),
-					new RequestError("Host is not connected")
+					new ExpectedError("Host is not connected")
 				);
 			});
 			it("should error on invalid broadcast", function() {

--- a/test/controller/InstanceManager.test.js
+++ b/test/controller/InstanceManager.test.js
@@ -102,7 +102,7 @@ describe("controller/InstanceManager", function () {
 		});
 
 		it("should throw when missing", function () {
-			assert.throws(() => instances.getForRequest(999), lib.RequestError);
+			assert.throws(() => instances.getForRequest(999), lib.ExpectedError);
 		});
 	});
 
@@ -149,7 +149,7 @@ describe("controller/InstanceManager", function () {
 
 			await assert.rejects(
 				() => instances.createInstance(config),
-				lib.RequestError
+				lib.ExpectedError
 			);
 		});
 
@@ -173,7 +173,7 @@ describe("controller/InstanceManager", function () {
 		it("should throw if host not connected", async function () {
 			await assert.rejects(
 				() => instances.assignInstance(1, 5),
-				lib.RequestError
+				lib.ExpectedError
 			);
 		});
 
@@ -205,7 +205,7 @@ describe("controller/InstanceManager", function () {
 
 			await assert.rejects(
 				() => instances.assignInstance(1, 6),
-				lib.RequestError
+				lib.ExpectedError
 			);
 
 			assert.equal(unassignRequest, undefined);

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -690,7 +690,7 @@ describe("Integration of Clusterio", function() {
 				slowTest(this);
 				await assert.rejects(
 					execCtl("instance create testClone --id 440 --from 441"),
-					new lib.RequestError("Instance with ID 441 does not exist")
+					new lib.ExpectedError("Instance with ID 441 does not exist")
 				);
 			});
 		});

--- a/test/lib/errors.js
+++ b/test/lib/errors.js
@@ -4,6 +4,23 @@ const assert = require("assert").strict;
 const lib = require("@clusterio/lib");
 
 describe("lib/errors", function() {
+	describe("class ExpectedError", function() {
+		it("should default the code to the class name", function() {
+			let err = new lib.ExpectedError("Something failed");
+			assert.equal(err.code, "ExpectedError");
+			assert.equal(err.message, "Something failed");
+		});
+		it("should be extended by the errors passed back to requesters", function() {
+			assert(new lib.PermissionError("Denied") instanceof lib.ExpectedError);
+			assert(new lib.InvalidAccess("Denied") instanceof lib.ExpectedError);
+			assert(new lib.InvalidValue("Bad") instanceof lib.ExpectedError);
+			assert(new lib.InvalidField("Bad") instanceof lib.ExpectedError);
+		});
+		it("should still be available under the deprecated RequestError name", function() {
+			assert.equal(lib.RequestError, lib.ExpectedError);
+			assert(new lib.RequestError("Old name") instanceof lib.ExpectedError);
+		});
+	});
 	describe("class InvalidMessage", function() {
 		it("should include validation errors in the stack", function() {
 			let errors = [{ instancePath: "/value", message: "must be number" }];

--- a/test/lib/subscriptions.test.js
+++ b/test/lib/subscriptions.test.js
@@ -1169,13 +1169,13 @@ describe("lib/subscriptions", function() {
 				assert.notEqual(logged, undefined);
 			});
 
-			it("should not log error when sendTo throws SessionLost RequestError", async function() {
+			it("should not log error when sendTo throws SessionLost ExpectedError", async function() {
 				let logged;
 				const originalError = lib.logger.error;
 				lib.logger.error = msg => { logged = msg; };
 
 				mockControl.sendTo = async function() {
-					const err = new lib.RequestError("Session lost");
+					const err = new lib.ExpectedError("Session lost");
 					err.code = "SessionLost";
 					throw err;
 				};


### PR DESCRIPTION
`RequestError` began as the marker for errors that should be passed back to the requester instead of logged, but it has become the base class for any error that is part of normal control flow. `PermissionError`, `InvalidAccess`, `InvalidValue` and `InvalidField` all extend it. This renames it to `ExpectedError`, which reads naturally next to the "Unexpected error responding to ..." log line that the check in `Link` guards.

I picked `ExpectedError` over alternatives like `OperationalError` or `HandledError` because it describes the contract directly: this error is expected, do not log it as a bug. Happy to change the name if there is a preference.

`RequestError` is kept as a deprecated alias (both value and type) so plugins keep compiling and running. The default `code` sent in error responses changes from `RequestError` to `ExpectedError`; nothing in the repo compares against that string.

The alpha 14 migration doc still shows `lib.RequestError` in its examples. I left it alone since it documents that specific migration, but can update it if wanted.

### Changelog
```
### Changes
- Renamed `RequestError` to `ExpectedError` to reflect its use as the base class for all errors that are part of normal control flow. `RequestError` remains as a deprecated alias. #900
```

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
