### PR TITLE
Cache builds in CI and skip them where unused

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -1,0 +1,36 @@
+name: Install dependencies
+description: Set up pnpm and Node.js, restore the pnpm store from the cache and run pnpm install
+
+inputs:
+  node-version:
+    description: Node.js version passed to actions/setup-node
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    # The lockfile is not committed, so the usual lockfile hash key does not
+    # apply. Instead a new store snapshot is saved whenever a package.json
+    # changes or a week passes, and every run restores the most recent one.
+    - id: store
+      shell: bash
+      run: |
+        echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+    - uses: actions/cache@v6
+      with:
+        path: ${{ steps.store.outputs.path }}
+        key: pnpm-store-${{ runner.os }}-${{ steps.store.outputs.week }}-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
+        restore-keys: pnpm-store-${{ runner.os }}-
+
+    - shell: bash
+      run: pnpm i --no-frozen-lockfile
+    # Drop packages the restored store had but this install did not use, so
+    # the snapshot does not grow with every version bump.
+    - shell: bash
+      run: pnpm store prune

--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -1,10 +1,13 @@
 name: Install dependencies
-description: Set up pnpm and Node.js, restore the pnpm store from the cache and run pnpm install
+description: Set up pnpm and Node.js, restore caches and run pnpm install
 
 inputs:
   node-version:
     description: Node.js version passed to actions/setup-node
     required: true
+  ignore-scripts:
+    description: Skip the prepare scripts that build the workspace packages
+    default: "false"
 
 runs:
   using: composite
@@ -28,8 +31,22 @@ runs:
         key: pnpm-store-${{ runner.os }}-${{ steps.store.outputs.week }}-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
         restore-keys: pnpm-store-${{ runner.os }}-
 
+    # The prepare scripts run tsc --build and webpack, both incremental when
+    # their previous output is present. Every run saves its output and the
+    # next run starts from the most recent one.
+    - if: inputs.ignore-scripts != 'true'
+      uses: actions/cache@v6
+      with:
+        path: |
+          packages/*/dist
+          plugins/*/dist
+          packages/*/node_modules/.cache
+          plugins/*/node_modules/.cache
+        key: build-${{ runner.os }}-${{ github.sha }}
+        restore-keys: build-${{ runner.os }}-
+
     - shell: bash
-      run: pnpm i --no-frozen-lockfile
+      run: pnpm i --no-frozen-lockfile ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
     # Drop packages the restored store had but this install did not use, so
     # the snapshot does not grow with every version bump.
     - shell: bash

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,13 +31,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - uses: pnpm/action-setup@v6
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+    - name: Prepare and install
+      uses: ./.github/actions/pnpm-install
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Prepare and install
-      run: pnpm i --no-frozen-lockfile
     - name: Use Factorio ${{ matrix.factorio-version }}
       run: wget -q -O factorio.tar.gz https://www.factorio.com/get-download/${{ matrix.factorio-version }}/headless/linux64 && tar -xf factorio.tar.gz && rm factorio.tar.gz
     - name: Run tests
@@ -78,12 +75,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - uses: pnpm/action-setup@v6
-    - uses: actions/setup-node@v7
+    - name: Prepare and install
+      uses: ./.github/actions/pnpm-install
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Prepare and install
-      run: pnpm i --no-frozen-lockfile
     - name: Build
       run: pnpm run build
     - name: Test ${{ matrix.controller }} controller with ${{ matrix.host }} host
@@ -98,11 +93,9 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v7
-    - uses: pnpm/action-setup@v6
-    - uses: actions/setup-node@v7
+    - uses: ./.github/actions/pnpm-install
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - run: pnpm i --no-frozen-lockfile
     - run: pnpm run lint
 
   build:
@@ -110,11 +103,9 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v7
-    - uses: pnpm/action-setup@v6
-    - uses: actions/setup-node@v7
+    - uses: ./.github/actions/pnpm-install
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - run: pnpm i --no-frozen-lockfile
     - run: pnpm run build-mod
     # Upload build to artifacts
     - name: Upload build to artifacts

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -96,6 +96,7 @@ jobs:
     - uses: ./.github/actions/pnpm-install
       with:
         node-version: ${{ env.NODE_VERSION }}
+        ignore-scripts: true
     - run: pnpm run lint
 
   build:
@@ -106,6 +107,7 @@ jobs:
     - uses: ./.github/actions/pnpm-install
       with:
         node-version: ${{ env.NODE_VERSION }}
+        ignore-scripts: true
     - run: pnpm run build-mod
     # Upload build to artifacts
     - name: Upload build to artifacts


### PR DESCRIPTION
Cooldude asked for a look at CI cache keys, given that the lockfile is not committed and the usual lockfile-hash key is out. This is what the numbers say, measured on fork runs of the Node.js CI workflow (cold run, then `gh run rerun` for the warm one). Branch is stacked on #1022 because both touch the same action lines; the diff shrinks to the last two commits once that merges.

**Downloads are not the cost.** A job's install step is 46 to 64 s, but resolving and downloading all 851 packages takes 3 to 4 s on the runners even with a cold cache. The rest is the `prepare` scripts building all 12 workspace packages with tsc and webpack. Factorio headless downloads take 4 to 5 s. So a pnpm store cache on its own saved about 2 s per job. It is still in here (keyed on a weekly date plus the package.json hash, restored by prefix so the newest snapshot always hits, 96 MB), but only because it is cheap and stops the registry being a failure point.

**What did help.**
- lint and build-mod never read the compiled output (eslint is not type-aware here, build_mod.js is plain JavaScript), so they install with `--ignore-scripts`. lint went from 78 s to 29 s, build from 57 s to 24 s.
- The test and version-compat jobs restore `packages/*/dist`, `plugins/*/dist` and the packages' `node_modules/.cache` from the latest previous run (39 MB). tsc's tsbuildinfo tracks content hashes and webpack's filesystem cache keeps its node_modules modules, so both become incremental after a fresh checkout. `pnpm i` went from 52 to 54 s down to 24 s, and the install step of a test job from 50 to 72 s down to 34 to 48 s.

**What it means for the wall clock.** The workflow's critical path is the coverage job, roughly 60 s install plus 200 s of tests plus a few seconds around it. This takes about 20 to 25 s off that. The test suite itself, which swung between 150 s and 255 s across otherwise identical runs, is where the time is. Total runner minutes per run go from about 21 to about 20. Useful, not dramatic.

**Caveat.** A restored build is only as good as tsc's and webpack's own invalidation. tsc is content-hash based so I am not worried there; webpack invalidates by mtime for source files and by package version for node_modules. If a run ever looks wrong, deleting the `build-Linux-*` caches from the repo's Actions cache page is the reset.

The three actions setup steps are now in a composite action under `.github/actions/pnpm-install`, so the four jobs share one definition. publish.yml is untouched since it needs `registry-url` and runs rarely.

### Changelog
None. CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
