### PR TITLE
Fix plugin dependencies

### DIFF
--- a/packages/create/templates/common/package.json
+++ b/packages/create/templates/common/package.json
@@ -27,6 +27,31 @@
 //%endif
 		"@clusterio/lib": "^__clusterio_version__"
 	},
+//%if controller | host | ctl
+	"peerDependenciesMeta": {
+//%endif
+//%if controller
+		"@clusterio/controller": {
+			"optional": true
+//%endif
+//%if controller & host | controller & ctl
+		},
+//%endif
+//%if host
+		"@clusterio/host": {
+			"optional": true
+//%endif
+//%if host & ctl
+		},
+//%endif
+//%if ctl
+		"@clusterio/ctl": {
+			"optional": true
+//%endif
+//%if controller | host | ctl
+		}
+	},
+//%endif
 	"devDependencies": {
 //%// Typescript and type declarations
 //%if typescript

--- a/packages/create/templates/common/package.json
+++ b/packages/create/templates/common/package.json
@@ -19,9 +19,6 @@
 //%if controller
 		"@clusterio/controller": "^__clusterio_version__",
 //%endif
-//%if webpack
-		"@clusterio/web_ui": "^__clusterio_version__",
-//%endif
 //%if host
 		"@clusterio/host": "^__clusterio_version__",
 //%endif

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -36,8 +36,7 @@
 	"peerDependencies": {
 		"@clusterio/ctl": "workspace:^",
 		"@clusterio/host": "workspace:^",
-		"@clusterio/lib": "workspace:^",
-		"@clusterio/web_ui": "workspace:^"
+		"@clusterio/lib": "workspace:^"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"

--- a/plugins/global_chat/package.json
+++ b/plugins/global_chat/package.json
@@ -38,6 +38,14 @@
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^"
 	},
+	"peerDependenciesMeta": {
+		"@clusterio/ctl": {
+			"optional": true
+		},
+		"@clusterio/host": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"
 	},

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -36,8 +36,7 @@
 	"peerDependencies": {
 		"@clusterio/controller": "workspace:^",
 		"@clusterio/host": "workspace:^",
-		"@clusterio/lib": "workspace:^",
-		"@clusterio/web_ui": "workspace:^"
+		"@clusterio/lib": "workspace:^"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"

--- a/plugins/inventory_sync/package.json
+++ b/plugins/inventory_sync/package.json
@@ -38,6 +38,14 @@
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^"
 	},
+	"peerDependenciesMeta": {
+		"@clusterio/controller": {
+			"optional": true
+		},
+		"@clusterio/host": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"
 	},

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -36,8 +36,7 @@
 	"peerDependencies": {
 		"@clusterio/controller": "workspace:^",
 		"@clusterio/host": "workspace:^",
-		"@clusterio/lib": "workspace:^",
-		"@clusterio/web_ui": "workspace:^"
+		"@clusterio/lib": "workspace:^"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:",

--- a/plugins/player_auth/package.json
+++ b/plugins/player_auth/package.json
@@ -38,6 +38,14 @@
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^"
 	},
+	"peerDependenciesMeta": {
+		"@clusterio/controller": {
+			"optional": true
+		},
+		"@clusterio/host": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:",
 		"jsonwebtoken": "catalog:",

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -36,8 +36,7 @@
 	"peerDependencies": {
 		"@clusterio/controller": "workspace:^",
 		"@clusterio/host": "workspace:^",
-		"@clusterio/lib": "workspace:^",
-		"@clusterio/web_ui": "workspace:^"
+		"@clusterio/lib": "workspace:^"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"

--- a/plugins/research_sync/package.json
+++ b/plugins/research_sync/package.json
@@ -38,6 +38,14 @@
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^"
 	},
+	"peerDependenciesMeta": {
+		"@clusterio/controller": {
+			"optional": true
+		},
+		"@clusterio/host": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"
 	},

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -37,6 +37,14 @@
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^"
 	},
+	"peerDependenciesMeta": {
+		"@clusterio/controller": {
+			"optional": true
+		},
+		"@clusterio/host": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@clusterio/web_ui": "workspace:^",
 		"@clusterio/host": "workspace:^",

--- a/plugins/statistics_exporter/package.json
+++ b/plugins/statistics_exporter/package.json
@@ -35,8 +35,7 @@
 
 	"peerDependencies": {
 		"@clusterio/host": "workspace:^",
-		"@clusterio/lib": "workspace:^",
-		"@clusterio/web_ui": "workspace:^"
+		"@clusterio/lib": "workspace:^"
 	},
 	"devDependencies": {
 		"@clusterio/web_ui": "workspace:^",

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -36,8 +36,7 @@
 	"peerDependencies": {
 		"@clusterio/controller": "workspace:^",
 		"@clusterio/host": "workspace:^",
-		"@clusterio/lib": "workspace:^",
-		"@clusterio/web_ui": "workspace:^"
+		"@clusterio/lib": "workspace:^"
 	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"

--- a/plugins/subspace_storage/package.json
+++ b/plugins/subspace_storage/package.json
@@ -38,6 +38,14 @@
 		"@clusterio/host": "workspace:^",
 		"@clusterio/lib": "workspace:^"
 	},
+	"peerDependenciesMeta": {
+		"@clusterio/controller": {
+			"optional": true
+		},
+		"@clusterio/host": {
+			"optional": true
+		}
+	},
 	"dependencies": {
 		"@sinclair/typebox": "catalog:"
 	},


### PR DESCRIPTION
Peer dependencies are installed by default by npm. This means putting something in there is equivalent to putting it in the dependencies specification. That in turn means we're currently installid web_ui when any of the core plugins are installed, which is not used for anything at runtime.

We also install the controller/host/ctl packages even if they aren't needed, for example if this is a host only install with some plugins.

Fix by removing the web_ui peer dependency and setting the other ones to be optional.

### Changelog
```
### Fixes
- Fixed core plugins needlessly installing the web_ui, controller, host and ctl packages. #1021
```
