### PR TITLE
Add inspect and modify tools for inventory sync

### DIFF
--- a/plugins/inventory_sync/README.md
+++ b/plugins/inventory_sync/README.md
@@ -17,6 +17,28 @@ Run the following commands in the folder Clusterio is installed to:
 
 Substitute clusteriocontroller with clusteriohost or clusterioctl if this a dedicated host or ctl installation respectively.
 
+## Fixing broken inventories
+
+The controller stores one entry per player in `inventories.json` and keeps a lock on the player while an instance has them online.
+When sync goes wrong for a player, the Inventory sync page in the web interface lists every stored entry with its generation, size and the instance holding the lock.
+Click an entry to see a summary of its inventories, export it as JSON, import an edited JSON file in its place, delete it, or release the lock.
+
+The same operations are available from clusterioctl:
+
+    npx clusterioctl inventory-sync list
+    npx clusterioctl inventory-sync show <player>
+    npx clusterioctl inventory-sync export <player> [file]
+    npx clusterioctl inventory-sync import <player> <file>
+    npx clusterioctl inventory-sync delete <player>
+    npx clusterioctl inventory-sync release <player>
+
+Importing bumps the generation so instances holding an older copy download the new one the next time the player joins.
+Deleting makes the next join turn whatever the player has on that instance into the new synced inventory.
+Both are refused while an instance holds the lock on the player, because the instance uploads its own copy when the player leaves and that would undo the change.
+Have the player leave first, or release the lock if the instance is stuck holding it.
+
+Viewing and exporting need the `inventory_sync.inventory.view` permission. Importing, deleting and releasing need `inventory_sync.inventory.modify`, which is not granted by default.
+
 ## Method of operation
 
 This plugin does event based synchronization of inventories.

--- a/plugins/inventory_sync/control.ts
+++ b/plugins/inventory_sync/control.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs/promises";
+import * as lib from "@clusterio/lib";
+import { BaseCtlPlugin, type Control } from "@clusterio/ctl";
+import * as msg from "./messages";
+import { summarizePlayerInventories } from "./player_data";
+
+function print(...content: any) {
+	// eslint-disable-next-line no-console
+	console.log(...content);
+}
+
+async function instanceName(control: Control, instanceId: number | undefined) {
+	if (instanceId === undefined) {
+		return "-";
+	}
+	let instance = await control.send(new lib.InstanceDetailsGetRequest(instanceId));
+	return `${instance.name} (${instanceId})`;
+}
+
+const inventorySyncCommands = new lib.CommandTree({
+	name: "inventory-sync", description: "Inventory sync plugin commands",
+});
+inventorySyncCommands.add(new lib.Command({
+	definition: [["list", "l"], "List player data stored on the controller"],
+	handler: async function(args: object, control: Control) {
+		let players = await control.send(new msg.ListPlayersRequest());
+		players.sort((a, b) => a.name.localeCompare(b.name));
+		print("name | generation | size | acquired by");
+		for (let player of players) {
+			print(
+				`${player.name} | ${player.generation ?? "-"} | ` +
+				`${player.size === undefined ? "-" : lib.formatBytes(player.size)} | ` +
+				`${await instanceName(control, player.instanceId)}`
+			);
+		}
+	},
+}));
+
+inventorySyncCommands.add(new lib.Command({
+	definition: ["show <player>", "Show a summary of the stored player data", (yargs) => {
+		yargs.positional("player", { describe: "Name of the player", type: "string" });
+	}],
+	handler: async function(args: { player: string }, control: Control) {
+		let response = await control.send(new msg.GetPlayerDataRequest(args.player));
+		print(`acquired by: ${await instanceName(control, response.instanceId)}`);
+		let playerData = response.playerData;
+		if (!playerData) {
+			print(`No player data stored for ${args.player}`);
+			return;
+		}
+		print(`generation: ${playerData.generation}`);
+		print(`size: ${lib.formatBytes(JSON.stringify(playerData).length)}`);
+		print(`controller: ${playerData.controller}`);
+		print(`force: ${playerData.force}`);
+		for (let inventory of summarizePlayerInventories(playerData)) {
+			print(`${inventory.name}:`);
+			for (let item of inventory.items) {
+				let quality = item.quality ? ` (${item.quality})` : "";
+				let size = item.exportSize ? ` ${lib.formatBytes(item.exportSize)}` : "";
+				print(`  ${item.count} ${item.name}${quality}${size}`);
+			}
+		}
+	},
+}));
+
+inventorySyncCommands.add(new lib.Command({
+	definition: ["export <player> [file]", "Export stored player data as JSON", (yargs) => {
+		yargs.positional("player", { describe: "Name of the player", type: "string" });
+		yargs.positional("file", { describe: "File to write to, prints to stdout if omitted", type: "string" });
+	}],
+	handler: async function(args: { player: string, file?: string }, control: Control) {
+		let response = await control.send(new msg.GetPlayerDataRequest(args.player));
+		if (!response.playerData) {
+			throw new lib.CommandError(`No player data stored for ${args.player}`);
+		}
+		let content = JSON.stringify(response.playerData, null, "\t");
+		if (args.file) {
+			await fs.writeFile(args.file, content);
+			print(`Wrote player data for ${args.player} to ${args.file}`);
+		} else {
+			print(content);
+		}
+	},
+}));
+
+inventorySyncCommands.add(new lib.Command({
+	definition: ["import <player> <file>", "Replace stored player data with JSON from a file", (yargs) => {
+		yargs.positional("player", { describe: "Name of the player", type: "string" });
+		yargs.positional("file", { describe: "File to read player data from", type: "string" });
+	}],
+	handler: async function(args: { player: string, file: string }, control: Control) {
+		let playerData = JSON.parse(await fs.readFile(args.file, "utf8"));
+		if (typeof playerData !== "object" || playerData === null || Array.isArray(playerData)) {
+			throw new lib.CommandError("Player data must be a JSON object");
+		}
+		playerData.name = args.player;
+		playerData.generation ??= 0;
+		let response = await control.send(new msg.SetPlayerDataRequest(args.player, playerData));
+		print(`Stored player data for ${args.player} as generation ${response.generation}`);
+	},
+}));
+
+inventorySyncCommands.add(new lib.Command({
+	definition: ["delete <player>", "Delete stored player data", (yargs) => {
+		yargs.positional("player", { describe: "Name of the player", type: "string" });
+	}],
+	handler: async function(args: { player: string }, control: Control) {
+		await control.send(new msg.DeletePlayerDataRequest(args.player));
+	},
+}));
+
+inventorySyncCommands.add(new lib.Command({
+	definition: ["release <player>", "Release the lock an instance holds on a player", (yargs) => {
+		yargs.positional("player", { describe: "Name of the player", type: "string" });
+	}],
+	handler: async function(args: { player: string }, control: Control) {
+		await control.send(new msg.ForceReleaseRequest(args.player));
+	},
+}));
+
+export class CtlPlugin extends BaseCtlPlugin {
+	async addCommands(rootCommand: lib.CommandTree) {
+		rootCommand.add(inventorySyncCommands);
+	}
+}

