### PR TITLE
Replace jszip with yauzl and yazl

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,11 +54,12 @@
 		"form-data": "^4.0.4",
 		"globals": "^16.3.0",
 		"jsonwebtoken": "^9.0.2",
-		"jszip": "^3.10.1",
 		"mocha": "^11.7.1",
 		"nyc": "^17.1.0",
 		"typedoc": "^0.28.9",
 		"typescript": "^5.9.2",
-		"yargs": "^18.0.0"
+		"yargs": "^18.0.0",
+		"yauzl": "catalog:",
+		"yazl": "catalog:"
 	}
 }

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -42,7 +42,6 @@
 		"express": "catalog:",
 		"finalhandler": "^1.3.1",
 		"jsonwebtoken": "catalog:",
-		"jszip": "catalog:",
 		"semver": "^7.7.1",
 		"winston": "catalog:",
 		"winston-daily-rotate-file": "catalog:",

--- a/packages/controller/src/routes.ts
+++ b/packages/controller/src/routes.ts
@@ -5,7 +5,6 @@ import busboy from "busboy";
 import crypto from "crypto";
 import events from "events";
 import fs from "node:fs/promises";
-import JSZip from "jszip";
 import jwt from "jsonwebtoken";
 import path from "path";
 import nodeStream from "stream";
@@ -234,9 +233,7 @@ async function uploadExport(req: Request, res: Response) {
 	for await (let chunk of req) {
 		data.push(chunk);
 	}
-	let buffer: Buffer | null = Buffer.concat(data);
-	let zip = await JSZip.loadAsync(buffer);
-	buffer = null;
+	let zip = await lib.ZipArchive.fromBuffer(Buffer.concat(data));
 
 	// This is hardcoded to prevent path expansion attacks
 	let exportFiles = [
@@ -256,14 +253,15 @@ async function uploadExport(req: Request, res: Response) {
 			continue;
 		}
 
+		let content = await zip.readEntry(file);
 		if (filePath === "export/settings.json") {
-			settingPrototypes = JSON.parse(await file.async("text"));
+			settingPrototypes = JSON.parse(content.toString("utf8"));
 		}
 
 		let { name, ext } = path.posix.parse(filePath);
-		let hash = await lib.hashStream(file.nodeStream());
+		let hash = await lib.hashStream(await zip.openStream(file));
 		assets[name] = `${name}.${hash}${ext}`;
-		await lib.safeOutputFile(path.join("static", `${name}.${hash}${ext}`), await file.async("nodebuffer"));
+		await lib.safeOutputFile(path.join("static", `${name}.${hash}${ext}`), content);
 	}
 
 	modPack.exportManifest = new lib.ExportManifest(assets, new Date().toISOString());

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -39,14 +39,14 @@
 		"@clusterio/lib": "workspace:^",
 		"@sinclair/typebox": "catalog:",
 		"jimp": "^1.6.0",
-		"jszip": "catalog:",
 		"pidusage": "^3.0.2",
 		"rcon-client": "^4.2.5",
 		"semver": "^7.7.1",
 		"set-blocking": "catalog:",
 		"winston": "catalog:",
 		"winston-daily-rotate-file": "catalog:",
-		"yargs": "^17.7.2"
+		"yargs": "^17.7.2",
+		"yazl": "catalog:"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",
@@ -54,6 +54,7 @@
 		"@types/semver": "^7.5.0",
 		"@types/set-blocking": "catalog:",
 		"@types/yargs": "^17.0.33",
+		"@types/yazl": "catalog:",
 		"typescript": "catalog:"
 	}
 }

--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "path";
 import pidusage from "pidusage";
+import stream from "node:stream";
 import util from "util";
 import type { Static } from "@sinclair/typebox";
 import { exec } from "child_process";
