### PR TITLE
Give each safeOutputFile call its own temporary file

### DIFF
--- a/packages/lib/src/file_ops.ts
+++ b/packages/lib/src/file_ops.ts
@@ -137,11 +137,11 @@ export async function getTempFile(prefix = "tmp.", suffix = "", tmpdir = "./") {
  * file.  If the operation fails because the parent directory does not exist, it
  * attempts to create the directory, including any ancestors and then retries
  * the operation.  The name of the temporary file is the same as the target file
- * with the suffix `.tmp` added before the extension.
+ * with a random tag and the suffix `.tmp` added before the extension, so
+ * concurrent writes to the same file do not interfere with each other.
  *
- * If the operation fails it may leave behind the temporary file.  This
- * should not be too much of an issue as the next time the same file is
- * written the temporary will be overwritten and renamed to the target file.
+ * If the operation fails the temporary file is removed.  Should the process
+ * die in the middle of writing the temporary file it is left behind.
  *
  * @param file - Path to file to write.
  * @param data - Content to write.
@@ -156,23 +156,24 @@ export async function safeOutputFile(
 	>,
 ) {
 	let { dir, name, ext } = path.parse(file);
-	let temporary = path.join(dir, `${name}.tmp${ext}`);
+	let temporary = path.join(dir, `${name}.${crypto.randomBytes(8).toString("hex")}.tmp${ext}`);
 	try {
-		await fs.writeFile(temporary, data, { ...options, flush: true });
+		await fs.writeFile(temporary, data, { ...options, flag: "wx", flush: true });
 	} catch (err: any) {
 		if (err.code === "ENOENT") {
 			// Try creating the folder and then retry the operation.
 			await fs.mkdir(dir, { recursive: true });
-			await fs.writeFile(temporary, data, { ...options, flush: true });
+			await fs.writeFile(temporary, data, { ...options, flag: "wx", flush: true });
 		} else {
 			throw err;
 		}
 	}
-	if (options?.mode !== undefined) {
-		// writeFile only applies mode when creating, a leftover temporary keeps its old mode.
-		await fs.chmod(temporary, options.mode);
+	try {
+		await fs.rename(temporary, file);
+	} catch (err: any) {
+		await fs.unlink(temporary).catch(() => {});
+		throw err;
 	}
-	await fs.rename(temporary, file);
 }
 
 // Reserved names by almost all filesystems

--- a/test/lib/file_ops.js
+++ b/test/lib/file_ops.js
@@ -87,28 +87,50 @@ describe("lib/file_ops", function() {
 	});
 
 	describe("safeOutputFile()", function() {
+		async function assertNoTemporary(target) {
+			let { dir, name } = path.parse(target);
+			let entries = (await fs.readdir(dir)).filter(
+				entry => entry.startsWith(`${name}.`) && entry !== path.basename(target)
+			);
+			assert.deepEqual(entries, [], "temporary was left behind");
+		}
 		it("should write new target file", async function() {
 			let target = path.join(baseDir, "safe", "simple.txt");
 			await lib.safeOutputFile(target, "a text file", "utf8");
-			await assert.rejects(fs.access(target.replace(".txt", ".tmp.txt")), "temporary was left behind");
+			await assertNoTemporary(target);
 			assert.equal(await fs.readFile(target, "utf8"), "a text file");
 		});
 		it("should overwrite existing target file", async function() {
 			let target = path.join(baseDir, "safe", "exists.txt");
 			await fs.writeFile(target, "previous", "utf8");
 			await lib.safeOutputFile(target, "current", "utf8");
-			await assert.rejects(fs.access(target.replace(".txt", ".tmp.txt")), "temporary was left behind");
+			await assertNoTemporary(target);
 			assert.equal(await fs.readFile(target, "utf8"), "current");
 		});
-		it("should apply mode to a leftover temporary file", async function() {
+		it("should apply mode to the target file", async function() {
 			if (process.platform === "win32") {
 				this.skip();
 			}
 			let target = path.join(baseDir, "safe", "mode.txt");
-			await fs.writeFile(target.replace(".txt", ".tmp.txt"), "stale", { mode: 0o644 });
 			await lib.safeOutputFile(target, "private", { mode: 0o600 });
 			assert.equal((await fs.stat(target)).mode & 0o777, 0o600);
 			assert.equal(await fs.readFile(target, "utf8"), "private");
+		});
+		it("should not interfere between concurrent writes to the same file", async function() {
+			let target = path.join(baseDir, "safe", "concurrent.txt");
+			let writes = [];
+			for (let i = 0; i < 20; i++) {
+				writes.push(lib.safeOutputFile(target, `write ${i}`, "utf8"));
+			}
+			await Promise.all(writes);
+			await assertNoTemporary(target);
+			assert.match(await fs.readFile(target, "utf8"), /^write \d+$/);
+		});
+		it("should remove the temporary file when the rename fails", async function() {
+			let target = path.join(baseDir, "safe", "rename-fails");
+			await fs.mkdir(target, { recursive: true });
+			await assert.rejects(lib.safeOutputFile(target, "data", "utf8"));
+			await assertNoTemporary(target);
 		});
 		it("should handle creating file in current working directory", async function() {
 			let target = "temporary-file-made-to-test-cwd.txt";


### PR DESCRIPTION
Follow-up to the flake noted in #1023. `safeOutputFile` writes to `name.tmp.ext` and renames it over the target, but two calls for the same file at the same time share that temporary. The second write truncates and rewrites the first call's temporary, and once the first rename moves it away the second call has nothing left to rename, so it fails with ENOENT. There is also a narrower window where the first rename lands while the second write is still in progress, which puts a half-written file at the target and defeats the point of the temporary.

The host does exactly this on `clusteriohost should auto start instances with auto_start enabled`, where the host saves an instance's config while the instance saves it too. It surfaced as `ENOENT chmod 'alt-instances/alt-start/instance.tmp.json'`. The chmod from #1017 made the window a little wider, but the race predates it: without the chmod the same interleaving fails on the rename instead.

Each call now gets its own temporary, `name.<random>.tmp.ext`, created with the exclusive flag, so concurrent writers never touch each other's file and no state is shared between calls. Two consequences of that: the temporary is always a fresh file, so the mode is applied on creation and the chmod for reused leftovers goes away, and a failed rename removes its temporary since nothing will overwrite it later. A process dying mid-write still leaves one behind, as before.

Concurrent writers in separate processes were never a problem here since no file has more than one owning process. Ordering between concurrent calls is whichever rename lands last, which is no weaker than before, where the second call crashed.

The new tests fire twenty concurrent writes at one path (fails on master with the rename ENOENT) and check a failed rename leaves nothing behind. Full suite locally: 1755 passing, 1 failing (the port 8080 test that always fails on my machine).

### Changelog
```
### Fixes
- Fixed concurrent saves of the same file racing on a shared temporary file. #1026
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