--- a/plugins/inventory_sync/controller.ts
+++ b/plugins/inventory_sync/controller.ts
@@ -49,6 +49,11 @@ export class ControllerPlugin extends BaseControllerPlugin {
 		this.controller.handle(msg.UploadRequest, this.handleUploadRequest.bind(this));
 		this.controller.handle(msg.DownloadRequest, this.handleDownloadRequest.bind(this));
 		this.controller.handle(msg.DatabaseStatsRequest, this.handleDatabaseStatsRequest.bind(this));
+		this.controller.handle(msg.ListPlayersRequest, this.handleListPlayersRequest.bind(this));
+		this.controller.handle(msg.GetPlayerDataRequest, this.handleGetPlayerDataRequest.bind(this));
+		this.controller.handle(msg.SetPlayerDataRequest, this.handleSetPlayerDataRequest.bind(this));
+		this.controller.handle(msg.DeletePlayerDataRequest, this.handleDeletePlayerDataRequest.bind(this));
+		this.controller.handle(msg.ForceReleaseRequest, this.handleForceReleaseRequest.bind(this));
 	}
 
 	async onInstanceStatusChanged(instance: InstanceRecord) {
@@ -79,14 +84,22 @@ export class ControllerPlugin extends BaseControllerPlugin {
 		}
 	}
 
-	acquire(instanceId: number, playerName: string): boolean {
+	// Returns the acquisition record for the player if it's still in effect
+	getAcquisition(playerName: string) {
 		let acquisitionRecord = this.acquiredPlayers.get(playerName);
 		if (
 			!acquisitionRecord
-			|| acquisitionRecord.instanceId === instanceId
 			|| !this.controller.instances.has(acquisitionRecord.instanceId)
 			|| acquisitionRecord.expiresMs && acquisitionRecord.expiresMs < Date.now()
 		) {
+			return undefined;
+		}
+		return acquisitionRecord;
+	}
+
+	acquire(instanceId: number, playerName: string): boolean {
+		let acquisitionRecord = this.getAcquisition(playerName);
+		if (!acquisitionRecord || acquisitionRecord.instanceId === instanceId) {
 			this.acquiredPlayers.set(playerName, { instanceId });
 			return true;
 		}
@@ -197,5 +210,77 @@ export class ControllerPlugin extends BaseControllerPlugin {
 				size: playerDatastore[0] && playerDatastore[0].length || 0,
 			},
 		);
+	}
+
+	async handleListPlayersRequest() {
+		let entries = new Map<string, msg.PlayerEntry>();
+		for (let [name, playerData] of this.playerDatastore) {
+			entries.set(name, new msg.PlayerEntry(name, playerData.generation, JSON.stringify(playerData).length));
+		}
+		for (let name of this.acquiredPlayers.keys()) {
+			let acquisitionRecord = this.getAcquisition(name);
+			if (!acquisitionRecord) {
+				continue;
+			}
+			let entry = entries.get(name) ?? new msg.PlayerEntry(name);
+			entry.instanceId = acquisitionRecord.instanceId;
+			entries.set(name, entry);
+		}
+		return [...entries.values()];
+	}
+
+	async handleGetPlayerDataRequest(request: msg.GetPlayerDataRequest) {
+		let { playerName } = request;
+		return new msg.GetPlayerDataRequest.Response(
+			this.playerDatastore.get(playerName) ?? null,
+			this.getAcquisition(playerName)?.instanceId,
+		);
+	}
+
+	// Modifying stored data while an instance holds the player is pointless
+	// as the instance uploads its own copy when the player leaves.
+	checkNotAcquired(playerName: string) {
+		let acquisitionRecord = this.getAcquisition(playerName);
+		if (acquisitionRecord) {
+			let instanceName = this.controller.instances.get(acquisitionRecord.instanceId)!.config.get("instance.name");
+			throw new lib.RequestError(
+				`${playerName} is currently acquired by ${instanceName}, ` +
+				"have the player leave or release the lock first"
+			);
+		}
+	}
+
+	async handleSetPlayerDataRequest(request: msg.SetPlayerDataRequest) {
+		let { playerName, playerData } = request;
+		this.checkNotAcquired(playerName);
+
+		// Bump the generation so instances holding an older copy download this one
+		let oldPlayerData = this.playerDatastore.get(playerName);
+		playerData.name = playerName;
+		playerData.generation = Math.max(playerData.generation, (oldPlayerData?.generation ?? 0) + 1);
+		this.playerDatastore.set(playerName, playerData);
+		this.playerDatastoreDirty = true;
+		this.logger.info(`Replaced player data for ${playerName} with generation ${playerData.generation}`);
+		return new msg.SetPlayerDataRequest.Response(playerData.generation);
+	}
+
+	async handleDeletePlayerDataRequest(request: msg.DeletePlayerDataRequest) {
+		let { playerName } = request;
+		if (!this.playerDatastore.has(playerName)) {
+			throw new lib.RequestError(`No player data stored for ${playerName}`);
+		}
+		this.checkNotAcquired(playerName);
+
+		this.playerDatastore.delete(playerName);
+		this.playerDatastoreDirty = true;
+		this.logger.info(`Deleted player data for ${playerName}`);
+	}
+
+	async handleForceReleaseRequest(request: msg.ForceReleaseRequest) {
+		let { playerName } = request;
+		if (!this.acquiredPlayers.delete(playerName)) {
+			throw new lib.RequestError(`${playerName} is not acquired by any instance`);
+		}
+		this.logger.info(`Released lock on ${playerName}`);
 	}
 }

--- a/plugins/inventory_sync/index.ts
+++ b/plugins/inventory_sync/index.ts
@@ -17,6 +17,12 @@ lib.definePermission({
 	grantByDefault: true,
 });
 
