### PR TITLE
Bump pnpm, GitHub Actions and CI Factorio version

### DIFF
--- a/.github/workflows/lua-lint.yml
+++ b/.github/workflows/lua-lint.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  EMMYLUA_CHECK_VERSION: "0.24.0"
+  EMMYLUA_CHECK_VERSION: "0.25.1"
 
 jobs:
   lint:

--- a/.github/workflows/lua-lint.yml
+++ b/.github/workflows/lua-lint.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Generate Factorio typedefs

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,10 +30,10 @@ jobs:
             coverage: true
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
     - name: Prepare and install
@@ -48,13 +48,13 @@ jobs:
       run: pnpm run ci-cover
     - name: Upload coverage to Codecov
       if: ${{ matrix.coverage }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         files: ./coverage/lcov.info
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test logs for debugging
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.node-version }}-${{ matrix.factorio-version }}
         path: temp/test/logs
@@ -77,9 +77,9 @@ jobs:
             host: local
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Prepare and install
@@ -97,9 +97,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ env.NODE_VERSION }}
     - run: pnpm i --no-frozen-lockfile
@@ -109,16 +109,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v4
-    - uses: pnpm/action-setup@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ env.NODE_VERSION }}
     - run: pnpm i --no-frozen-lockfile
     - run: pnpm run build-mod
     # Upload build to artifacts
     - name: Upload build to artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: clusterio_lib
         path: ./dist

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,12 +21,12 @@ jobs:
         node-version: [24.x]
 
         # Supported factorio versions are latest stable and one minor version before stable (even if from a previous major) 
-        factorio-version: [1.1.110, 2.0.77, 2.1.8]
+        factorio-version: [1.1.110, 2.0.77, 2.1.17]
     
         # Coverage is performed on the older of the supported node versions
         include:
           - node-version: 22.x
-            factorio-version: 2.1.8
+            factorio-version: 2.1.17
             coverage: true
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
       - run: pnpm install --no-frozen-lockfile
       - run: pnpm -r --filter='./{plugins,packages}/*' publish --no-git-checks
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: pnpm-lock.yaml
 
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
       - run: pnpm install --no-frozen-lockfile
@@ -41,6 +41,6 @@ jobs:
       - run: node ./publish.js factorio ./dist
         env:
           FACTORIO_TOKEN: ${{ secrets.FACTORIO_TOKEN }}
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: ./dist/*

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-auto-install-peers=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 as subspace_storage_builder
+FROM node:24 AS subspace_storage_builder
 RUN apt update && apt install -y git
 WORKDIR /
 RUN git clone https://github.com/clusterio/subspace_storage.git
@@ -6,7 +6,7 @@ WORKDIR /subspace_storage
 RUN npm install \
 && node build
 
-FROM node:20 as clusterio_builder
+FROM node:24 AS clusterio_builder
 RUN apt update \
 && apt install -y wget \
 && mkdir /clusterio

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "root",
 	"private": true,
 	"files": [],
-	"packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
+	"packageManager": "pnpm@12.4.1+sha512.2e81e399d73fe8390dab25e06aa788ab7a5908248d2f5a370f82b481147a6a7a367bf8048f9a6fdb6460f21a66f0542dedb8b94ca2c8723596741920b1656d4c",
 	"type": "module",
 	"scripts": {
 		"build": "tsc --build",
@@ -14,7 +14,7 @@
 		"no-external-test": "NO_EXTERNAL_TEST=y pnpm test",
 		"cover": "nyc pnpm test",
 		"fast-cover": "FAST_TEST=y nyc pnpm test",
-		"ci-cover": "nyc --reporter=lcovonly pnpm run-script test",
+		"ci-cover": "nyc --reporter=lcovonly pnpm test",
 		"lint": "eslint packages plugins test",
 		"lint-fix": "eslint --fix packages plugins test",
 		"clean": "node ./clean.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,9 +36,11 @@ catalog:
 
 catalogMode: strict
 
+autoInstallPeers: false
+
 linkWorkspacePackages: true
 
-onlyBuiltDependencies:
-  - '@swc/core'
+allowBuilds:
+  '@swc/core': true
 
 shellEmulator: true


### PR DESCRIPTION
Chores Cooldude asked for so the tooling is current before the AI-driven test rounds. Dependency range bumps are in a separate PR.

**pnpm 10.28.1 to 12.4.1.** pnpm 11 removed `onlyBuiltDependencies` (now `allowBuilds`) and stopped reading non-auth settings from `.npmrc`, so `auto-install-peers=false` moved to `autoInstallPeers: false` in pnpm-workspace.yaml and `.npmrc` is gone. Two behaviour changes worth knowing: `minimumReleaseAge` now defaults to one day, so a package published in the last 24 hours is not resolved (CI installs with `--no-frozen-lockfile`, so this only shows up as a slightly older pick), and `pnpm publish` no longer shells out to npm. The native flow supports npm trusted publishing, but only with pnpm/action-setup v6.0.6 or later (pnpm/pnpm#11513), which is why the action bump is in the same PR. I could not exercise the publish job itself, so the first release after this merges is the real test.

**GitHub Actions.** checkout, setup-node, upload-artifact and codecov-action to v7, pnpm/action-setup to v6, action-gh-release to v3. All now run on the node24 actions runtime. I went through the release notes for each major; none of the inputs the workflows use changed. setup-node v5 briefly auto-enabled pnpm caching from the `packageManager` field and v6 narrowed that back to npm only, so nothing changes for us.

**Factorio 2.1.17 and emmylua_check 0.25.1.** 2.1.17 is the current experimental. The Lua lint recipe from the workflow run locally against 0.25.1 gives 0 diagnostics over 28 files.

**Dockerfile node:20 to node:24.** Node 20 is end of life. The Dockerfile has not been touched since 2023 and does not install pnpm before calling it, so it did not build before this change either. I left that alone since it is a bigger fix than a version bump.

Verified locally on Node 24.21.0 with Factorio 2.1.17: `pnpm i` with pnpm 12.4.1, build, lint, and the full suite (1754 passing, 1 failing which is the port 8080 test that always fails on my machine).

### Changelog
```
### Changes
- Bumped pnpm to 12, the GitHub Actions used by CI to their current majors, and the CI Factorio version to 2.1.17. #1022
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
