### PR TITLE
Fix listener leaks when a control connection closes

### DIFF
--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -53,7 +53,7 @@ export default class ControlConnection extends BaseConnection {
 		});
 		this.connector.on("close", () => {
 			if (this.logTransport) {
-				logger.remove(this.logTransport);
+				this._controller.clusterLogger.remove(this.logTransport);
 				this.logTransport = null;
 			}
 			if (this.ws_dumper) {
@@ -1325,6 +1325,9 @@ export default class ControlConnection extends BaseConnection {
 	}
 
 	async handleDebugDumpWsRequest(request: lib.DebugDumpWsRequest) {
+		if (this.ws_dumper) {
+			return; // Already dumping
+		}
 		this.ws_dumper = data => {
 			if (this.connector.connected) {
 				this.send(new lib.DebugWsMessageEvent(data.direction, data.content));

--- a/test/controller/ControlConnection.test.js
+++ b/test/controller/ControlConnection.test.js
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
-import { ControlConnection } from "@clusterio/controller";
+import events from "node:events";
+import * as lib from "@clusterio/lib";
+import { ControlConnection, ControllerHooks } from "@clusterio/controller";
+import { MockConnector, MockLogger } from "../mock.js";
+
+const addr = lib.Address.fromShorthand;
 
 describe("controller/src/ControlConnection", function() {
 	describe(".handleControllerRestartRequest()", function() {
@@ -36,6 +41,54 @@ describe("controller/src/ControlConnection", function() {
 			await assert.rejects(restart, /Stop the controller before starting the older version manually/);
 			assert.equal(mockController.shouldRestart, false);
 			assert.equal(mockController.stopped, false);
+		});
+	});
+
+	describe("close cleanup", function() {
+		let connector;
+		let mockController;
+		let connection;
+
+		beforeEach(function() {
+			connector = new MockConnector(addr("controller"), addr({ controlId: 1 }));
+			connector._socket = {};
+			const transports = new Set();
+			mockController = {
+				hooks: new ControllerHooks(new MockLogger()),
+				router: null,
+				_registeredRequests: new Map(),
+				_fallbackedRequests: new Map(),
+				_registeredEvents: new Map(),
+				_snoopedEvents: new Map(),
+				subscriptions: { unsubscribeLink() {} },
+				clusterLogger: {
+					transports,
+					add(transport) { transports.add(transport); },
+					remove(transport) { transports.delete(transport); },
+				},
+				debugEvents: new events.EventEmitter(),
+				sendRequestToHostByInstanceId() {},
+			};
+			connection = new ControlConnection({ version: "test" }, connector, mockController, {}, 1);
+		});
+
+		it("removes the log transport from clusterLogger", async function() {
+			await connection.handleLogSetSubscriptionsRequest(
+				new lib.LogSetSubscriptionsRequest(true, false, [], [])
+			);
+			assert.equal(mockController.clusterLogger.transports.size, 1);
+			connector.emit("close");
+			assert.equal(mockController.clusterLogger.transports.size, 0);
+			assert.equal(connection.logTransport, null);
+		});
+
+		it("removes the debug dump listener after repeated requests", async function() {
+			await connection.handleDebugDumpWsRequest(new lib.DebugDumpWsRequest());
+			await connection.handleDebugDumpWsRequest(new lib.DebugDumpWsRequest());
+			assert.equal(mockController.debugEvents.listenerCount("message"), 1);
+			assert.equal(connector._socket.clusterio_ignore_dump, true);
+			connector.emit("close");
+			assert.equal(mockController.debugEvents.listenerCount("message"), 0);
 		});
 	});
 });


### PR DESCRIPTION
While sending control requests straight to a running controller I found two listeners that outlive the control connection that created them.

`updateLogSubscriptions` adds a `LinkTransport` to the controller's `clusterLogger`, but the connector close handler removes it from the global lib `logger`, which never had it. Every control connection that subscribed to logs stays attached to `clusterLogger` after it closes. The web UI log console subscribes on the controller, host and instance pages, so this happens on normal use. Nothing errors because `LinkTransport.log` checks `connector.valid`; the closed connection just stays in memory and every later cluster log line runs through its filter.

`handleDebugDumpWsRequest` adds a `debugEvents` listener on every call and overwrites `ws_dumper`, so close only removes the last one. Sending `DebugDumpWsRequest` 11 times on one connection prints `MaxListenersExceededWarning` on the controller and leaves 10 listeners behind after close. A repeated request is now ignored while the connection is already dumping.

The new tests build a real `ControlConnection` with a mock connector and check that both are gone after close. Both fail without the change.

### Changelog
```
### Fixes
- Fixed control connections leaving their log subscription and debug dump listeners attached after closing. #1027
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