+lib.definePermission({
+	name: "inventory_sync.inventory.modify",
+	title: "Modify player inventories",
+	description: "Replace, delete and release the lock on player inventories stored on the controller",
+});
+
 export const plugin: lib.PluginDeclaration = {
 	name: "inventory_sync",
 	title: "Inventory sync",
@@ -34,6 +40,7 @@ export const plugin: lib.PluginDeclaration = {
 	},
 
 	controllerEntrypoint: "dist/node/controller",
+	ctlEntrypoint: "dist/node/control",
 	controllerConfigFields: {
 		"inventory_sync.player_lock_timeout": {
 			title: "Player Lock Timeout",
@@ -56,6 +63,11 @@ export const plugin: lib.PluginDeclaration = {
 		messages.UploadRequest,
 		messages.DownloadRequest,
 		messages.DatabaseStatsRequest,
+		messages.ListPlayersRequest,
+		messages.GetPlayerDataRequest,
+		messages.SetPlayerDataRequest,
+		messages.DeletePlayerDataRequest,
+		messages.ForceReleaseRequest,
 	],
 	webEntrypoint: "./web",
 	routes: ["/inventory"],

--- a/plugins/inventory_sync/messages.ts
+++ b/plugins/inventory_sync/messages.ts
@@ -1,5 +1,5 @@
 import { Type, Static } from "@sinclair/typebox";
-import { StringEnum } from "@clusterio/lib";
+import { StringEnum, jsonArray } from "@clusterio/lib";
 
 // .\module\serialize.lua:serialize.serialize_player()
 export type IpcPlayerData = {
@@ -189,4 +189,159 @@ export class DatabaseStatsRequest {
 	static plugin = "inventory_sync" as const;
 	static permission = "inventory_sync.inventory.view" as const;
 	static Response = DatabaseStatsResponse;
+}
+
+export class PlayerEntry {
+	constructor(
+		public name: string,
+		public generation?: number,
+		public size?: number,
+		public instanceId?: number,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"name": Type.String(),
+		"generation": Type.Optional(Type.Integer()),
+		"size": Type.Optional(Type.Integer()),
+		"instanceId": Type.Optional(Type.Integer()),
+	});
+
+	static fromJSON(json: Static<typeof PlayerEntry.jsonSchema>): PlayerEntry {
+		return new this(json.name, json.generation, json.size, json.instanceId);
+	}
+}
+
+export class ListPlayersRequest {
+	declare ["constructor"]: typeof ListPlayersRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static plugin = "inventory_sync" as const;
+	static permission = "inventory_sync.inventory.view" as const;
+	static Response = jsonArray(PlayerEntry);
+}
+
+export class GetPlayerDataResponse {
+	constructor(
+		public playerData: IpcPlayerData | null,
+		public instanceId?: number,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"playerData": Type.Union([jsonPlayerData, Type.Null()]),
+		"instanceId": Type.Optional(Type.Integer()),
+	});
+
+	static fromJSON(json: Static<typeof GetPlayerDataResponse.jsonSchema>): GetPlayerDataResponse {
+		return new this(json.playerData as IpcPlayerData | null, json.instanceId);
+	}
+}
+
+export class GetPlayerDataRequest {
+	declare ["constructor"]: typeof GetPlayerDataRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static plugin = "inventory_sync" as const;
+	static permission = "inventory_sync.inventory.view" as const;
+	static Response = GetPlayerDataResponse;
+
+	constructor(
+		public playerName: string,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"playerName": Type.String(),
+	});
+
+	static fromJSON(json: Static<typeof GetPlayerDataRequest.jsonSchema>) {
+		return new this(json.playerName);
+	}
+}
+
+export class SetPlayerDataResponse {
+	constructor(
+		public generation: number,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"generation": Type.Integer(),
+	});
+
+	static fromJSON(json: Static<typeof SetPlayerDataResponse.jsonSchema>): SetPlayerDataResponse {
+		return new this(json.generation);
+	}
+}
+
+export class SetPlayerDataRequest {
+	declare ["constructor"]: typeof SetPlayerDataRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static plugin = "inventory_sync" as const;
+	static permission = "inventory_sync.inventory.modify" as const;
+	static Response = SetPlayerDataResponse;
+
+	constructor(
+		public playerName: string,
+		public playerData: IpcPlayerData,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"playerName": Type.String(),
+		"playerData": jsonPlayerData,
+	});
+
+	static fromJSON(json: Static<typeof SetPlayerDataRequest.jsonSchema>) {
+		return new this(json.playerName, json.playerData as IpcPlayerData);
+	}
+}
+
+export class DeletePlayerDataRequest {
+	declare ["constructor"]: typeof DeletePlayerDataRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static plugin = "inventory_sync" as const;
+	static permission = "inventory_sync.inventory.modify" as const;
+
+	constructor(
+		public playerName: string,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"playerName": Type.String(),
+	});
+
+	static fromJSON(json: Static<typeof DeletePlayerDataRequest.jsonSchema>) {
+		return new this(json.playerName);
+	}
+}
+
+export class ForceReleaseRequest {
+	declare ["constructor"]: typeof ForceReleaseRequest;
+	static type = "request" as const;
+	static src = "control" as const;
+	static dst = "controller" as const;
+	static plugin = "inventory_sync" as const;
+	static permission = "inventory_sync.inventory.modify" as const;
+
+	constructor(
+		public playerName: string,
+	) {
+	}
+
+	static jsonSchema = Type.Object({
+		"playerName": Type.String(),
+	});
+
+	static fromJSON(json: Static<typeof ForceReleaseRequest.jsonSchema>) {
+		return new this(json.playerName);
+	}
 }

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -34,6 +34,7 @@
 
 	"peerDependencies": {
 		"@clusterio/controller": "workspace:^",
+		"@clusterio/ctl": "workspace:^",
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^",
 		"@clusterio/web_ui": "workspace:^"
@@ -43,6 +44,7 @@
 	},
 	"devDependencies": {
 		"@clusterio/controller": "workspace:^",
+		"@clusterio/ctl": "workspace:^",
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^",
 		"@clusterio/web_ui": "workspace:^",

--- a/plugins/inventory_sync/player_data.ts
+++ b/plugins/inventory_sync/player_data.ts
@@ -1,0 +1,56 @@
+import type { IpcPlayerData } from "./messages";
+
+// See packages/host/modules/clusterio/serialize.lua for the item stack format
+type SerializedItem = {
+	n?: string,
+	c?: number,
+	q?: string,
+	r?: number,
+	e?: string,
+};
+
+export type ItemSummary = {
+	name: string,
+	quality?: string,
+	count: number,
+	/** Length of the export string for blueprints and other exportable items */
+	exportSize?: number,
+};
+
+export type InventorySummary = {
+	name: string,
+	items: ItemSummary[],
+};
+
+export function summarizeInventory(inventory: { i?: SerializedItem[] }): ItemSummary[] {
+	let items: ItemSummary[] = [];
+	let stacks = new Map<string, ItemSummary>();
+	for (let entry of inventory.i ?? []) {
+		let repeat = (entry.r ?? 0) + 1;
+		if (entry.e !== undefined) {
+			for (let i = 0; i < repeat; i++) {
+				items.push({ name: "exported item", count: 1, exportSize: entry.e.length });
+			}
+			continue;
+		}
+		if (entry.n === undefined) {
+			continue;
+		}
+		let key = `${entry.n}\0${entry.q ?? ""}`;
+		let stack = stacks.get(key);
+		if (!stack) {
+			stack = { name: entry.n, quality: entry.q, count: 0 };
+			stacks.set(key, stack);
+			items.push(stack);
+		}
+		stack.count += (entry.c ?? 0) * repeat;
+	}
+	return items;
+}
+
+export function summarizePlayerInventories(playerData: IpcPlayerData): InventorySummary[] {
+	let inventories = playerData.character?.inventories ?? playerData.inventories ?? {};
+	return Object.entries(inventories).map(
+		([name, inventory]) => ({ name, items: summarizeInventory(inventory as { i?: SerializedItem[] }) })
+	);
+}

--- a/plugins/inventory_sync/test/plugin.js
+++ b/plugins/inventory_sync/test/plugin.js
@@ -1,0 +1,246 @@
+"use strict";
+const assert = require("assert").strict;
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+
+const lib = require("@clusterio/lib");
+const { InstanceRecord } = require("@clusterio/controller");
+
+const mock = require("../../../test/mock");
+const { testRoundTripJsonSerialisable, testMatrix } = require("../../../test/common");
+const controller = require("../dist/node/controller");
+const info = require("../dist/node/index").plugin;
+const msg = require("../dist/node/messages");
+const { summarizeInventory, summarizePlayerInventories } = require("../dist/node/player_data");
+
+
+function playerData(name, generation, extra = {}) {
+	return { generation, name, controller: "character", force: "player", ...extra };
+}
+
+describe("inventory_sync plugin", function() {
+	describe("messages", function() {
+		it("PlayerEntry should be round trip json serialisable", function() {
+			testRoundTripJsonSerialisable(msg.PlayerEntry, testMatrix(
+				["player"], // name
+				[undefined, 0, 4], // generation
+				[undefined, 0, 1234], // size
+				[undefined, 1], // instanceId
+			));
+		});
+		it("GetPlayerDataResponse should be round trip json serialisable", function() {
+			testRoundTripJsonSerialisable(msg.GetPlayerDataResponse, testMatrix(
+				[null, playerData("player", 1)], // playerData
+				[undefined, 1], // instanceId
+			));
+		});
+		it("SetPlayerDataResponse should be round trip json serialisable", function() {
+			testRoundTripJsonSerialisable(msg.SetPlayerDataResponse, testMatrix([1, 5]));
+		});
+		it("requests should be round trip json serialisable", function() {
+			testRoundTripJsonSerialisable(msg.GetPlayerDataRequest, testMatrix(["player"]));
+			testRoundTripJsonSerialisable(msg.DeletePlayerDataRequest, testMatrix(["player"]));
+			testRoundTripJsonSerialisable(msg.ForceReleaseRequest, testMatrix(["player"]));
+			testRoundTripJsonSerialisable(msg.SetPlayerDataRequest, testMatrix(
+				["player"], // playerName
+				[playerData("player", 3)], // playerData
+			));
+		});
+	});
+
+	describe("summarizeInventory()", function() {
+		it("should merge stacks and expand repeats", function() {
+			assert.deepEqual(summarizeInventory({ i: [
+				{ n: "iron-plate", c: 100, r: 2 },
+				{ n: "iron-plate", c: 50, q: "rare" },
+				{ n: "iron-plate", c: 7, s: 10 },
+				{ e: "0eNq", r: 1 },
+				{ f: "copper-plate" },
+			] }), [
+				{ name: "iron-plate", quality: undefined, count: 307 },
+				{ name: "iron-plate", quality: "rare", count: 50 },
+				{ name: "exported item", count: 1, exportSize: 4 },
+				{ name: "exported item", count: 1, exportSize: 4 },
+			]);
+		});
+		it("should handle empty inventories", function() {
+			assert.deepEqual(summarizeInventory({}), []);
+		});
+	});
+
+	describe("summarizePlayerInventories()", function() {
+		it("should prefer character inventories", function() {
+			const data = playerData("player", 1, {
+				character: { inventories: { main: { i: [{ n: "wood", c: 1 }] } } },
+				inventories: { main: { i: [{ n: "stone", c: 1 }] } },
+			});
+			assert.deepEqual(summarizePlayerInventories(data), [
+				{ name: "main", items: [{ name: "wood", quality: undefined, count: 1 }] },
+			]);
+		});
+		it("should fall back to player inventories", function() {
+			const data = playerData("player", 1, { inventories: { main: { i: [{ n: "stone", c: 1 }] } } });
+			assert.deepEqual(summarizePlayerInventories(data), [
+				{ name: "main", items: [{ name: "stone", quality: undefined, count: 1 }] },
+			]);
+		});
+		it("should handle missing inventories", function() {
+			assert.deepEqual(summarizePlayerInventories(playerData("player", 1)), []);
+		});
+	});
+
+	describe("class ControllerPlugin", function() {
+		let controllerPlugin;
+		let databaseDir;
+		before(async function() {
+			databaseDir = await fs.mkdtemp(path.join(os.tmpdir(), "inventory_sync-"));
+			const mockController = new mock.MockController();
+			mockController.mockConfigEntries.set("controller.database_directory", databaseDir);
+			mockController.mockConfigEntries.set("inventory_sync.player_lock_timeout", 60);
+			for (const [id, name] of [[1, "Running"], [2, "Stopped"]]) {
+				mockController.instances.records.set(id, new InstanceRecord(
+					new lib.InstanceConfig("controller", { "instance.id": id, "instance.name": name }), "running",
+				));
+			}
+			controllerPlugin = new controller.ControllerPlugin(info, mockController, {}, new mock.MockLogger());
+			await controllerPlugin.init();
+		});
+		after(async function() {
+			await fs.rm(databaseDir, { recursive: true, force: true });
+		});
+		beforeEach(function() {
+			controllerPlugin.acquiredPlayers.clear();
+			controllerPlugin.playerDatastore.clear();
+			controllerPlugin.playerDatastoreDirty = false;
+			controllerPlugin.playerDatastore.set("stored", playerData("stored", 3));
+			controllerPlugin.acquiredPlayers.set("stored", { instanceId: 1 });
+			controllerPlugin.acquiredPlayers.set("online", { instanceId: 1 });
+			controllerPlugin.acquiredPlayers.set("expired", { instanceId: 2, expiresMs: Date.now() - 1000 });
+			controllerPlugin.acquiredPlayers.set("gone", { instanceId: 99 });
+		});
+
+		describe(".handleListPlayersRequest()", function() {
+			it("should list stored data and live acquisitions", async function() {
+				const entries = await controllerPlugin.handleListPlayersRequest();
+				entries.sort((a, b) => a.name.localeCompare(b.name));
+				assert.deepEqual(entries, [
+					new msg.PlayerEntry("online", undefined, undefined, 1),
+					new msg.PlayerEntry(
+						"stored", 3, JSON.stringify(controllerPlugin.playerDatastore.get("stored")).length, 1
+					),
+				]);
+			});
+		});
+
+		describe(".handleGetPlayerDataRequest()", function() {
+			it("should return stored data and acquisition", async function() {
+				const response = await controllerPlugin.handleGetPlayerDataRequest(
+					new msg.GetPlayerDataRequest("stored")
+				);
+				assert.deepEqual(response, new msg.GetPlayerDataResponse(playerData("stored", 3), 1));
+			});
+			it("should return null for unknown players", async function() {
+				const response = await controllerPlugin.handleGetPlayerDataRequest(
+					new msg.GetPlayerDataRequest("unknown")
+				);
+				assert.deepEqual(response, new msg.GetPlayerDataResponse(null, undefined));
+			});
+			it("should ignore expired and dangling acquisitions", async function() {
+				for (const name of ["expired", "gone"]) {
+					const response = await controllerPlugin.handleGetPlayerDataRequest(
+						new msg.GetPlayerDataRequest(name)
+					);
+					assert.equal(response.instanceId, undefined);
+				}
+			});
+		});
+
+		describe(".handleSetPlayerDataRequest()", function() {
+			it("should store data with a bumped generation", async function() {
+				controllerPlugin.acquiredPlayers.delete("stored");
+				const response = await controllerPlugin.handleSetPlayerDataRequest(
+					new msg.SetPlayerDataRequest("stored", playerData("other", 1))
+				);
+				assert.deepEqual(response, new msg.SetPlayerDataResponse(4));
+				assert.deepEqual(controllerPlugin.playerDatastore.get("stored"), playerData("stored", 4));
+				assert(controllerPlugin.playerDatastoreDirty);
+			});
+			it("should keep a higher provided generation", async function() {
+				controllerPlugin.acquiredPlayers.delete("stored");
+				const response = await controllerPlugin.handleSetPlayerDataRequest(
+					new msg.SetPlayerDataRequest("stored", playerData("stored", 10))
+				);
+				assert.equal(response.generation, 10);
+			});
+			it("should store data for new players", async function() {
+				const response = await controllerPlugin.handleSetPlayerDataRequest(
+					new msg.SetPlayerDataRequest("new", playerData("new", 0))
+				);
+				assert.equal(response.generation, 1);
+				assert.equal(controllerPlugin.playerDatastore.get("new").generation, 1);
+			});
+			it("should reject when the player is acquired", async function() {
+				await assert.rejects(
+					controllerPlugin.handleSetPlayerDataRequest(
+						new msg.SetPlayerDataRequest("stored", playerData("stored", 3))
+					),
+					new lib.RequestError(
+						"stored is currently acquired by Running, have the player leave or release the lock first"
+					),
+				);
+				assert.equal(controllerPlugin.playerDatastore.get("stored").generation, 3);
+			});
+		});
+
+		describe(".handleDeletePlayerDataRequest()", function() {
+			it("should delete stored data", async function() {
+				controllerPlugin.acquiredPlayers.delete("stored");
+				await controllerPlugin.handleDeletePlayerDataRequest(new msg.DeletePlayerDataRequest("stored"));
+				assert(!controllerPlugin.playerDatastore.has("stored"));
+				assert(controllerPlugin.playerDatastoreDirty);
+			});
+			it("should reject unknown players", async function() {
+				await assert.rejects(
+					controllerPlugin.handleDeletePlayerDataRequest(new msg.DeletePlayerDataRequest("unknown")),
+					new lib.RequestError("No player data stored for unknown"),
+				);
+			});
+			it("should reject when the player is acquired", async function() {
+				await assert.rejects(
+					controllerPlugin.handleDeletePlayerDataRequest(new msg.DeletePlayerDataRequest("stored")),
+					new lib.RequestError(
+						"stored is currently acquired by Running, have the player leave or release the lock first"
+					),
+				);
+				assert(controllerPlugin.playerDatastore.has("stored"));
+			});
+		});
+
+		describe(".handleForceReleaseRequest()", function() {
+			it("should remove the acquisition", async function() {
+				await controllerPlugin.handleForceReleaseRequest(new msg.ForceReleaseRequest("online"));
+				assert(!controllerPlugin.acquiredPlayers.has("online"));
+				assert(controllerPlugin.acquire(2, "online"));
+			});
+			it("should reject players that are not acquired", async function() {
+				await assert.rejects(
+					controllerPlugin.handleForceReleaseRequest(new msg.ForceReleaseRequest("unknown")),
+					new lib.RequestError("unknown is not acquired by any instance"),
+				);
+			});
+		});
+
+		describe(".acquire()", function() {
+			it("should refuse players held by another instance", function() {
+				assert(!controllerPlugin.acquire(2, "online"));
+				assert(controllerPlugin.acquire(1, "online"));
+			});
+			it("should take over expired and dangling acquisitions", function() {
+				assert(controllerPlugin.acquire(1, "expired"));
+				assert(controllerPlugin.acquire(1, "gone"));
+				assert.deepEqual(controllerPlugin.acquiredPlayers.get("gone"), { instanceId: 1 });
+			});
+		});
+	});
+});

--- a/plugins/inventory_sync/test/plugin.js
+++ b/plugins/inventory_sync/test/plugin.js
@@ -10,6 +10,7 @@ const { InstanceRecord } = require("@clusterio/controller");
 const mock = require("../../../test/mock");
 const { testRoundTripJsonSerialisable, testMatrix } = require("../../../test/common");
 const controller = require("../dist/node/controller");
+const { CtlPlugin } = require("../dist/node/control");
 const info = require("../dist/node/index").plugin;
 const msg = require("../dist/node/messages");
 const { summarizeInventory, summarizePlayerInventories } = require("../dist/node/player_data");
@@ -66,6 +67,10 @@ describe("inventory_sync plugin", function() {
 		});
 		it("should handle empty inventories", function() {
 			assert.deepEqual(summarizeInventory({}), []);
+			assert.deepEqual(
+				summarizeInventory({ i: [{ n: "wood" }] }),
+				[{ name: "wood", quality: undefined, count: 0 }],
+			);
 		});
 	});
 
