### PR TITLE
Add context to connection and response log messages

### DIFF
--- a/packages/controller/src/WsServerConnector.ts
+++ b/packages/controller/src/WsServerConnector.ts
@@ -106,6 +106,9 @@ export default class WsServerConnector extends lib.WebSocketBaseConnector {
 		this._state = "connected";
 		this._attachSocketHandlers();
 		this._dropSendBufferSeq(lastSeq);
+		logger.verbose(
+			`Connector | resuming session with ${this.dst}, resending ${this._sendBuffer.length} buffered messages`
+		);
 		for (let message of this._sendBuffer) {
 			this._socket.send(JSON.stringify(message));
 		}
@@ -113,7 +116,7 @@ export default class WsServerConnector extends lib.WebSocketBaseConnector {
 	}
 
 	_timedOut() {
-		logger.verbose("Connector | Connection timed out");
+		logger.verbose(`Connector | Connection to ${this.dst} timed out`);
 		this._close();
 	}
 

--- a/packages/lib/src/link/connectors.ts
+++ b/packages/lib/src/link/connectors.ts
@@ -710,12 +710,14 @@ export abstract class WebSocketClientConnector extends WebSocketBaseConnector<We
 			this.emit("connect", data);
 
 		} else if (type === "continue") {
-			logger.info("Connector | resuming existing session");
 			this._state = "connected";
 			this._heartbeatInterval = data.heartbeatInterval;
 			this._sessionTimeout = data.sessionTimeout;
 			this.startHeartbeat();
 			this._dropSendBufferSeq(data.lastSeq);
+			logger.info(
+				`Connector | resuming existing session, resending ${this._sendBuffer.length} buffered messages`
+			);
 			for (let bufferedMessage of this._sendBuffer) {
 				this._sendInternal(bufferedMessage);
 			}

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -444,7 +444,7 @@ export class Link {
 		let pending = this._pendingRequests.get(message.dst.requestId!);
 		if (!pending) {
 			throw new libErrors.InvalidMessage(
-				`Received response ${message.dst.requestId} without a pending request`
+				`Received response ${message.dst.requestId} from ${message.src} without a pending request`
 			);
 		}
 
@@ -465,7 +465,7 @@ export class Link {
 		let pending = this._pendingRequests.get(message.dst.requestId!);
 		if (!pending) {
 			throw new libErrors.InvalidMessage(
-				`Received error response ${message.dst.requestId} without a pending request`
+				`Received error response ${message.dst.requestId} from ${message.src} without a pending request`
 			);
 		}
 


### PR DESCRIPTION
Closes #1007.

Three log messages lacked the detail needed to act on them. The "without a pending request" error now names the address the response came from. The server side connector timeout now names the peer it was waiting on, so a host or control timing out is identifiable from the controller log. Both sides of a session resume now log how many buffered messages get resent, which is a cheap way to see how much was queued while the link was down.

### Changelog
```
### Changes
- Log the source of responses received without a pending request, the peer of timed out connections and the number of messages resent on session resume. #1007
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