@@ -1339,13 +1340,12 @@ end`.replace(/\r?\n/g, " ");
 			await this.syncMods();
 			let zip = await exportData(this.server);
 
-			let content = await zip.generateAsync({ type: "nodebuffer" });
 			let url = new URL(this._host.config.get("host.controller_url"));
 			url.pathname += "api/upload-export";
 			url.searchParams.set("mod_pack_id", String(this.activeModPack.id));
 			let response = await fetch(url, {
 				method: "PUT",
-				body: content,
+				body: stream.Readable.toWeb(lib.zipOutputStream(zip)),
 				duplex: "half",
 				headers: {
 					"Content-Type": "application/zip",

--- a/packages/host/src/export.ts
+++ b/packages/host/src/export.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "path";
 import { Jimp, JimpMime, type JimpInstance } from "jimp";
-import JSZip from "jszip";
+import yazl from "yazl";
 
 import * as lib from "@clusterio/lib";
 import * as libBuildMod from "@clusterio/lib/dist/node/build_mod";
@@ -64,7 +64,11 @@ async function generateExportMod(server: FactorioServer) {
 	});
 }
 
-let zipCache = new Map<string, JSZip>();
+interface ModZip {
+	zip: lib.ZipArchive;
+	root: string;
+}
+let zipCache = new Map<string, ModZip>();
 async function loadZip(server: FactorioServer, modVersions: Map<string, string>, mod: string) {
 	let modVersion = modVersions.get(mod);
 	if (!modVersion) {
@@ -72,13 +76,26 @@ async function loadZip(server: FactorioServer, modVersions: Map<string, string>,
 	}
 
 	let zipPath = server.writePath("mods", `${mod}_${modVersion}.zip`);
-	let zip = zipCache.get(zipPath);
-	if (!zip) {
-		zip = await JSZip.loadAsync(await fs.readFile(zipPath));
-		zipCache.set(zipPath, zip);
+	let modZip = zipCache.get(zipPath);
+	if (!modZip) {
+		const zip = await lib.ZipArchive.fromFile(zipPath);
+		try {
+			modZip = { zip, root: lib.findRoot(zip) };
+		} catch (err) {
+			zip.close();
+			throw err;
+		}
+		zipCache.set(zipPath, modZip);
 	}
 
-	return zip.folder(lib.findRoot(zip))!;
+	return modZip;
+}
+
+function closeZipCache() {
+	for (const { zip } of zipCache.values()) {
+		zip.close();
+	}
+	zipCache.clear();
 }
 
 /**
@@ -111,9 +128,9 @@ async function loadFile(server: FactorioServer, modVersions: Map<string, string>
 		}
 	}
 
-	let zip;
+	let modZip;
 	try {
-		zip = await loadZip(server, modVersions, mod);
+		modZip = await loadZip(server, modVersions, mod);
 	} catch (err: any) {
 		if (err.code === "ENOENT") {
 			return null;
@@ -121,12 +138,7 @@ async function loadFile(server: FactorioServer, modVersions: Map<string, string>
 		throw err;
 	}
 
-	let file = zip.file(filePath);
-	if (!file) {
-		return null;
-	}
-
-	return await file.async("nodebuffer");
+	return await modZip.zip.readFile(path.posix.join(modZip.root, filePath));
 }
 
 type Image = JimpInstance;
@@ -445,18 +457,21 @@ async function exportLocale(
 			continue;
 		}
 
-		let zip;
+		let modZip;
 		try {
-			zip = await loadZip(server, modVersions, mod);
+			modZip = await loadZip(server, modVersions, mod);
 		} catch (err: any) {
 			if (err.code === "ENOENT") {
 				continue;
 			}
 			throw err;
 		}
-		for (let file of zip.file(new RegExp(`locale\\/${languageCode}\\/.*\\.cfg`))) {
-			let content = await file.async("nodebuffer");
-			mergeLocale(lib.parse(content.toString("utf8")));
+		const localePath = `${path.posix.join(modZip.root, "locale", languageCode)}/`;
+		for (const entry of modZip.zip.entries.values()) {
+			if (entry.fileName.startsWith(localePath) && entry.fileName.endsWith(".cfg")) {
+				let content = await modZip.zip.readEntry(entry);
+				mergeLocale(lib.parse(content.toString("utf8")));
+			}
 		}
 	}
 
@@ -470,6 +485,15 @@ async function exportLocale(
  * @returns zip file with exported data.
  */
 export async function exportData(server: FactorioServer) {
+	try {
+		return await buildExport(server);
+	} finally {
+		// Free up the zip files loaded during the export.
+		closeZipCache();
+	}
+}
+
+async function buildExport(server: FactorioServer) {
 	await generateExportMod(server);
 
 	let settings: lib.ExportSettings = {};
@@ -551,14 +575,12 @@ export async function exportData(server: FactorioServer) {
 
 	let locale = await exportLocale(server, modVersions, modOrder, "en");
 
-	// Free up the memory used by zip files loaded during the export.
-	zipCache.clear();
-
-	let zip = new JSZip();
-	zip.file("export/settings.json", JSON.stringify(settings satisfies lib.ExportSettings));
-	zip.file("export/prototypes.json", JSON.stringify(prototypes satisfies lib.ExportPrototypes));
-	zip.file("export/locale.json", JSON.stringify([...locale.entries()] satisfies lib.ExportLocale));
-	zip.file("export/defines.json", JSON.stringify(defines satisfies lib.ExportDefines));
+	let zip = new yazl.ZipFile();
+	const addJson = (name: string, value: unknown) => zip.addBuffer(Buffer.from(JSON.stringify(value)), name);
+	addJson("export/settings.json", settings satisfies lib.ExportSettings);
+	addJson("export/prototypes.json", prototypes satisfies lib.ExportPrototypes);
+	addJson("export/locale.json", [...locale.entries()] satisfies lib.ExportLocale);
+	addJson("export/defines.json", defines satisfies lib.ExportDefines);
 
 	// Build a single unified spritesheet across all prototypes with icons.
 	const state = await createSheetState();
@@ -579,8 +601,9 @@ export async function exportData(server: FactorioServer) {
 	// Crop sheet to actual used height and write single spritesheet + metadata.
 	const usedRows = Math.ceil(state.pos / (SHEET_WIDTH / SHEET_ICON_SIZE));
 	state.sheet.crop({ x: 0, y: 0, w: SHEET_WIDTH, h: Math.max(usedRows * SHEET_ICON_SIZE, 1) });
-	zip.file("export/spritesheet.png", await state.sheet.getBuffer(JimpMime.png));
-	zip.file("export/metadata.json", JSON.stringify(state.metadata satisfies lib.ExportMetadata));
+	zip.addBuffer(await state.sheet.getBuffer(JimpMime.png), "export/spritesheet.png");
+	addJson("export/metadata.json", state.metadata satisfies lib.ExportMetadata);
+	zip.end();
 
 	server._logger.info(`Export complete: ${state.pos} icons on ${usedRows} row(s)`);
 

--- a/packages/host/src/patch.ts
+++ b/packages/host/src/patch.ts
@@ -4,7 +4,6 @@ import fs from "node:fs/promises";
 import path from "path";
 import semver from "semver";
 import { pipeline } from "node:stream/promises";
-import yazl from "yazl";
 import { Type, Static } from "@sinclair/typebox";
 
 import * as lib from "@clusterio/lib";
@@ -435,37 +434,33 @@ export async function patch(savePath: string, modules: SaveModule[]) {
 		files.set("clusterio.json", Buffer.from(JSON.stringify(patchInfo, null, "\t"), "utf8"));
 
 		// Write back the save, keeping the order of the entries in the original
-		const output = new yazl.ZipFile();
 		const added = new Map([...files].map(([relativePath, contents]) => [rootPath(relativePath), contents]));
-		for (const entry of zip.entries.values()) {
-			const name = entry.fileName;
-			if (removed.has(name)) {
-				continue;
-			}
-			const contents = added.get(name);
-			if (contents !== undefined) {
-				output.addBuffer(contents, name);
-				added.delete(name);
-			} else if (name.endsWith("/")) {
-				output.addEmptyDirectory(name, { mtime: entry.getLastModDate() });
-			} else {
-				output.addReadStreamLazy(
-					name,
-					{ mtime: entry.getLastModDate(), size: entry.uncompressedSize },
-					cb => zip.zipfile.openReadStream(entry, cb),
-				);
-			}
-		}
-		for (const [name, contents] of added) {
-			output.addBuffer(contents, name);
-		}
-		output.end();
-
+		const output = new lib.ZipWriter();
 		let writeStream;
 		[tempSavePath, writeStream] = await lib.createTempWriteStream(savePath);
+		const writing = pipeline(output.outputStream, writeStream);
 		try {
-			await pipeline(lib.zipOutputStream(output), writeStream);
+			for (const entry of zip.entries.values()) {
+				const name = entry.fileName;
+				if (removed.has(name)) {
+					continue;
+				}
+				const contents = added.get(name);
+				if (contents !== undefined) {
+					await output.addBuffer(contents, name);
+					added.delete(name);
+				} else {
+					await output.addEntry(zip, entry);
+				}
+			}
+			for (const [name, contents] of added) {
+				await output.addBuffer(contents, name);
+			}
+			await output.end();
+			await writing;
 		} catch (err) {
+			output.outputStream.destroy();
+			await writing.catch(() => {});
 			await fs.rm(tempSavePath, { force: true });
 			throw err;
 		}

--- a/packages/host/src/patch.ts
+++ b/packages/host/src/patch.ts
@@ -1,10 +1,10 @@
 // Library for patching Factorio saves with scenario code.
 
-import events from "events";
 import fs from "node:fs/promises";
-import JSZip from "jszip";
 import path from "path";
 import semver from "semver";
+import { pipeline } from "node:stream/promises";
+import yazl from "yazl";
 import { Type, Static } from "@sinclair/typebox";
 
 import * as lib from "@clusterio/lib";
@@ -75,18 +75,16 @@ export class SaveModule {
 		};
 	}
 
-	static async fromSave(json: Static<typeof SaveModule.jsonSchema>, root: JSZip) {
+	static async fromSave(json: Static<typeof SaveModule.jsonSchema>, zip: lib.ZipArchive, root: string) {
 		const module = new this(lib.ModuleInfo.fromJSON(json));
-		module.files = new Map(await Promise.all(json.files
-			.map(filename => ({filename, file: root.file(filename)}))
-			.filter(({filename, file}) => {
-				if (file === null) {
-					lib.logger.warn(`Missing file ${filename} in save`);
-				}
-				return file !== null;
-			})
-			.map(async ({filename, file}) => [filename, await file!.async("nodebuffer")] as const)
-		));
+		for (const filename of json.files) {
+			const content = await zip.readFile(path.posix.join(root, filename));
+			if (content === null) {
+				lib.logger.warn(`Missing file ${filename} in save`);
+				continue;
+			}
+			module.files.set(filename, content);
+		}
 		return module;
 	}
 
@@ -175,7 +173,7 @@ export class PatchInfo {
 		};
 	}
 
-	static async fromSave(json: Static<typeof PatchInfo.jsonSchema>, root: JSZip) {
+	static async fromSave(json: Static<typeof PatchInfo.jsonSchema>, zip: lib.ZipArchive, root: string) {
 		if (json.version === undefined) {
 			interface ScenarioInfoV0 {
 				name: string;
@@ -199,7 +197,7 @@ export class PatchInfo {
 		return new this(
 			json.patch_number,
 			lib.ModuleInfo.fromJSON(json.scenario),
-			await Promise.all(json.modules.map(m => SaveModule.fromSave(m, root))),
+			await Promise.all(json.modules.map(m => SaveModule.fromSave(m, zip, root))),
 		);
 	}
 }
@@ -366,80 +364,113 @@ const knownScenarios: Record<string, lib.ModuleInfo> = {
  * @param modules - Description of the modules to patch.
  */
 export async function patch(savePath: string, modules: SaveModule[]) {
-	let zip = await JSZip.loadAsync(await fs.readFile(savePath));
-	let root = zip.folder(lib.findRoot(zip))!;
+	const zip = await lib.ZipArchive.fromFile(savePath);
+	let tempSavePath: string;
+	try {
+		const root = lib.findRoot(zip);
+		const rootPath = (relativePath: string) => path.posix.join(root, relativePath);
 
-	let patchInfoFile = root.file("clusterio.json");
-	let patchInfo: PatchInfo;
-	if (patchInfoFile !== null) {
-		let content = await patchInfoFile.async("string");
-		patchInfo = await PatchInfo.fromSave(JSON.parse(content), root);
-		if (patchInfo.version > PatchInfo.currentVersion) {
-			throw new Error(
-				`Save patch version ${patchInfo.version} is newer than the patch version this ` +
-				`version of Clusterio can load (${PatchInfo.currentVersion})`
-			);
-		}
+		// Files to add or replace in the save, relative to the root
+		const files = new Map<string, Buffer>();
+		let patchInfo: PatchInfo;
+		const patchInfoContent = await zip.readFile(rootPath("clusterio.json"));
+		if (patchInfoContent !== null) {
+			patchInfo = await PatchInfo.fromSave(JSON.parse(patchInfoContent.toString("utf8")), zip, root);
+			if (patchInfo.version > PatchInfo.currentVersion) {
+				throw new Error(
+					`Save patch version ${patchInfo.version} is newer than the patch version this ` +
+					`version of Clusterio can load (${PatchInfo.currentVersion})`
+				);
+			}
 
-	// No info file present, try to detect if it's a known compatible scenario.
-	} else {
-		let controlFile = root.file("control.lua");
-		if (!controlFile) {
-			throw new Error("Unable to patch save, missing control.lua file.");
-		}
-		let controlStream = controlFile.nodeStream("nodebuffer");
-		let controlHash = await lib.hashStream(controlStream);
-
-		if (controlHash in knownScenarios) {
-			patchInfo = new PatchInfo(0, knownScenarios[controlHash], []);
-			root.file("scenario.lua", controlFile.nodeStream("nodebuffer"));
+		// No info file present, try to detect if it's a known compatible scenario.
 		} else {
-			throw new Error(`Unable to patch save, unknown scenario (${controlHash})`);
-		}
-	}
+			const controlFile = zip.file(rootPath("control.lua"));
+			if (!controlFile) {
+				throw new Error("Unable to patch save, missing control.lua file.");
+			}
+			const controlHash = await lib.hashStream(await zip.openStream(controlFile));
 
-	// Increment patch number
-	patchInfo.patchNumber = patchInfo.patchNumber + 1;
-
-	// Remove any existing modules from the save
-	if (patchInfo.version === 0) {
-		for (let file of root.file(/^modules\//)) {
-			zip.remove(file.name);
-		}
-	} else {
-		for (let module of patchInfo.modules) {
-			for (let filepath of module.files.keys()) {
-				const file = root.file(filepath);
-				if (file !== null) {
-					zip.remove(file.name);
-				}
+			if (controlHash in knownScenarios) {
+				patchInfo = new PatchInfo(0, knownScenarios[controlHash], []);
+				files.set("scenario.lua", await zip.readEntry(controlFile));
+			} else {
+				throw new Error(`Unable to patch save, unknown scenario (${controlHash})`);
 			}
 		}
-		patchInfo.modules = [];
-	}
 
-	reorderDependencies(modules);
+		// Increment patch number
+		patchInfo.patchNumber = patchInfo.patchNumber + 1;
 
-	// Add the modules to the save.
-	for (let module of modules) {
-		for (let [relativePath, contents] of module.files) {
-			root.file(relativePath, contents);
+		// Remove any existing modules from the save
+		const removed = new Set<string>();
+		if (patchInfo.version === 0) {
+			const modulesPath = rootPath("modules/");
+			for (const name of zip.entries.keys()) {
+				if (name.startsWith(modulesPath)) {
+					removed.add(name);
+				}
+			}
+		} else {
+			for (const module of patchInfo.modules) {
+				for (const filepath of module.files.keys()) {
+					removed.add(rootPath(filepath));
+				}
+			}
+			patchInfo.modules = [];
 		}
-		patchInfo.modules.push(module);
-	}
 
-	// Add loading code and patch info
-	root.file("control.lua", generateLoader(patchInfo));
-	root.file("clusterio.json", JSON.stringify(patchInfo, null, "\t"));
+		reorderDependencies(modules);
 
-	// Write back the save
-	let stream = zip.generateNodeStream({ compression: "DEFLATE" });
-	const [tempSavePath, writeStream] = await lib.createTempWriteStream(savePath);
-	try {
-		let pipe = stream.pipe(writeStream);
-		await events.once(pipe, "finish");
+		// Add the modules to the save.
+		for (const module of modules) {
+			for (const [relativePath, contents] of module.files) {
+				files.set(relativePath, contents);
+			}
+			patchInfo.modules.push(module);
+		}
+
+		// Add loading code and patch info
+		files.set("control.lua", Buffer.from(generateLoader(patchInfo), "utf8"));
+		files.set("clusterio.json", Buffer.from(JSON.stringify(patchInfo, null, "\t"), "utf8"));
+
+		// Write back the save, keeping the order of the entries in the original
+		const output = new yazl.ZipFile();
+		const added = new Map([...files].map(([relativePath, contents]) => [rootPath(relativePath), contents]));
+		for (const entry of zip.entries.values()) {
+			const name = entry.fileName;
+			if (removed.has(name)) {
+				continue;
+			}
+			const contents = added.get(name);
+			if (contents !== undefined) {
+				output.addBuffer(contents, name);
+				added.delete(name);
+			} else if (name.endsWith("/")) {
+				output.addEmptyDirectory(name, { mtime: entry.getLastModDate() });
+			} else {
+				output.addReadStreamLazy(
+					name,
+					{ mtime: entry.getLastModDate(), size: entry.uncompressedSize },
+					cb => zip.zipfile.openReadStream(entry, cb),
+				);
+			}
+		}
+		for (const [name, contents] of added) {
+			output.addBuffer(contents, name);
+		}
+		output.end();
+
+		let writeStream;
+		[tempSavePath, writeStream] = await lib.createTempWriteStream(savePath);
+		try {
+			await pipeline(lib.zipOutputStream(output), writeStream);
+		} catch (err) {
+			await fs.rm(tempSavePath, { force: true });
+			throw err;
+		}
 	} finally {
-		writeStream.destroy();
+		zip.close();
 	}
 	await fs.rename(tempSavePath, savePath);
 }

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -1,9 +1,11 @@
 // Factorio Server interface
 import fs from "node:fs/promises";
-import { type FSWatcher, watch as fsWatch, writeFileSync } from "node:fs";
+import { type FSWatcher, createWriteStream, watch as fsWatch, writeFileSync } from "node:fs";
 import child_process from "child_process";
 import path from "path";
-import JSZip from "jszip";
+import stream from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream } from "node:stream/web";
 import events from "events";
 import util from "util";
 import crypto from "crypto";
@@ -112,29 +114,38 @@ async function downloadAndExtractZip(url: string, targetDir: string) {
 		throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
 	}
 
-  	// Load the ZIP with JSZip
-	const buffer = Buffer.from(await res.arrayBuffer());
-	const zip = await JSZip.loadAsync(buffer);
+	if (!res.body) {
+		throw new Error(`Failed to fetch ${url}: empty response`);
+	}
 
-  	// Extract each file/folder
-	await fs.mkdir(targetDir, { recursive: true });
-	await Promise.all(
-		Object.values(zip.files).map(async (entry) => {
-			const parts = entry.name.split("/").filter(Boolean);
-			const strippedPath = parts.slice(1).join("/");
-			if (!strippedPath) {
-				return; // This copies the behaviour of tar --strip-components 1
-			}
+	// Write the download to a temp file, zip files need random access to read
+	const tmpFilePath = `${targetDir}.tmp`;
+	await fs.writeFile(tmpFilePath, stream.Readable.fromWeb(res.body as ReadableStream));
+	try {
+		const zip = await lib.ZipArchive.fromFile(tmpFilePath);
+		try {
+			await fs.mkdir(targetDir, { recursive: true });
+			for (const entry of zip.entries.values()) {
+				const parts = entry.fileName.split("/").filter(Boolean);
+				const strippedPath = parts.slice(1).join("/");
+				if (!strippedPath) {
+					continue; // This copies the behaviour of tar --strip-components 1
+				}
 
-			const entryPath = path.join(targetDir, strippedPath);
-			if (entry.dir) {
-				await fs.mkdir(entryPath, { recursive: true });
-			} else {
-				await fs.mkdir(path.dirname(entryPath), { recursive: true });
-				await fs.writeFile(entryPath, await entry.async("nodebuffer"));
+				const entryPath = path.join(targetDir, strippedPath);
+				if (entry.fileName.endsWith("/")) {
+					await fs.mkdir(entryPath, { recursive: true });
+				} else {
+					await fs.mkdir(path.dirname(entryPath), { recursive: true });
+					await pipeline(await zip.openStream(entry), createWriteStream(entryPath));
+				}
 			}
-		})
-	);
+		} finally {
+			zip.close();
+		}
+	} finally {
+		await fs.rm(tmpFilePath);
+	}
 }
 
 /**

--- a/packages/lib/build_mod.js
+++ b/packages/lib/build_mod.js
@@ -1,13 +1,10 @@
 /* eslint-disable no-console */
 "use strict";
 const fs = require("node:fs/promises");
-const JSZip = require("jszip");
 const path = require("path");
-const stream = require("stream");
-const util = require("util");
+const { pipeline } = require("node:stream/promises");
 const yargs = require("yargs");
-
-const finished = util.promisify(stream.finished);
+const yazl = require("yazl");
 
 
 async function buildMod(args, info, modName) {
@@ -16,7 +13,7 @@ async function buildMod(args, info, modName) {
 		modName = args.modName ?? `${info.name}_${info.version}`;
 
 		if (args.pack) {
-			let zip = new JSZip();
+			let zip = new yazl.ZipFile();
 			for await (const dirent of await fs.opendir(args.sourceDir, { recursive: true })) {
 				if (dirent.isFile()) {
 					const itemPath = path.join(dirent.parentPath, dirent.name);
@@ -29,30 +26,29 @@ async function buildMod(args, info, modName) {
 						// The info.json file is overridden later.
 						continue;
 					}
-					zip.file(path.posix.join(modName, basePath), (await fs.open(itemPath)).createReadStream());
+					zip.addFile(itemPath, path.posix.join(modName, basePath));
 				}
 			}
 
 			for (let [fileName, pathParts] of Object.entries(info.additional_files || {})) {
 				let filePath = path.join(args.sourceDir, ...pathParts);
-				let fileStream;
 				try {
-					fileStream = (await fs.open(filePath)).createReadStream();
+					await fs.access(filePath);
 				} catch (err) {
 					throw new Error(`Error reading additional file ${filePath}`, { cause: err });
 				}
-				zip.file(path.posix.join(modName, fileName), fileStream);
+				zip.addFile(filePath, path.posix.join(modName, fileName));
 			}
 			delete info.additional_files;
 
-			zip.file(path.posix.join(modName, "info.json"), JSON.stringify(info, null, "\t"));
+			zip.addBuffer(Buffer.from(JSON.stringify(info, null, "\t")), path.posix.join(modName, "info.json"));
+			zip.end();
+			// yazl reports errors on the zip object, not the output stream.
+			zip.on("error", err => zip.outputStream.destroy(err));
 
 			let modPath = path.join(args.outputDir, `${modName}.zip`);
 			console.log(`Writing ${modPath}`);
-			let writeStream = zip.generateNodeStream().pipe(
-				(await fs.open(modPath, "w")).createWriteStream()
-			);
-			await finished(writeStream);
+			await pipeline(zip.outputStream, (await fs.open(modPath, "w")).createWriteStream());
 
 		} else {
 			let modDir = path.join(args.outputDir, modName);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,16 +34,19 @@
 
 	"dependencies": {
 		"@sinclair/typebox": "catalog:",
+		"@types/yauzl": "catalog:",
+		"@types/yazl": "catalog:",
 		"ajv": "^8.17.1",
 		"chalk": "catalog:",
 		"fast-deep-equal": "^3.1.3",
-		"jszip": "catalog:",
 		"set-blocking": "catalog:",
 		"triple-beam": "^1.4.1",
 		"winston": "catalog:",
 		"winston-transport": "catalog:",
 		"ws": "catalog:",
-		"yargs": "^17.7.2"
+		"yargs": "^17.7.2",
+		"yauzl": "catalog:",
+		"yazl": "catalog:"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",

--- a/packages/lib/src/data/ModInfo.ts
+++ b/packages/lib/src/data/ModInfo.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
-import JSZip from "jszip";
+import path from "path";
 import { Type, Static } from "@sinclair/typebox";
 
 import * as libHash from "../hash";
 import * as libSchema from "../schema";
-import { findRoot } from "../zip_ops";
+import { ZipArchive, findRoot } from "../zip_ops";
 import { ModRecord } from "./ModPack";
 
 import {
@@ -352,18 +352,15 @@ export default class ModInfo {
 
 	static async fromModFile(modPath: string) {
 		let modInfo: Static<typeof ModInfo.jsonSchema>;
-		{
-			// XXX: JSZip needs the whole archive loaded in memory to work.
-			// This is clearly untenable and will be replaced later.
-			let zip = await JSZip.loadAsync(await fs.readFile(modPath));
-			let root = zip.folder(findRoot(zip))!;
-
-			let infoFile = root.file("info.json");
-			if (!infoFile) {
+		let zip = await ZipArchive.fromFile(modPath);
+		try {
+			let content = await zip.readFile(path.posix.join(findRoot(zip), "info.json"));
+			if (content === null) {
 				throw new Error("Mod contains no info.json file");
 			}
-
-			modInfo = JSON.parse(await infoFile.async("string"));
+			modInfo = JSON.parse(content.toString("utf8"));
+		} finally {
+			zip.close();
 		}
 
 		let valid = this.validateInfo(modInfo);

--- a/packages/lib/src/zip_ops.ts
+++ b/packages/lib/src/zip_ops.ts
@@ -1,4 +1,117 @@
-import type JSZip from "jszip";
+/**
+ * Zip file helpers
+ * @module lib/zip_ops
+ */
+import type { Readable } from "stream";
+import yauzl from "yauzl";
+import type yazl from "yazl";
+
+
+/**
+ * Zip archive opened for random access reading
+ *
+ * Only the central directory is read up front, the content of entries is
+ * streamed from the archive on demand.  Archives opened from a file hold
+ * the file open until close() is called.
+ */
+export class ZipArchive {
+	private constructor(
+		/** Underlying yauzl zip file. */
+		public zipfile: yauzl.ZipFile,
+		/** Entries by file name in the order they appear in the central directory. */
+		public entries: Map<string, yauzl.Entry>,
+	) { }
+
+	/**
+	 * Open a zip archive from the file system
+	 *
+	 * @param zipPath - Path to the zip file to open.
+	 */
+	static async fromFile(zipPath: string) {
+		return this.load(await yauzl.openPromise(zipPath, { autoClose: false }));
+	}
+
+	/**
+	 * Open a zip archive held in memory
+	 *
+	 * @param buffer - Content of the zip file.
+	 */
+	static async fromBuffer(buffer: Buffer) {
+		return this.load(await yauzl.fromBufferPromise(buffer));
+	}
+
+	private static async load(zipfile: yauzl.ZipFile) {
+		const entries = new Map<string, yauzl.Entry>();
+		try {
+			for await (const entry of zipfile.eachEntry()) {
+				entries.set(entry.fileName, entry);
+			}
+		} catch (err) {
+			zipfile.close();
+			throw err;
+		}
+		return new this(zipfile, entries);
+	}
+
+	/**
+	 * Look up a file in the archive
+	 *
+	 * @param filePath - Path of the file in the archive.
+	 * @returns entry for the file, or null if it does not exist.
+	 */
+	file(filePath: string) {
+		const entry = this.entries.get(filePath);
+		if (!entry || entry.fileName.endsWith("/")) {
+			return null;
+		}
+		return entry;
+	}
+
+	/**
+	 * Open a stream of the decompressed content of an entry
+	 *
+	 * @param entry - Entry to read, must belong to this archive.
+	 */
+	openStream(entry: yauzl.Entry): Promise<Readable> {
+		return this.zipfile.openReadStreamPromise(entry);
+	}
+
+	/**
+	 * Read the decompressed content of an entry
+	 *
+	 * @param entry - Entry to read, must belong to this archive.
+	 */
+	async readEntry(entry: yauzl.Entry) {
+		const chunks: Buffer[] = [];
+		for await (const chunk of await this.openStream(entry)) {
+			chunks.push(chunk);
+		}
+		return Buffer.concat(chunks);
+	}
+
+	/**
+	 * Read the content of a file in the archive
+	 *
+	 * @param filePath - Path of the file in the archive.
+	 * @returns content of the file, or null if it does not exist.
+	 */
+	async readFile(filePath: string) {
+		const entry = this.file(filePath);
+		if (!entry) {
+			return null;
+		}
+		return await this.readEntry(entry);
+	}
+
+	/**
+	 * Close the archive
+	 *
+	 * Streams already opened are still readable until they end.
+	 */
+	close() {
+		this.zipfile.close();
+	}
+}
 
 /**
  * Returns the root folder in the zip file
@@ -12,8 +125,8 @@ import type JSZip from "jszip";
  * @param zip - Zip to search through.
  * @returns name of the root folder.
  */
-export function findRoot(zip: JSZip) {
-	const relativePath = Object.keys(zip.files)[0];
+export function findRoot(zip: ZipArchive) {
+	const relativePath = zip.entries.keys().next().value;
 	if (relativePath === undefined) {
 		throw new Error("Empty zip file");
 	}
@@ -24,4 +137,19 @@ export function findRoot(zip: JSZip) {
 	}
 
 	return relativePath.slice(0, index);
+}
+
+/**
+ * Returns the output stream of a zip file being written
+ *
+ * yazl reports errors on the ZipFile object and leaves the output stream
+ * hanging.  The stream returned here is destroyed with the error instead so
+ * that consumers like stream.pipeline see it.
+ *
+ * @param zipFile - zip file being written.
+ */
+export function zipOutputStream(zipFile: yazl.ZipFile) {
+	const output = zipFile.outputStream as Readable;
+	zipFile.on("error", err => output.destroy(err));
+	return output;
 }

--- a/packages/lib/src/zip_ops.ts
+++ b/packages/lib/src/zip_ops.ts
@@ -2,9 +2,14 @@
  * Zip file helpers
  * @module lib/zip_ops
  */
-import type { Readable } from "stream";
+import events from "events";
+import { PassThrough, type Readable } from "stream";
+import util from "util";
+import zlib from "zlib";
 import yauzl from "yauzl";
 import type yazl from "yazl";
+
+const deflateRaw = util.promisify(zlib.deflateRaw);
 
 
 /**
@@ -152,4 +157,249 @@ export function zipOutputStream(zipFile: yazl.ZipFile) {
 	const output = zipFile.outputStream as Readable;
 	zipFile.on("error", err => output.destroy(err));
 	return output;
+}
+
+const zip64Limit = 0xffffffff;
+
+function dosDateTime(date: Date) {
+	if (date.getFullYear() < 1980) {
+		return { date: 0x21, time: 0 };
+	}
+	const year = Math.min(date.getFullYear(), 2107);
+	return {
+		date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+		time: (date.getHours() << 11) | (date.getMinutes() << 5) | (date.getSeconds() >> 1),
+	};
+}
+
+interface WriterEntry {
+	fileName: Buffer;
+	fileComment: Buffer;
+	versionMadeBy: number;
+	generalPurposeBitFlag: number;
+	compressionMethod: number;
+	lastModFileTime: number;
+	lastModFileDate: number;
+	crc32: number;
+	compressedSize: number;
+	uncompressedSize: number;
+	externalFileAttributes: number;
+	offset: number;
+}
+
+export interface ZipWriterOptions {
+	/** Use ZIP64 structures even when the archive does not need them. */
+	forceZip64?: boolean;
+}
+
+export interface ZipWriterBufferOptions {
+	/** Modification time to record for the file, defaults to now. */
+	mtime?: Date;
+}
+
+/**
+ * Streaming zip file writer
+ *
+ * Writes entries to outputStream as they are added.  Entries from an
+ * existing archive are copied without decompressing them.  Sizes and
+ * offsets past 4 GiB and more than 65535 entries use ZIP64 structures.
+ */
+export class ZipWriter {
+	/** Content of the zip file, ends when end() has been called. */
+	outputStream = new PassThrough();
+	private offset = 0;
+	private entries: WriterEntry[] = [];
+	private forceZip64: boolean;
+
+	constructor(options: ZipWriterOptions = {}) {
+		this.forceZip64 = options.forceZip64 ?? false;
+	}
+
+	/**
+	 * Copy an entry from an archive
+	 *
+	 * The compressed content is copied as is along with the metadata
+	 * Factorio writes.  Extra fields are dropped.
+	 *
+	 * @param zip - Archive to copy from.
+	 * @param entry - Entry to copy, must belong to zip.
+	 */
+	async addEntry(zip: ZipArchive, entry: yauzl.Entry) {
+		const writerEntry: WriterEntry = {
+			fileName: Buffer.from(entry.fileName, "utf8"),
+			fileComment: Buffer.from(entry.fileComment, "utf8"),
+			versionMadeBy: entry.versionMadeBy,
+			// Sizes are written in the local header so no data descriptor is
+			// needed, and names are re-encoded as UTF-8.
+			generalPurposeBitFlag: (entry.generalPurposeBitFlag & ~0x8) | 0x800,
+			compressionMethod: entry.compressionMethod,
+			lastModFileTime: entry.lastModFileTime,
+			lastModFileDate: entry.lastModFileDate,
+			crc32: entry.crc32,
+			compressedSize: entry.compressedSize,
+			uncompressedSize: entry.uncompressedSize,
+			externalFileAttributes: entry.externalFileAttributes,
+			offset: this.offset,
+		};
+		await this.write(this.localFileHeader(writerEntry));
+		const stream = await zip.zipfile.openReadStreamPromise(entry, { decodeFileData: false });
+		for await (const chunk of stream) {
+			await this.write(chunk);
+		}
+		this.entries.push(writerEntry);
+	}
+
+	/**
+	 * Add a file with the given content
+	 *
+	 * @param buffer - Content of the file.
+	 * @param fileName - Path of the file in the archive.
+	 * @param options - Options for the entry.
+	 */
+	async addBuffer(buffer: Buffer, fileName: string, options: ZipWriterBufferOptions = {}) {
+		const deflated = await deflateRaw(buffer);
+		const { date, time } = dosDateTime(options.mtime ?? new Date());
+		const writerEntry: WriterEntry = {
+			fileName: Buffer.from(fileName, "utf8"),
+			fileComment: Buffer.alloc(0),
+			versionMadeBy: 20,
+			generalPurposeBitFlag: 0x800,
+			compressionMethod: 8,
+			lastModFileTime: time,
+			lastModFileDate: date,
+			crc32: zlib.crc32(buffer),
+			compressedSize: deflated.length,
+			uncompressedSize: buffer.length,
+			externalFileAttributes: 0,
+			offset: this.offset,
+		};
+		await this.write(this.localFileHeader(writerEntry));
+		await this.write(deflated);
+		this.entries.push(writerEntry);
+	}
+
+	/**
+	 * Write the central directory and end the output stream
+	 */
+	async end() {
+		const start = this.offset;
+		for (const entry of this.entries) {
+			await this.write(this.centralDirectoryHeader(entry));
+		}
+		const size = this.offset - start;
+		const zip64 = this.forceZip64 || this.entries.length >= 0xffff || start >= zip64Limit || size >= zip64Limit;
+		if (zip64) {
+			const record = Buffer.alloc(56);
+			record.writeUInt32LE(0x06064b50, 0);
+			record.writeBigUInt64LE(44n, 4);
+			record.writeUInt16LE(45, 12); // version made by
+			record.writeUInt16LE(45, 14); // version needed to extract
+			record.writeUInt32LE(0, 16); // number of this disk
+			record.writeUInt32LE(0, 20); // disk with the central directory
+			record.writeBigUInt64LE(BigInt(this.entries.length), 24);
+			record.writeBigUInt64LE(BigInt(this.entries.length), 32);
+			record.writeBigUInt64LE(BigInt(size), 40);
+			record.writeBigUInt64LE(BigInt(start), 48);
+			const locator = Buffer.alloc(20);
+			locator.writeUInt32LE(0x07064b50, 0);
+			locator.writeUInt32LE(0, 4); // disk with the zip64 end of central directory
+			locator.writeBigUInt64LE(BigInt(this.offset), 8);
+			locator.writeUInt32LE(1, 16); // total number of disks
+			await this.write(record);
+			await this.write(locator);
+		}
+		const eocd = Buffer.alloc(22);
+		eocd.writeUInt32LE(0x06054b50, 0);
+		eocd.writeUInt16LE(0, 4); // number of this disk
+		eocd.writeUInt16LE(0, 6); // disk with the central directory
+		eocd.writeUInt16LE(zip64 ? 0xffff : this.entries.length, 8);
+		eocd.writeUInt16LE(zip64 ? 0xffff : this.entries.length, 10);
+		eocd.writeUInt32LE(zip64 ? zip64Limit : size, 12);
+		eocd.writeUInt32LE(zip64 ? zip64Limit : start, 16);
+		eocd.writeUInt16LE(0, 20); // comment length
+		await this.write(eocd);
+		this.outputStream.end();
+	}
+
+	private localFileHeader(entry: WriterEntry) {
+		const zip64 = this.forceZip64
+			|| entry.compressedSize >= zip64Limit
+			|| entry.uncompressedSize >= zip64Limit;
+		const extra = zip64 ? Buffer.alloc(20) : Buffer.alloc(0);
+		if (zip64) {
+			extra.writeUInt16LE(0x0001, 0);
+			extra.writeUInt16LE(16, 2);
+			extra.writeBigUInt64LE(BigInt(entry.uncompressedSize), 4);
+			extra.writeBigUInt64LE(BigInt(entry.compressedSize), 12);
+		}
+		const header = Buffer.alloc(30);
+		header.writeUInt32LE(0x04034b50, 0);
+		header.writeUInt16LE(zip64 ? 45 : 20, 4); // version needed to extract
+		header.writeUInt16LE(entry.generalPurposeBitFlag, 6);
+		header.writeUInt16LE(entry.compressionMethod, 8);
+		header.writeUInt16LE(entry.lastModFileTime, 10);
+		header.writeUInt16LE(entry.lastModFileDate, 12);
+		header.writeUInt32LE(entry.crc32, 14);
+		header.writeUInt32LE(zip64 ? zip64Limit : entry.compressedSize, 18);
+		header.writeUInt32LE(zip64 ? zip64Limit : entry.uncompressedSize, 22);
+		header.writeUInt16LE(entry.fileName.length, 26);
+		header.writeUInt16LE(extra.length, 28);
+		return Buffer.concat([header, entry.fileName, extra]);
+	}
+
+	private centralDirectoryHeader(entry: WriterEntry) {
+		const zip64 = this.forceZip64
+			|| entry.compressedSize >= zip64Limit
+			|| entry.uncompressedSize >= zip64Limit
+			|| entry.offset >= zip64Limit;
+		const extra = zip64 ? Buffer.alloc(28) : Buffer.alloc(0);
+		if (zip64) {
+			extra.writeUInt16LE(0x0001, 0);
+			extra.writeUInt16LE(24, 2);
+			extra.writeBigUInt64LE(BigInt(entry.uncompressedSize), 4);
+			extra.writeBigUInt64LE(BigInt(entry.compressedSize), 12);
+			extra.writeBigUInt64LE(BigInt(entry.offset), 20);
+		}
+		const header = Buffer.alloc(46);
+		header.writeUInt32LE(0x02014b50, 0);
+		header.writeUInt16LE(entry.versionMadeBy, 4);
+		header.writeUInt16LE(zip64 ? 45 : 20, 6); // version needed to extract
+		header.writeUInt16LE(entry.generalPurposeBitFlag, 8);
+		header.writeUInt16LE(entry.compressionMethod, 10);
+		header.writeUInt16LE(entry.lastModFileTime, 12);
+		header.writeUInt16LE(entry.lastModFileDate, 14);
+		header.writeUInt32LE(entry.crc32, 16);
+		header.writeUInt32LE(zip64 ? zip64Limit : entry.compressedSize, 20);
+		header.writeUInt32LE(zip64 ? zip64Limit : entry.uncompressedSize, 24);
+		header.writeUInt16LE(entry.fileName.length, 28);
+		header.writeUInt16LE(extra.length, 30);
+		header.writeUInt16LE(entry.fileComment.length, 32);
+		header.writeUInt16LE(0, 34); // disk number start
+		header.writeUInt16LE(0, 36); // internal file attributes
+		header.writeUInt32LE(entry.externalFileAttributes, 38);
+		header.writeUInt32LE(zip64 ? zip64Limit : entry.offset, 42);
+		return Buffer.concat([header, entry.fileName, extra, entry.fileComment]);
+	}
+
+	private async write(buffer: Buffer) {
+		if (this.outputStream.destroyed) {
+			throw this.outputStream.errored ?? new Error("Zip output stream was closed");
+		}
+		if (!this.outputStream.write(buffer)) {
+			// once() rejects if the stream errors, close covers a plain destroy.
+			const controller = new AbortController();
+			const { signal } = controller;
+			try {
+				await Promise.race([
+					events.once(this.outputStream, "drain", { signal }),
+					events.once(this.outputStream, "close", { signal }).then(() => {
+						throw this.outputStream.errored ?? new Error("Zip output stream was closed");
+					}),
+				]);
+			} finally {
+				controller.abort();
+			}
+		}
+		this.offset += buffer.length;
+	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,11 +15,12 @@ catalog:
   '@types/react': ^18.3.18
   '@types/set-blocking': ^2.0.0
   '@types/ws': ^8.5.14
+  '@types/yauzl': ^3.4.0
+  '@types/yazl': ^3.3.1
   antd: ^5.24.2
   chalk: ^4.1.2
   express: ^5.1.0
   jsonwebtoken: ^9.0.2
-  jszip: ^3.10.1
   react: ^18.2.0
   react-dom: ^18.2.0
   react-markdown: ^10.1.0
@@ -33,6 +34,8 @@ catalog:
   winston-daily-rotate-file: ^4.7.1
   winston-transport: ^4.9.0
   ws: ^8.18.1
+  yauzl: ^3.4.0
+  yazl: ^3.3.1
 
 catalogMode: strict
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,7 @@
 "use strict";
 const assert = require("assert").strict;
-const { compile } = require("@clusterio/lib");
+const yazl = require("yazl");
+const { compile, zipOutputStream } = require("@clusterio/lib");
 
 /**
  * Generate a flat array of tests from a matrix of inputs.
@@ -35,7 +36,38 @@ function testRoundTripJsonSerialisable(Class, tests) {
 	}
 }
 
+/**
+ * Create a zip file in memory
+ *
+ * @param {Iterable<[string, string | Buffer]>} files - Paths and content of the files to add.
+ * @returns {yazl.ZipFile} zip file with the output stream ready to be read.
+ */
+function createZip(files) {
+	const zip = new yazl.ZipFile();
+	for (const [filePath, content] of files) {
+		zip.addBuffer(Buffer.from(content), filePath);
+	}
+	zip.end();
+	return zip;
+}
+
+/**
+ * Create a zip file in memory and return its content
+ *
+ * @param {Iterable<[string, string | Buffer]>} files - Paths and content of the files to add.
+ * @returns {Promise<Buffer>} content of the zip file.
+ */
+async function createZipBuffer(files) {
+	const chunks = [];
+	for await (const chunk of zipOutputStream(createZip(files))) {
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks);
+}
+
 module.exports = {
 	testMatrix,
 	testRoundTripJsonSerialisable,
+	createZip,
+	createZipBuffer,
 };

--- a/test/common.js
+++ b/test/common.js
@@ -39,13 +39,18 @@ function testRoundTripJsonSerialisable(Class, tests) {
 /**
  * Create a zip file in memory
  *
- * @param {Iterable<[string, string | Buffer]>} files - Paths and content of the files to add.
+ * @param {Iterable<[string, string | Buffer]>} files -
+ *     Paths and content of the files to add, paths ending with / are directories.
  * @returns {yazl.ZipFile} zip file with the output stream ready to be read.
  */
 function createZip(files) {
 	const zip = new yazl.ZipFile();
 	for (const [filePath, content] of files) {
-		zip.addBuffer(Buffer.from(content), filePath);
+		if (filePath.endsWith("/")) {
+			zip.addEmptyDirectory(filePath);
+		} else {
+			zip.addBuffer(Buffer.from(content), filePath);
+		}
 	}
 	zip.end();
 	return zip;

--- a/test/host/patch.js
+++ b/test/host/patch.js
@@ -1,11 +1,11 @@
 "use strict";
 const assert = require("assert").strict;
 const fs = require("node:fs/promises");
-const JSZip = require("jszip");
 const path = require("path");
 
 const lib = require("@clusterio/lib");
 const patch = require("@clusterio/host/dist/node/src/patch");
+const { createZipBuffer } = require("../common");
 
 
 describe("host/patch", function() {
@@ -228,10 +228,8 @@ describe("host/patch", function() {
 
 	describe("patch()", function() {
 		it("should throw on unknown scenario", async function() {
-			let zip = new JSZip();
-			zip.file("world/control.lua", "-- unknown\n");
 			let zipPath = path.join("temp", "test", "patch.zip");
-			await fs.writeFile(zipPath, await zip.generateAsync({ type: "nodebuffer" }));
+			await fs.writeFile(zipPath, await createZipBuffer([["world/control.lua", "-- unknown\n"]]));
 
 			await assert.rejects(
 				patch.patch(zipPath, []),

--- a/test/integration/patch.js
+++ b/test/integration/patch.js
@@ -1,7 +1,5 @@
 "use strict";
 const assert = require("assert").strict;
-const fs = require("node:fs/promises");
-const JSZip = require("jszip");
 const path = require("path");
 
 const { patch, SaveModule } = require("@clusterio/host/dist/node/src/patch");
@@ -24,23 +22,31 @@ describe("Integration of lib/factorio/patch", function() {
 			await subdirModule.loadFiles("test/file/modules/subdir");
 			await patch(savePath, [testModule, subdirModule]);
 
-			let zip = await JSZip.loadAsync(await fs.readFile(savePath));
-			assert.equal(await zip.file("test/modules/test/test.lua").async("string"), "-- test\n");
-			assert.equal(await zip.file("test/modules/subdir/dir/test.lua").async("string"), "-- test\n");
-			assert.equal(
-				await zip.file("test/locale/en/test.cfg").async("string"),
-				"module-test=A Test\n"
-			);
-			assert.equal(
-				await zip.file("test/locale/en/test-locale.cfg").async("string"),
-				"module-test-locale=Test Locale\n"
-			);
+			let zip = await lib.ZipArchive.fromFile(savePath);
+			try {
+				assert.equal((await zip.readFile("test/modules/test/test.lua")).toString(), "-- test\n");
+				assert.equal((await zip.readFile("test/modules/subdir/dir/test.lua")).toString(), "-- test\n");
+				assert.equal(
+					(await zip.readFile("test/locale/en/test.cfg")).toString(),
+					"module-test=A Test\n"
+				);
+				assert.equal(
+					(await zip.readFile("test/locale/en/test-locale.cfg")).toString(),
+					"module-test-locale=Test Locale\n"
+				);
+			} finally {
+				zip.close();
+			}
 		});
 		it("should remove old modules in a save", async function() {
 			slowTest(this);
 			await patch(savePath, []);
-			let zip = await JSZip.loadAsync(await fs.readFile(savePath));
-			assert.equal(zip.file("test/modules/test/test.lua"), null);
+			let zip = await lib.ZipArchive.fromFile(savePath);
+			try {
+				assert.equal(zip.file("test/modules/test/test.lua"), null);
+			} finally {
+				zip.close();
+			}
 		});
 	});
 });

--- a/test/lib/ModStore.test.js
+++ b/test/lib/ModStore.test.js
@@ -3,19 +3,18 @@ const assert = require("assert").strict;
 const path = require("path");
 const fs = require("node:fs/promises");
 const stream = require("node:stream");
-const JSZip = require("jszip"); // Added for creating mock zips
 
 // Capture native fetch before any potential mocks are applied
 const nativeFetch = global.fetch;
 
-const { ModStore, ModInfo, ModVersionEquality } = require("@clusterio/lib"); // Adjust path based on compiled output
+const { ModStore, ModInfo, ModVersionEquality, zipOutputStream } = require("@clusterio/lib");
 const { externalTest } = require("../integration");
+const { createZip, createZipBuffer } = require("../common");
 
 const MODS_DIR = path.join("temp", "test", "mod_store", "mods");
 const CACHE_FILE = path.join(MODS_DIR, "mod-info-cache.json");
 
-function createMockModJSZip(name, version, factorioVersion = "1.1", dependencies = ["base >= 1.1"]) {
-	const zip = new JSZip();
+function mockModFiles(name, version, factorioVersion = "1.1", dependencies = ["base >= 1.1"]) {
 	const infoJson = {
 		name: name,
 		version: version,
@@ -25,16 +24,15 @@ function createMockModJSZip(name, version, factorioVersion = "1.1", dependencies
 		dependencies: dependencies,
 		description: `Description for ${name}`,
 	};
-	zip.file(`${name}/info.json`, JSON.stringify(infoJson, null, 4));
-	zip.file(`${name}/dummy.lua`, "-- Mock Lua file");
-
-	return zip;
+	return [
+		[`${name}/info.json`, JSON.stringify(infoJson, null, 4)],
+		[`${name}/dummy.lua`, "-- Mock Lua file"],
+	];
 }
 
 // Helper function to create a mock mod zip file
 async function createMockModZip(filePath, name, version, factorioVersion = "1.1", dependencies = ["base >= 1.1"]) {
-	const zip = createMockModJSZip(name, version, factorioVersion, dependencies);
-	const buffer = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+	const buffer = await createZipBuffer(mockModFiles(name, version, factorioVersion, dependencies));
 	await fs.writeFile(filePath, buffer);
 }
 
@@ -254,8 +252,8 @@ describe("lib/ModStore", function () {
 					if (name === "bad-download-mod") {
 						return { ok: false, status: 503, statusText: "Test Mock download error" };
 					}
-					const zip = createMockModJSZip(name, version);
-					return { ok: true, status: 200, body: stream.Readable.toWeb(zip.generateNodeStream()) };
+					const zip = createZip(mockModFiles(name, version));
+					return { ok: true, status: 200, body: stream.Readable.toWeb(zipOutputStream(zip)) };
 				}
 				// Fallback for unhandled fetches in this test
 				return { ok: false, status: 404, statusText: `Test Mock 404: ${urlString}` };

--- a/test/lib/zip_ops.js
+++ b/test/lib/zip_ops.js
@@ -1,8 +1,18 @@
 "use strict";
 const assert = require("assert").strict;
+const zlib = require("zlib");
 
-const { ZipArchive, findRoot } = require("@clusterio/lib");
+const { ZipArchive, ZipWriter, findRoot } = require("@clusterio/lib");
 const { createZipBuffer } = require("../common");
+
+
+async function readAll(stream) {
+	const chunks = [];
+	for await (const chunk of stream) {
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks);
+}
 
 
 describe("lib/zip_ops", function() {
@@ -20,6 +30,71 @@ describe("lib/zip_ops", function() {
 		});
 		it("should reject invalid zips", async function() {
 			await assert.rejects(ZipArchive.fromBuffer(Buffer.from("not a zip file")));
+		});
+	});
+
+	describe("class ZipWriter", function() {
+		const sourceFiles = [
+			["root/", ""],
+			["root/foo.txt", "foo"],
+			["root/big.txt", "lorem ipsum ".repeat(10000)],
+			["root/ünïcode.txt", "unicode"],
+		];
+
+		async function roundTrip(forceZip64) {
+			const source = await ZipArchive.fromBuffer(await createZipBuffer(sourceFiles));
+			const writer = new ZipWriter({ forceZip64 });
+			const output = readAll(writer.outputStream);
+			for (const entry of source.entries.values()) {
+				await writer.addEntry(source, entry);
+			}
+			await writer.addBuffer(Buffer.from("added"), "root/added.txt", { mtime: new Date(2020, 0, 2, 3, 4, 6) });
+			await writer.end();
+			return { source, copy: await ZipArchive.fromBuffer(await output) };
+		}
+
+		async function assertRoundTrip(forceZip64) {
+			const { source, copy } = await roundTrip(forceZip64);
+			assert.deepEqual([...copy.entries.keys()], [...source.entries.keys(), "root/added.txt"]);
+			for (const [name, sourceEntry] of source.entries) {
+				const entry = copy.entries.get(name);
+				assert.equal(entry.compressionMethod, sourceEntry.compressionMethod, name);
+				assert.equal(entry.compressedSize, sourceEntry.compressedSize, name);
+				assert.equal(entry.uncompressedSize, sourceEntry.uncompressedSize, name);
+				assert.equal(entry.crc32, sourceEntry.crc32, name);
+				assert.deepEqual(entry.getLastModDate(), sourceEntry.getLastModDate({ forceDosFormat: true }), name);
+				if (!name.endsWith("/")) {
+					const content = await copy.readEntry(entry);
+					assert.deepEqual(content, await source.readEntry(sourceEntry), name);
+					assert.equal(zlib.crc32(content), entry.crc32, name);
+				}
+			}
+			const added = copy.entries.get("root/added.txt");
+			assert.equal((await copy.readEntry(added)).toString(), "added");
+			assert.equal(zlib.crc32("added"), added.crc32);
+			assert.deepEqual(added.getLastModDate(), new Date(2020, 0, 2, 3, 4, 6));
+			assert.equal(added.versionNeededToExtract, forceZip64 ? 45 : 20);
+		}
+
+		it("should copy entries and add files", async function() {
+			await assertRoundTrip(false);
+		});
+		it("should write ZIP64 structures when forced", async function() {
+			await assertRoundTrip(true);
+		});
+		it("should reject writes after the output stream is destroyed", async function() {
+			const writer = new ZipWriter();
+			writer.outputStream.on("error", () => {});
+			writer.outputStream.destroy(new Error("Test error"));
+			await assert.rejects(writer.addBuffer(Buffer.from(""), "foo.txt"), new Error("Test error"));
+			await assert.rejects(writer.end(), new Error("Test error"));
+		});
+		it("should fail when the output stream is destroyed while waiting for drain", async function() {
+			const writer = new ZipWriter();
+			writer.outputStream.pause();
+			const adding = writer.addBuffer(Buffer.alloc(1024 * 1024), "foo.txt");
+			writer.outputStream.destroy();
+			await assert.rejects(adding, new Error("Zip output stream was closed"));
 		});
 	});
 

--- a/test/lib/zip_ops.js
+++ b/test/lib/zip_ops.js
@@ -1,42 +1,58 @@
 "use strict";
 const assert = require("assert").strict;
-const JSZip = require("jszip");
 
-const { findRoot } = require("@clusterio/lib");
+const { ZipArchive, findRoot } = require("@clusterio/lib");
+const { createZipBuffer } = require("../common");
 
 
-describe("lib/factorio", function() {
+describe("lib/zip_ops", function() {
+	describe("class ZipArchive", function() {
+		it("should read files from a zip", async function() {
+			const zip = await ZipArchive.fromBuffer(await createZipBuffer([
+				["root/foo.txt", "foo"],
+				["root/bar.txt", "bar"],
+			]));
+			assert.deepEqual([...zip.entries.keys()], ["root/foo.txt", "root/bar.txt"]);
+			assert.equal((await zip.readFile("root/foo.txt")).toString(), "foo");
+			assert.equal(await zip.readFile("root/missing.txt"), null);
+			assert.equal(zip.file("root/missing.txt"), null);
+			assert.equal(zip.file("root/bar.txt").fileName, "root/bar.txt");
+		});
+		it("should reject invalid zips", async function() {
+			await assert.rejects(ZipArchive.fromBuffer(Buffer.from("not a zip file")));
+		});
+	});
+
 	describe("findRoot()", function() {
-		it("should find the root of a zip", function() {
-			let zip = new JSZip();
-			zip.file("root/foo.txt", "");
-			zip.file("root/bar.txt", "");
-
+		it("should find the root of a zip", async function() {
+			const zip = await ZipArchive.fromBuffer(await createZipBuffer([
+				["root/foo.txt", ""],
+				["root/bar.txt", ""],
+			]));
 			assert.equal(findRoot(zip), "root");
 		});
 
-		it("should throw if the first file is at the root of the zip", function() {
-			let zip = new JSZip();
-			zip.file("bar.txt", "");
-			zip.file("root/foo.txt", "");
-
+		it("should throw if the first file is at the root of the zip", async function() {
+			const zip = await ZipArchive.fromBuffer(await createZipBuffer([
+				["bar.txt", ""],
+				["root/foo.txt", ""],
+			]));
 			assert.throws(
 				() => findRoot(zip),
 				new Error("Zip contains file 'bar.txt' in root dir")
 			);
 		});
 
-		it("should return directory of first file if there are multiple root dirs", function() {
-			let zip = new JSZip();
-			zip.file("root-1/foo.txt", "");
-			zip.file("root-2/bar.txt", "");
-
+		it("should return directory of first file if there are multiple root dirs", async function() {
+			const zip = await ZipArchive.fromBuffer(await createZipBuffer([
+				["root-1/foo.txt", ""],
+				["root-2/bar.txt", ""],
+			]));
 			assert.equal(findRoot(zip), "root-1");
 		});
 
-		it("should throw if given an empty zip file", function() {
-			let zip = new JSZip();
-
+		it("should throw if given an empty zip file", async function() {
+			const zip = await ZipArchive.fromBuffer(await createZipBuffer([]));
 			assert.throws(
 				() => findRoot(zip),
 				new Error("Empty zip file")


### PR DESCRIPTION
Closes #1002.

jszip loads the whole archive into memory to read it and buffers the output when writing. This replaces it with yauzl for reading, which reads the central directory and streams entries on demand from the file, and yazl for writing new zips, which streams the output. Patched saves are written by a small writer in lib that copies entries from the source without decompressing them.

Changes:
- `lib` gets a `ZipArchive` wrapper around yauzl (`fromFile`, `fromBuffer`, `entries`, `file`, `readFile`, `readEntry`, `openStream`, `close`) and `zipOutputStream()` which forwards yazl errors onto its output stream so `stream.pipeline` sees them. `findRoot()` now takes a `ZipArchive`.
- `lib` also gets `ZipWriter`, a streaming writer with `addEntry` to copy an entry from a `ZipArchive` byte for byte and `addBuffer` for new files. It writes ZIP64 structures when an entry or the archive passes 4 GiB or 65535 entries. Copied entries keep their method, sizes, CRC, DOS timestamp, attributes and comment. Extra fields are dropped, which for Factorio saves is nothing since Factorio writes none.
- `patch()` opens the save from disk, copies every kept entry through `ZipWriter` and appends the module files. Entry order is preserved. The archive is closed before the rename so it also works on Windows.
- `ModInfo.fromModFile()` reads `info.json` straight from the mod file.
- `exportData()` returns a yazl `ZipFile` and the instance streams it to the controller as the request body. Mod zips opened during the export are closed when it finishes, including on errors.
- `downloadAndExtractZip()` streams the download to a temp file and extracts from there, like the tar variant.
- `build_mod.js` adds files with `addFile`, so only one file is open at a time.
- Tests build zips through `createZip`/`createZipBuffer` in `test/common.js`. `ZipWriter` has round-trip tests through yauzl, with and without forced ZIP64.

Why a writer of our own for patching: yazl cannot add pre-compressed data, so going through it means inflating and deflating every entry in the save on each instance start. Measured on a 336 MB synthetic save (half random bytes, half text):

| | patch time | peak RSS |
|---|---|---|
| jszip (master) | 0.75 s | 417 MB |
| yazl re-encode | 7.2 s | 150 MB |
| `ZipWriter` raw copy (this PR) | 0.4 s | 143 MB |

Peak memory no longer grows with the save size. A real save patched by this branch has the same entries and sizes as one patched by master (master also adds an empty `modules/test/` directory entry which jszip created implicitly) and Factorio 2.1.12 loads it.

Full suite: 1680 passing, 2 failing on this machine, both environmental (port 8080 in use, no web build in the worktree). Lint is clean apart from pre-existing unused-directive warnings.

### Changelog
```
### Changes
- Replaced jszip with yauzl and yazl so saves and mods are no longer loaded fully into memory when patched, read or exported. #1002
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