@@ -87,6 +92,127 @@ describe("inventory_sync plugin", function() {
 		});
 		it("should handle missing inventories", function() {
 			assert.deepEqual(summarizePlayerInventories(playerData("player", 1)), []);
+			assert.deepEqual(summarizePlayerInventories(playerData("player", 1, { character: {} })), []);
+		});
+	});
+
+	describe("class CtlPlugin", function() {
+		let commands;
+		let sent;
+		let printed;
+		let responses;
+		const control = {
+			async send(message) {
+				sent.push(message);
+				const handler = responses.get(message.constructor);
+				if (!handler) {
+					throw new Error(`Unexpected ${message.constructor.name}`);
+				}
+				return handler(message);
+			},
+		};
+		const storedData = playerData("alice", 2, {
+			character: { inventories: { main: { i: [{ n: "wood", c: 5, q: "rare" }, { e: "0eNq" }] } } },
+		});
+		let tempDir;
+
+		before(async function() {
+			const root = new lib.CommandTree({ name: "clusterioctl", description: "root" });
+			const ctlPlugin = new CtlPlugin(info, new mock.MockLogger());
+			await ctlPlugin.addCommands(root);
+			commands = root.subCommands.get("inventory-sync").subCommands;
+			tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "inventory_sync-ctl-"));
+		});
+		after(async function() {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		});
+		beforeEach(function() {
+			sent = [];
+			printed = [];
+			responses = new Map([
+				[lib.InstanceDetailsGetRequest, request => ({ id: request.instanceId, name: "Test" })],
+				[msg.ListPlayersRequest, () => [
+					new msg.PlayerEntry("bob", undefined, undefined, 1),
+					new msg.PlayerEntry("alice", 2, 100),
+				]],
+				[msg.GetPlayerDataRequest, request => new msg.GetPlayerDataResponse(
+					request.playerName === "alice" ? storedData : null, request.playerName === "alice" ? 1 : undefined
+				)],
+				[msg.SetPlayerDataRequest, () => new msg.SetPlayerDataResponse(3)],
+				[msg.DeletePlayerDataRequest, () => undefined],
+				[msg.ForceReleaseRequest, () => undefined],
+			]);
+		});
+
+		async function run(name, args = {}) {
+			/* eslint-disable no-console */
+			const original = console.log;
+			console.log = (...values) => printed.push(values.join(" "));
+			try {
+				await commands.get(name).run(args, control);
+			} finally {
+				console.log = original;
+			}
+			/* eslint-enable no-console */
+		}
+
+		it("list should print sorted entries", async function() {
+			await run("list");
+			assert.deepEqual(printed, [
+				"name | generation | size | acquired by",
+				`alice | 2 | ${lib.formatBytes(100)} | -`,
+				"bob | - | - | Test (1)",
+			]);
+		});
+		it("show should print a summary", async function() {
+			await run("show", { player: "alice" });
+			assert.deepEqual(printed, [
+				"acquired by: Test (1)",
+				"generation: 2",
+				`size: ${lib.formatBytes(JSON.stringify(storedData).length)}`,
+				"controller: character",
+				"force: player",
+				"main:",
+				"  5 wood (rare)",
+				`  1 exported item ${lib.formatBytes(4)}`,
+			]);
+		});
+		it("show should handle players without data", async function() {
+			await run("show", { player: "carol" });
+			assert.deepEqual(printed, ["acquired by: -", "No player data stored for carol"]);
+		});
+		it("export should print or write JSON", async function() {
+			await run("export", { player: "alice" });
+			assert.deepEqual(JSON.parse(printed.join("\n")), storedData);
+			const file = path.join(tempDir, "alice.json");
+			await run("export", { player: "alice", file });
+			assert.deepEqual(JSON.parse(await fs.readFile(file, "utf8")), storedData);
+			await assert.rejects(
+				run("export", { player: "carol" }),
+				new lib.CommandError("No player data stored for carol"),
+			);
+		});
+		it("import should send the file contents", async function() {
+			const file = path.join(tempDir, "import.json");
+			await fs.writeFile(file, JSON.stringify({ name: "other", controller: "god" }));
+			await run("import", { player: "alice", file });
+			assert.deepEqual(sent, [
+				new msg.SetPlayerDataRequest("alice", { name: "alice", controller: "god", generation: 0 }),
+			]);
+			assert.deepEqual(printed, ["Stored player data for alice as generation 3"]);
+		});
+		it("import should reject non-object JSON", async function() {
+			const file = path.join(tempDir, "bad.json");
+			await fs.writeFile(file, "[1]");
+			await assert.rejects(
+				run("import", { player: "alice", file }),
+				new lib.CommandError("Player data must be a JSON object"),
+			);
+		});
+		it("delete and release should send requests", async function() {
+			await run("delete", { player: "alice" });
+			await run("release", { player: "alice" });
+			assert.deepEqual(sent, [new msg.DeletePlayerDataRequest("alice"), new msg.ForceReleaseRequest("alice")]);
 		});
 	});
 

