### PR TITLE
Add a plugin browser backed by npm keyword search

### DIFF
--- a/docs/managing-a-cluster.md
+++ b/docs/managing-a-cluster.md
@@ -254,6 +254,15 @@ If remote plugin updates are enabled on the remote, this will execute `npm updat
 
 If remote plugin installs are enabled on the remote, this will execute `npm install --save <name>`. Changes will not be applied until the remote is restarted. If the `--restart` flag is provided, the remote will automatically restart once the update is complete.
 
+### Search
+
+    ctl> controller plugin search [query] [--page <n>] [--page-size <n>]
+
+Searches the npm registry for packages tagged with the clusterio-plugin keyword.
+The search is done by the controller and does not require remote installs to be enabled.
+The web UI has a plugin browser on the plugins page that uses the same search and can install the result to the controller, selected hosts, or all hosts that allow remote installs.
+
+
 ### Enable/Disable Updates
 
     host> config set host.allow_plugin_updates true/false

--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -128,6 +128,7 @@ export default class ControlConnection extends BaseConnection {
 		this.handle(lib.PluginListRequest, this.handlePluginListRequest.bind(this));
 		this.handle(lib.PluginUpdateRequest, this.handlePluginUpdateRequest.bind(this));
 		this.handle(lib.PluginInstallRequest, this.handlePluginInstallRequest.bind(this));
+		this.handle(lib.PluginSearchRequest, this.handlePluginSearchRequest.bind(this));
 		this.handle(lib.DebugDumpWsRequest, this.handleDebugDumpWsRequest.bind(this));
 	}
 
@@ -1305,6 +1306,10 @@ export default class ControlConnection extends BaseConnection {
 			throw new lib.RequestError("Plugin installs are disabled on this machine");
 		}
 		return await lib.handlePluginInstall(request.pluginPackage);
+	}
+
+	async handlePluginSearchRequest(request: lib.PluginSearchRequest) {
+		return await lib.searchPlugins(request.query, request.page, request.pageSize);
 	}
 
 	async handlePluginListRequest(request: lib.PluginListRequest) {

--- a/packages/ctl/src/commands_controller.ts
+++ b/packages/ctl/src/commands_controller.ts
@@ -184,6 +184,25 @@ controllerPluginCommands.add(new lib.Command({
 	},
 }));
 controllerPluginCommands.add(new lib.Command({
+	definition: ["search [query]", "Search npm for plugins", (yargs) => {
+		yargs.positional("query", { describe: "Text to search for", type: "string", default: "" });
+		yargs.option("page", { type: "number", description: "Page of results to show", default: 1 });
+		yargs.option("page-size", { type: "number", description: "Results per page", default: 20 });
+	}],
+	handler: async function(args: { query: string, page: number, pageSize: number }, control: Control) {
+		const response = await control.sendTo(
+			"controller", new lib.PluginSearchRequest(args.query, args.page, args.pageSize)
+		);
+		print(asTable(response.results.map(plugin => ({
+			name: plugin.name,
+			version: plugin.version,
+			publisher: plugin.publisher ?? "",
+			description: plugin.description ?? "",
+		}))));
+		print(`Showing ${response.results.length} of ${response.total} results`);
+	},
+}));
+controllerPluginCommands.add(new lib.Command({
 	definition: ["install <plugin>", "Install a plugin on the controller", (yargs) => {
 		yargs.positional("plugin", { describe: "Plugin to install", type: "string" });
 		yargs.option("restart", { alias: "r", type: "boolean", description: "Restart after update" });

--- a/packages/lib/src/data/messages_plugin.ts
+++ b/packages/lib/src/data/messages_plugin.ts
@@ -91,3 +91,75 @@ export class PluginInstallRequest {
 		return this.pluginPackage;
 	}
 }
+
+/* Plugin package listed on the npm registry */
+export class PluginSearchResult {
+	constructor(
+		public name: string,
+		public version: string,
+		public description?: string,
+		public publisher?: string,
+		public date?: string,
+		public homepage?: string,
+		public repository?: string,
+		public npm?: string,
+	) {}
+
+	static jsonSchema = Type.Object({
+		name: Type.String(),
+		version: Type.String(),
+		description: Type.Optional(Type.String()),
+		publisher: Type.Optional(Type.String()),
+		date: Type.Optional(Type.String()),
+		homepage: Type.Optional(Type.String()),
+		repository: Type.Optional(Type.String()),
+		npm: Type.Optional(Type.String()),
+	});
+
+	static fromJSON(json: Static<typeof this.jsonSchema>) {
+		return new this(
+			json.name, json.version, json.description, json.publisher,
+			json.date, json.homepage, json.repository, json.npm,
+		);
+	}
+}
+
+export class PluginSearchRequest {
+	declare ["constructor"]: typeof PluginSearchRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static permission = "core.plugin.search";
+
+	constructor(
+		public query: string = "",
+		public page: number = 1,
+		public pageSize: number = 20,
+	) {}
+
+	static jsonSchema = Type.Object({
+		query: Type.String(),
+		page: Type.Integer(),
+		pageSize: Type.Integer(),
+	});
+
+	static fromJSON(json: Static<typeof this.jsonSchema>) {
+		return new this(json.query, json.page, json.pageSize);
+	}
+
+	static Response = class Response {
+		constructor(
+			public total: number,
+			public results: PluginSearchResult[],
+		) {}
+
+		static jsonSchema = Type.Object({
+			total: Type.Integer(),
+			results: Type.Array(PluginSearchResult.jsonSchema),
+		});
+
+		static fromJSON(json: Static<typeof this.jsonSchema>) {
+			return new this(json.total, json.results.map(r => PluginSearchResult.fromJSON(r)));
+		}
+	};
+}

--- a/packages/lib/src/link/messages.ts
+++ b/packages/lib/src/link/messages.ts
@@ -140,4 +140,5 @@ export const dataClasses: (RequestClass<unknown, unknown> | EventClass<unknown>)
 	plugin.PluginListRequest,
 	plugin.PluginUpdateRequest,
 	plugin.PluginInstallRequest,
+	plugin.PluginSearchRequest,
 ];

--- a/packages/lib/src/permissions.ts
+++ b/packages/lib/src/permissions.ts
@@ -512,6 +512,11 @@ definePermission({
 	title: "Install plugin",
 	description: "Remotely install a plugin if the target allows remote installs of plugins.",
 });
+definePermission({
+	name: "core.plugin.search",
+	title: "Search plugins",
+	description: "Search the npm registry for plugins via the controller.",
+});
 
 definePermission({
 	name: "core.debug.dump_ws",

--- a/packages/lib/src/rce_ops.ts
+++ b/packages/lib/src/rce_ops.ts
@@ -4,6 +4,7 @@ import { exec } from "child_process";
 import { logger } from "./logging";
 import { RequestError } from "./errors";
 import { PluginNodeEnvInfo } from "./plugin";
+import { PluginSearchRequest, PluginSearchResult } from "./data/messages_plugin";
 const execAsync = util.promisify(exec);
 
 function isDev() {
@@ -51,4 +52,47 @@ export async function handlePluginInstall(pluginName: string) {
 	}
 
 	return await installPackage(packageName);
+}
+
+const npmSearchMaxSize = 250; // Limit imposed by the registry
+
+export async function searchPlugins(query: string, page: number, pageSize: number) {
+	if (query.length > 214) {
+		throw new RequestError("Search query too long");
+	}
+	if (page < 1 || pageSize < 1 || pageSize > npmSearchMaxSize) {
+		throw new RequestError("Invalid page or page size");
+	}
+
+	const url = new URL("https://registry.npmjs.com/-/v1/search");
+	url.searchParams.set("text", `keywords:clusterio-plugin ${query}`.trim());
+	url.searchParams.set("size", String(pageSize));
+	url.searchParams.set("from", String((page - 1) * pageSize));
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new RequestError(`npm registry search failed: ${response.status} ${response.statusText}`);
+	}
+
+	const json = await response.json() as {
+		total: number,
+		objects: {
+			package: {
+				name: string,
+				version: string,
+				description?: string,
+				date?: string,
+				publisher?: { username?: string },
+				links?: { npm?: string, homepage?: string, repository?: string },
+			},
+		}[],
+	};
+
+	return new PluginSearchRequest.Response(
+		json.total,
+		json.objects.map(({ package: pkg }) => new PluginSearchResult(
+			pkg.name, pkg.version, pkg.description, pkg.publisher?.username,
+			pkg.date, pkg.links?.homepage, pkg.links?.repository, pkg.links?.npm,
+		)),
+	);
 }

--- a/packages/web_ui/src/components/PluginBrowser.tsx
+++ b/packages/web_ui/src/components/PluginBrowser.tsx
@@ -1,0 +1,246 @@
+import { useContext, useEffect, useState } from "react";
+import { Button, Descriptions, Input, Modal, Select, Space, Table, Tag, Typography } from "antd";
+import SearchOutlined from "@ant-design/icons/SearchOutlined";
+
+import * as lib from "@clusterio/lib";
+
+import { useAccount } from "../model/account";
+import { useHosts } from "../model/host";
+import notify, { notifyErrorHandler } from "../util/notify";
+import ControlContext from "./ControlContext";
+
+const { Text, Link } = Typography;
+
+type InstallTarget = { name: string, address: lib.AddressShorthand };
+
+// Which targets accept remote plugin installs, assumed true when the config can't be read.
+function useInstallAllowed() {
+	const control = useContext(ControlContext);
+	const account = useAccount();
+	const [hosts] = useHosts();
+	const [controllerAllowed, setControllerAllowed] = useState(true);
+	const [hostsAllowed, setHostsAllowed] = useState(new Map<number, boolean>());
+	const connectedHostIds = [...hosts.values()].filter(host => host.connected).map(host => host.id);
+
+	useEffect(() => {
+		if (!account.hasPermission("core.controller.get_config")) {
+			return;
+		}
+		control.send(new lib.ControllerConfigGetRequest()).then(serializedConfig => {
+			const config = lib.ControllerConfig.fromJSON(serializedConfig, "control");
+			setControllerAllowed(config.get("controller.allow_plugin_install"));
+		}).catch(notifyErrorHandler("Failed to fetch controller config"));
+	}, []);
+
+	useEffect(() => {
+		if (!account.hasPermission("core.host.get_config")) {
+			return;
+		}
+		Promise.all(connectedHostIds.map(async hostId => {
+			try {
+				const serializedConfig = await control.sendTo({ hostId }, new lib.HostConfigGetRequest());
+				const config = lib.HostConfig.fromJSON(serializedConfig, "control");
+				return [hostId, config.get("host.allow_plugin_install")] as const;
+			} catch (err) {
+				return [hostId, true] as const;
+			}
+		})).then(entries => { setHostsAllowed(new Map(entries)); });
+	}, [connectedHostIds.join(",")]);
+
+	return {
+		controller: controllerAllowed,
+		host: (hostId: number) => hostsAllowed.get(hostId) ?? true,
+	};
+}
+
+function InstallControls(props: { plugin: lib.PluginSearchResult }) {
+	const control = useContext(ControlContext);
+	const account = useAccount();
+	const [hosts] = useHosts();
+	const allowed = useInstallAllowed();
+	const [selectedHostIds, setSelectedHostIds] = useState<number[]>([]);
+	const [installing, setInstalling] = useState(false);
+
+	const connectedHosts = [...hosts.values()].filter(host => host.connected);
+	const eligibleHosts = connectedHosts.filter(host => allowed.host(host.id));
+	const canInstall = account.hasPermission("core.plugin.install");
+
+	async function install(targets: InstallTarget[]) {
+		setInstalling(true);
+		try {
+			const results = await Promise.allSettled(targets.map(
+				target => control.sendTo(target.address, new lib.PluginInstallRequest(props.plugin.name))
+			));
+			const installed = targets.filter((_, i) => results[i].status === "fulfilled");
+			if (installed.length) {
+				notify(
+					`Installed ${props.plugin.name}`, "success",
+					`Installed on ${installed.map(t => t.name).join(", ")}. A restart is required to load it.`,
+				);
+			}
+			results.forEach((result, i) => {
+				if (result.status === "rejected") {
+					notifyErrorHandler(`Failed to install ${props.plugin.name} on ${targets[i].name}`)(result.reason);
+				}
+			});
+		} finally {
+			setInstalling(false);
+		}
+	}
+
+	const hostTarget = (host: lib.HostDetails): InstallTarget => ({ name: host.name, address: { hostId: host.id } });
+
+	return <Space wrap>
+		<Button
+			type="primary"
+			loading={installing}
+			disabled={!canInstall || !allowed.controller}
+			onClick={() => { install([{ name: "controller", address: "controller" }]); }}
+		>Install to controller</Button>
+		<Select
+			mode="multiple"
+			style={{ minWidth: 200 }}
+			placeholder="Select hosts"
+			value={selectedHostIds}
+			onChange={setSelectedHostIds}
+			options={connectedHosts.map(host => ({
+				value: host.id,
+				label: allowed.host(host.id) ? host.name : `${host.name} (remote install disabled)`,
+				disabled: !allowed.host(host.id),
+			}))}
+		/>
+		<Button
+			loading={installing}
+			disabled={!canInstall || !selectedHostIds.length}
+			onClick={() => {
+				install(connectedHosts.filter(host => selectedHostIds.includes(host.id)).map(hostTarget));
+			}}
+		>Install to selected hosts</Button>
+		<Button
+			loading={installing}
+			disabled={!canInstall || !eligibleHosts.length}
+			onClick={() => { install(eligibleHosts.map(hostTarget)); }}
+		>Install to all hosts</Button>
+	</Space>;
+}
+
+function PluginDetails(props: { plugin: lib.PluginSearchResult }) {
+	const { plugin } = props;
+	return <>
+		<Descriptions size="small" column={1} bordered style={{ marginBottom: 16 }}>
+			<Descriptions.Item label="Package">{plugin.name}</Descriptions.Item>
+			<Descriptions.Item label="Version">{plugin.version}</Descriptions.Item>
+			{plugin.description && <Descriptions.Item label="Description">{plugin.description}</Descriptions.Item>}
+			{plugin.publisher && <Descriptions.Item label="Publisher">{plugin.publisher}</Descriptions.Item>}
+			{plugin.date && <Descriptions.Item label="Published">
+				{new Date(plugin.date).toLocaleString()}
+			</Descriptions.Item>}
+			<Descriptions.Item label="Links">
+				<Space wrap>
+					{plugin.npm && <Link href={plugin.npm} target="_blank">npm</Link>}
+					{plugin.homepage && <Link href={plugin.homepage} target="_blank">Homepage</Link>}
+					{plugin.repository && <Link href={plugin.repository} target="_blank">Repository</Link>}
+				</Space>
+			</Descriptions.Item>
+		</Descriptions>
+		<InstallControls plugin={plugin} />
+	</>;
+}
+
+export function PluginBrowserButton() {
+	const control = useContext(ControlContext);
+	const account = useAccount();
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const [page, setPage] = useState(1);
+	const [pageSize, setPageSize] = useState(10);
+	const [loading, setLoading] = useState(false);
+	const [total, setTotal] = useState(0);
+	const [results, setResults] = useState<lib.PluginSearchResult[]>([]);
+	const [selected, setSelected] = useState<lib.PluginSearchResult | undefined>();
+	const [installed, setInstalled] = useState(new Set<string>());
+
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		setLoading(true);
+		let canceled = false;
+		control.send(new lib.PluginSearchRequest(query, page, pageSize)).then(response => {
+			if (canceled) { return; }
+			setTotal(response.total);
+			setResults(response.results);
+			setSelected(current => response.results.find(r => r.name === current?.name));
+		}).catch(notifyErrorHandler("Error searching for plugins")).finally(() => {
+			if (!canceled) { setLoading(false); }
+		});
+		// eslint-disable-next-line consistent-return
+		return () => { canceled = true; };
+	}, [open, query, page, pageSize]);
+
+	useEffect(() => {
+		if (!open || !account.hasPermission("core.plugin.list")) {
+			return;
+		}
+		control.send(new lib.PluginListRequest()).then(plugins => {
+			setInstalled(new Set(plugins.flatMap(p => (p.npmPackage ? [p.npmPackage] : []))));
+		}).catch(notifyErrorHandler("Error fetching installed plugins"));
+	}, [open]);
+
+	return <>
+		<Button icon={<SearchOutlined />} onClick={() => { setOpen(true); }}>Browse plugins</Button>
+		<Modal
+			title="Browse plugins"
+			open={open}
+			onCancel={() => { setOpen(false); }}
+			width={1000}
+			footer={<Button onClick={() => { setOpen(false); }}>Close</Button>}
+		>
+			<Input.Search
+				placeholder="Search npm for plugins"
+				allowClear
+				enterButton
+				style={{ marginBottom: 16 }}
+				onSearch={value => { setQuery(value); setPage(1); }}
+			/>
+			<Table
+				size="small"
+				loading={loading}
+				dataSource={results}
+				rowKey="name"
+				rowClassName={plugin => (plugin.name === selected?.name ? "ant-table-row-selected" : "")}
+				onRow={plugin => ({ onClick: () => { setSelected(plugin); }, style: { cursor: "pointer" } })}
+				pagination={{
+					current: page,
+					pageSize,
+					total,
+					showSizeChanger: true,
+					onChange: (newPage, newPageSize) => { setPage(newPage); setPageSize(newPageSize); },
+				}}
+				columns={[
+					{
+						title: "Name",
+						key: "name",
+						render: (_, plugin) => <>
+							{plugin.name}
+							{installed.has(plugin.name) && <Tag style={{ marginLeft: 8 }}>Installed on controller</Tag>}
+						</>,
+					},
+					{ title: "Version", dataIndex: "version", key: "version", width: 120 },
+					{ title: "Publisher", dataIndex: "publisher", key: "publisher", width: 160, responsive: ["md"] },
+					{
+						title: "Description",
+						dataIndex: "description",
+						key: "description",
+						ellipsis: true,
+						responsive: ["lg"],
+					},
+				]}
+			/>
+			{selected
+				? <PluginDetails plugin={selected} />
+				: <Text type="secondary">Select a plugin to see details and install it.</Text>
+			}
+		</Modal>
+	</>;
+}

--- a/packages/web_ui/src/components/PluginsPage.tsx
+++ b/packages/web_ui/src/components/PluginsPage.tsx
@@ -6,7 +6,9 @@ import InfoCircleFilled from "@ant-design/icons/InfoCircleFilled";
 import type { PluginWebApi, PluginWebpackEnvInfo } from "@clusterio/lib";
 
 import notify from "../util/notify";
+import { useAccount } from "../model/account";
 import ControlContext from "./ControlContext";
+import { PluginBrowserButton } from "./PluginBrowser";
 import PageLayout from "./PageLayout";
 import PageHeader from "./PageHeader";
 import useTableQueryState from "../util/useTableQueryState";
@@ -25,6 +27,7 @@ type PluginRow = {
 
 export default function PluginsPage() {
 	const control = useContext(ControlContext);
+	const account = useAccount();
 	let [pluginList, setPluginList] = useState<PluginWebApi[]>([]);
 	const tableState = useTableQueryState<PluginRow>({
 		namespace: "plugin", defaultSortKey: "name",
@@ -63,7 +66,10 @@ export default function PluginsPage() {
 	}
 
 	return <PageLayout nav={[{ name: "Plugins" }]}>
-		<PageHeader title="Plugins" />
+		<PageHeader
+			title="Plugins"
+			extra={account.hasPermission("core.plugin.search") ? <PluginBrowserButton /> : undefined}
+		/>
 		<Table
 			columns={[
 				{

--- a/test/integration/clusterio.js
+++ b/test/integration/clusterio.js
@@ -518,6 +518,18 @@ describe("Integration of Clusterio", function() {
 			// Install always fails, we can not test restart option
 		});
 
+		describe("controller plugin search", function() {
+			it("runs", async function() {
+				await execCtl("controller plugin search global_chat --page-size 5");
+			});
+			it("rejects invalid paging", async function() {
+				await assert.rejects(
+					execCtl("controller plugin search --page 0"),
+					/Invalid page or page size/
+				);
+			});
+		});
+
 		describe("controller update", function() {
 			it("runs", async function() {
 				await execCtl("controller update");

--- a/test/lib/rce_ops.js
+++ b/test/lib/rce_ops.js
@@ -73,4 +73,84 @@ describe("rce_ops", function() {
 			assert.equal(calledWith, "https://registry.npmjs.com/foo");
 		});
 	});
+
+	describe("searchPlugins", function() {
+		const _fetch = global.fetch;
+		const registryResponse = {
+			total: 1,
+			objects: [{
+				package: {
+					name: "@clusterio/plugin-foo",
+					version: "1.0.0",
+					description: "Foo",
+					date: "2026-01-01T00:00:00.000Z",
+					publisher: { username: "bar" },
+					links: {
+						npm: "https://www.npmjs.com/package/@clusterio/plugin-foo",
+						homepage: "https://example.com",
+						repository: "https://github.com/example/foo",
+					},
+				},
+			}],
+		};
+		after(function() {
+			global.fetch = _fetch;
+		});
+
+		it("queries the registry with the plugin keyword", async function() {
+			let calledWith;
+			global.fetch = function(url) {
+				calledWith = new URL(url);
+				return { ok: true, json: async () => registryResponse };
+			};
+
+			const response = await lib.searchPlugins("foo", 2, 10);
+			assert.equal(calledWith.origin + calledWith.pathname, "https://registry.npmjs.com/-/v1/search");
+			assert.equal(calledWith.searchParams.get("text"), "keywords:clusterio-plugin foo");
+			assert.equal(calledWith.searchParams.get("size"), "10");
+			assert.equal(calledWith.searchParams.get("from"), "10");
+			assert.deepEqual(response, new lib.PluginSearchRequest.Response(1, [
+				new lib.PluginSearchResult(
+					"@clusterio/plugin-foo", "1.0.0", "Foo", "bar", "2026-01-01T00:00:00.000Z",
+					"https://example.com", "https://github.com/example/foo",
+					"https://www.npmjs.com/package/@clusterio/plugin-foo",
+				),
+			]));
+		});
+		it("omits the query when empty", async function() {
+			let calledWith;
+			global.fetch = function(url) {
+				calledWith = new URL(url);
+				return { ok: true, json: async () => ({ total: 0, objects: [] }) };
+			};
+
+			await lib.searchPlugins("", 1, 20);
+			assert.equal(calledWith.searchParams.get("text"), "keywords:clusterio-plugin");
+			assert.equal(calledWith.searchParams.get("from"), "0");
+		});
+		it("handles missing optional fields", async function() {
+			global.fetch = function() {
+				return { ok: true, json: async () => ({ total: 1, objects: [{
+					package: { name: "foo", version: "1.0.0" },
+				}]}) };
+			};
+
+			const response = await lib.searchPlugins("", 1, 20);
+			assert.deepEqual(response.results, [new lib.PluginSearchResult("foo", "1.0.0")]);
+		});
+		it("rejects invalid paging", async function() {
+			await assert.rejects(lib.searchPlugins("", 0, 20), /Invalid page or page size/);
+			await assert.rejects(lib.searchPlugins("", 1, 0), /Invalid page or page size/);
+			await assert.rejects(lib.searchPlugins("", 1, 251), /Invalid page or page size/);
+		});
+		it("rejects overly long queries", async function() {
+			await assert.rejects(lib.searchPlugins("a".repeat(215), 1, 20), /Search query too long/);
+		});
+		it("rejects when the registry errors", async function() {
+			global.fetch = function() {
+				return { ok: false, status: 503, statusText: "Service Unavailable" };
+			};
+			await assert.rejects(lib.searchPlugins("", 1, 20), /npm registry search failed: 503/);
+		});
+	});
 });

--- a/test/messages/plugin.test.js
+++ b/test/messages/plugin.test.js
@@ -134,6 +134,35 @@ describe("messages/plugin", function() {
 		});
 	});
 
+	describe("PluginSearchRequest", function() {
+		const _fetch = global.fetch;
+		after(function() {
+			global.fetch = _fetch;
+		});
+
+		it("has round trip json serialisation", function() {
+			const request = new lib.PluginSearchRequest("foo", 2, 10);
+			const json = JSON.stringify(request);
+			const reconstructed = lib.PluginSearchRequest.fromJSON(JSON.parse(json));
+			assert.deepEqual(reconstructed, request);
+		});
+		it("has round trip json serialisation of the response", function() {
+			const response = new lib.PluginSearchRequest.Response(1, [
+				new lib.PluginSearchResult("foo", "1.0.0", "Foo", "bar", "date", "home", "repo", "npm"),
+			]);
+			const json = JSON.stringify(response);
+			const reconstructed = lib.PluginSearchRequest.Response.fromJSON(JSON.parse(json));
+			assert.deepEqual(reconstructed, response);
+		});
+		it("runs on the controller", async function() {
+			global.fetch = function() {
+				return { ok: true, json: async () => ({ total: 0, objects: [] }) };
+			};
+			const response = await controlConnection.handlePluginSearchRequest(new lib.PluginSearchRequest());
+			assert.deepEqual(response, new lib.PluginSearchRequest.Response(0, []));
+		});
+	});
+
 	describe("PluginInstallRequest", function() {
 		const _fetch = global.fetch;
 		before(function() {


### PR DESCRIPTION
Closes #1001.

Since plugins carry the `clusterio-plugin` keyword in their package.json, the npm registry search endpoint can list them. This adds a `PluginSearchRequest` (control to controller) that queries `registry.npmjs.com/-/v1/search` with `keywords:clusterio-plugin` plus the user's text, with `from`/`size` paging, and returns name, version, description, publisher, publish date and the npm/homepage/repository links. It's guarded by a new `core.plugin.search` permission. I did not gate the search on `allow_plugin_install`, since browsing has no side effects and installs still go through the existing `PluginInstallRequest` checks on each target. Doing the search on the controller rather than in the browser keeps all registry traffic in one place and gives ctl the same feature for free.

The plugins page in the web UI gets a "Browse plugins" button. The modal has a search box, a paged results table, and a details panel for the selected package with install buttons per the discussion on the issue: install to controller, install to selected hosts, install to all hosts. When the user can read the controller and host configs, targets with remote installs disabled are disabled in the UI (hosts show "(remote install disabled)" in the picker). Otherwise the buttons are enabled and the target's own rejection is reported. Each install is sent per target and the result is reported per target, so one host refusing doesn't hide successes on the others. Packages already installed on the controller get a tag when the user has `core.plugin.list`.

`clusterioctl controller plugin search [query] [--page n] [--page-size n]` prints the same results as a table. Docs updated under Plugins (Remote).

Tested with unit tests for the registry query, paging validation and response shape, plus a Playwright click-through against the integration harness with remote installs both enabled (search, details, all three install buttons succeed and notify) and disabled (buttons disabled, host option greyed out).

### Changelog
```
### Features
- Added a plugin browser to the plugins page that searches npm for packages with the clusterio-plugin keyword and installs them to the controller, selected hosts or all hosts. #1001
- Added `controller plugin search` command to clusterioctl. #1001
- Added `core.plugin.search` permission. #1001
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