--- a/plugins/inventory_sync/tsconfig.browser.json
+++ b/plugins/inventory_sync/tsconfig.browser.json
@@ -4,5 +4,5 @@
 		{ "path": "../../packages/lib/tsconfig.browser.json" },
 		{ "path": "../../packages/web_ui/tsconfig.browser.json" },
 	],
-	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "package.json" ],
+	"include": [ "web/**/*.tsx", "web/**/*.ts", "messages.ts", "player_data.ts", "package.json" ],
 }

--- a/plugins/inventory_sync/tsconfig.node.json
+++ b/plugins/inventory_sync/tsconfig.node.json
@@ -4,6 +4,7 @@
 		{ "path": "../../packages/lib/tsconfig.node.json" },
 		{ "path": "../../packages/host/tsconfig.node.json" },
 		{ "path": "../../packages/controller/tsconfig.node.json" },
+		{ "path": "../../packages/ctl/tsconfig.node.json" },
 	],
 	"include": ["./**/*.ts"],
 	"exclude": ["test/*", "./dist/*"],

--- a/plugins/inventory_sync/web/index.tsx
+++ b/plugins/inventory_sync/web/index.tsx
@@ -1,29 +1,279 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { Alert, Button, Descriptions, Drawer, Popconfirm, Space, Table, Typography, Upload } from "antd";
 
-import { BaseWebPlugin, PageLayout, PageHeader, ControlContext } from "@clusterio/web_ui";
-import { DatabaseStatsRequest, DatabaseStatsResponse } from "../messages";
+import * as lib from "@clusterio/lib";
+import {
+	BaseWebPlugin, PageLayout, PageHeader, ControlContext, FactorioIcon, notify, notifyErrorHandler,
+	useAccount, useInstances, useDefaultModPack, useExportLocale, useExportPrototypeMetadata,
+	useTableQueryState, useColumnSearch,
+} from "@clusterio/web_ui";
+import {
+	DatabaseStatsRequest, DatabaseStatsResponse, DeletePlayerDataRequest, ForceReleaseRequest,
+	GetPlayerDataRequest, GetPlayerDataResponse, IpcPlayerData, ListPlayersRequest, PlayerEntry,
+	SetPlayerDataRequest,
+} from "../messages";
+import { type ItemSummary, summarizePlayerInventories } from "../player_data";
 
 import "./style.css";
 
+const strcmp = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" }).compare;
+
+function useInstanceName() {
+	const [instances] = useInstances();
+	return (instanceId?: number) => {
+		if (instanceId === undefined) {
+			return "";
+		}
+		return instances.get(instanceId)?.name ?? `Instance ${instanceId}`;
+	};
+}
+
+function InventoryTable(props: { name: string, items: ItemSummary[] }) {
+	const modPack = useDefaultModPack();
+	const locale = useExportLocale(modPack);
+	const prototypes = useExportPrototypeMetadata(modPack);
+	const itemMetadata = prototypes?.get("item");
+
+	function getLocaleName(itemName: string) {
+		let meta = itemMetadata?.get(itemName);
+		if (typeof meta?.localised_name === "string") {
+			return meta.localised_name;
+		}
+		if (meta?.localised_name) {
+			return locale.get(meta.localised_name[0]) ?? itemName;
+		}
+		return locale.get(`item-name.${itemName}`) ?? locale.get(`entity-name.${itemName}`) ?? itemName;
+	}
+
+	return <Table
+		size="small"
+		title={() => props.name}
+		columns={[
+			{
+				title: "Item",
+				key: "item",
+				render: (_, item) => (item.exportSize !== undefined
+					? <Typography.Text type="secondary">{item.name}</Typography.Text>
+					: <>
+						<FactorioIcon modPackId={modPack?.id} prototype={itemMetadata?.get(item.name)} />
+						{getLocaleName(item.name)}
+					</>
+				),
+			},
+			{
+				title: "Quality",
+				key: "quality",
+				render: (_, item) => item.quality,
+			},
+			{
+				title: "Count",
+				key: "count",
+				align: "right",
+				render: (_, item) => item.count,
+			},
+			{
+				title: "Size",
+				key: "size",
+				align: "right",
+				render: (_, item) => (item.exportSize === undefined ? "" : lib.formatBytes(item.exportSize)),
+			},
+		]}
+		dataSource={props.items.map((item, key) => ({ ...item, key }))}
+		pagination={false}
+	/>;
+}
+
+function PlayerDrawer(props: { playerName?: string, onClose: () => void, onChange: () => void }) {
+	const control = useContext(ControlContext);
+	const account = useAccount();
+	const instanceName = useInstanceName();
+	const [response, setResponse] = useState<GetPlayerDataResponse>();
+	const { playerName } = props;
+
+	const reload = useCallback(() => {
+		if (playerName === undefined) {
+			setResponse(undefined);
+			return;
+		}
+		control.send(new GetPlayerDataRequest(playerName)).then(setResponse).catch(
+			notifyErrorHandler("Error loading player data")
+		);
+	}, [control, playerName]);
+	useEffect(reload, [reload]);
+
+	function changed() {
+		reload();
+		props.onChange();
+	}
+
+	async function upload(file: File) {
+		let playerData: IpcPlayerData;
+		try {
+			playerData = JSON.parse(await file.text());
+		} catch (err: any) {
+			notify("Invalid JSON", "error", err.message);
+			return;
+		}
+		playerData.name = playerName!;
+		playerData.generation ??= 0;
+		let result = await control.send(new SetPlayerDataRequest(playerName!, playerData));
+		notify(`Stored player data for ${playerName} as generation ${result.generation}`);
+		changed();
+	}
+
+	function download() {
+		let json = JSON.stringify(response!.playerData, null, "\t");
+		let url = URL.createObjectURL(new Blob([json], { type: "application/json" }));
+		let link = document.createElement("a");
+		link.href = url;
+		link.download = `${playerName}.json`;
+		link.click();
+		URL.revokeObjectURL(url);
+	}
+
+	const canModify = account.hasPermission("inventory_sync.inventory.modify");
+	const playerData = response?.playerData;
+	const acquiredBy = response?.instanceId !== undefined ? instanceName(response.instanceId) : undefined;
+	return <Drawer
+		title={playerName}
+		open={playerName !== undefined}
+		onClose={props.onClose}
+		size="large"
+	>
+		{response && <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+			{acquiredBy !== undefined && <Alert
+				type="info"
+				showIcon
+				message={`Acquired by ${acquiredBy}`}
+				description={
+					"The instance uploads its copy of the player data when the player leaves. Have the player " +
+					"leave before modifying it, or release the lock if the instance is stuck holding it."
+				}
+				action={canModify && <Popconfirm
+					title="Release the lock on this player?"
+					onConfirm={() => control.send(new ForceReleaseRequest(playerName!)).then(changed).catch(
+						notifyErrorHandler("Error releasing lock")
+					)}
+				>
+					<Button>Release</Button>
+				</Popconfirm>}
+			/>}
+			<Descriptions bordered size="small" column={2}>
+				<Descriptions.Item label="Generation">{playerData?.generation ?? "-"}</Descriptions.Item>
+				<Descriptions.Item label="Size">
+					{playerData ? lib.formatBytes(JSON.stringify(playerData).length) : "-"}
+				</Descriptions.Item>
+				<Descriptions.Item label="Controller">{playerData?.controller ?? "-"}</Descriptions.Item>
+				<Descriptions.Item label="Force">{playerData?.force ?? "-"}</Descriptions.Item>
+			</Descriptions>
+			<Space wrap>
+				<Button disabled={!playerData} onClick={download}>Export JSON</Button>
+				{canModify && <Upload
+					accept=".json,application/json"
+					showUploadList={false}
+					beforeUpload={file => {
+						upload(file).catch(notifyErrorHandler("Error storing player data"));
+						return false;
+					}}
+				>
+					<Button>Import JSON</Button>
+				</Upload>}
+				{canModify && <Popconfirm
+					title="Delete the stored player data?"
+					description={
+						"The next join creates a new synced inventory from whatever the player has on that instance."
+					}
+					okText="Delete"
+					okButtonProps={{ danger: true }}
+					onConfirm={() => control.send(new DeletePlayerDataRequest(playerName!)).then(changed).catch(
+						notifyErrorHandler("Error deleting player data")
+					)}
+				>
+					<Button danger disabled={!playerData}>Delete</Button>
+				</Popconfirm>}
+			</Space>
+			{!playerData && <Typography.Text type="secondary">No player data stored</Typography.Text>}
+			{playerData && summarizePlayerInventories(playerData).map(
+				inventory => <InventoryTable key={inventory.name} {...inventory} />
+			)}
+		</Space>}
+	</Drawer>;
+}
+
 function InventoryPage() {
-	let control = useContext(ControlContext);
+	const control = useContext(ControlContext);
+	const instanceName = useInstanceName();
+	const [statsData, setStatsData] = useState<DatabaseStatsResponse>();
+	const [players, setPlayers] = useState<PlayerEntry[]>([]);
+	const [selected, setSelected] = useState<string>();
 
-	let [statsData, updateStatsData] = useState<DatabaseStatsResponse>();
+	const tableState = useTableQueryState<PlayerEntry>({
+		namespace: "inventory", defaultSortKey: "name", pagination: { defaultPageSize: 50 },
+	});
+	const nameSearch = useColumnSearch<PlayerEntry>(tableState, "name", player => player.name, "Search");
 
-	useEffect(() => {
-		(async () => {
-			// Get statistics
-			updateStatsData(await control.send(new DatabaseStatsRequest()));
-		})();
-	}, []);
+	const reload = useCallback(() => {
+		control.send(new DatabaseStatsRequest()).then(setStatsData).catch(
+			notifyErrorHandler("Error loading inventory sync statistics")
+		);
+		control.send(new ListPlayersRequest()).then(setPlayers).catch(
+			notifyErrorHandler("Error loading player list")
+		);
+	}, [control]);
+	useEffect(reload, [reload]);
 
 	return <PageLayout nav={[{ name: "Inventory sync" }]}>
 		<PageHeader title="Inventory sync" />
 		{statsData && <>
-			<p>Database size: {Math.round(statsData.databaseSize / 1000)}kB</p>
+			<p>Database size: {lib.formatBytes(statsData.databaseSize)}</p>
 			<p>Database entries: {statsData.databaseEntries}</p>
-			<p>Largest entry is {statsData.largestEntry.name} with {(statsData.largestEntry.size / 1000)}kB</p>
+			<p>Largest entry is {statsData.largestEntry.name} with {lib.formatBytes(statsData.largestEntry.size)}</p>
 		</>}
+		<Table
+			columns={[
+				{
+					title: "Name",
+					key: "name",
+					dataIndex: "name",
+					...nameSearch,
+					filteredValue: tableState.filteredValue("name"),
+					sorter: (a, b) => strcmp(a.name, b.name),
+					sortOrder: tableState.sortOrder("name"),
+				},
+				{
+					title: "Generation",
+					key: "generation",
+					align: "right",
+					sorter: (a, b) => (a.generation ?? -1) - (b.generation ?? -1),
+					sortOrder: tableState.sortOrder("generation"),
+					render: (_, player) => player.generation ?? "-",
+				},
+				{
+					title: "Size",
+					key: "size",
+					align: "right",
+					sorter: (a, b) => (a.size ?? -1) - (b.size ?? -1),
+					sortOrder: tableState.sortOrder("size"),
+					render: (_, player) => (player.size === undefined ? "-" : lib.formatBytes(player.size)),
+				},
+				{
+					title: "Acquired by",
+					key: "instance",
+					sorter: (a, b) => strcmp(instanceName(a.instanceId), instanceName(b.instanceId)),
+					sortOrder: tableState.sortOrder("instance"),
+					render: (_, player) => instanceName(player.instanceId),
+				},
+			]}
+			dataSource={players}
+			rowKey="name"
+			pagination={tableState.pagination}
+			onChange={tableState.onChange}
+			onRow={player => ({
+				style: { cursor: "pointer" },
+				onClick: () => setSelected(player.name),
+			})}
+		/>
+		<PlayerDrawer playerName={selected} onClose={() => setSelected(undefined)} onChange={reload} />
 	</PageLayout>;
 }
 


### PR DESCRIPTION
Closes #1003

When inventory sync breaks for a player there was no way to see what the controller has stored for them or to fix it. This adds that, on the controller side only.

The Inventory sync web page now lists every stored entry with its generation, size and the instance currently holding the lock. Clicking a row opens a drawer with a per-inventory item summary (blueprints and other exported items show their export size instead of a name), Export JSON, Import JSON, Delete, and a Release button when an instance holds the lock. The same operations exist as `clusterioctl inventory-sync list|show|export|import|delete|release`.

Import bumps the generation past the stored one so instances holding an older copy download the new data on the next join. Import and delete are refused while an instance holds the player, since the instance uploads its own copy when the player leaves and that would undo the change. Release exists for the case where an instance is stuck holding a lock. A new `inventory_sync.inventory.modify` permission (not granted by default) gates the write operations; the existing view permission covers listing and export.

The detail view is a drawer rather than a `/inventory/:name` route because plugin web bundles do not share react-router-dom, so a plugin page cannot use `useParams`.

Not included: anything that touches the in-game state on an instance. A "force resync on instance" command could be a follow-up if wanted.

Tested with a new mocha suite for the messages, inventory summary and controller handlers, and by clicking through the web page and running each ctl command against the integration harness in a real browser.

### Changelog
```
### Features
- Added tools to inspect, replace, delete and unlock player data stored by inventory sync, in the web interface and as `clusterioctl inventory-sync` commands. #1003
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
