### PR TITLE
Log errors from instance config change handlers instead of exiting the host

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -61,7 +61,7 @@ function applyAsConfig(name: string) {
 			// Replace spaces with non-break spaces and delimit by spaces.
 			// This does change the defined tags, but there doesn't seem to
 			// be a way to include a space into a tag from the console.
-			value = value.map(tag => tag.replace(/ /g, "\u00a0")).join(" ");
+			value = value.map(tag => String(tag).replace(/ /g, "\u00a0")).join(" ");
 		}
 		try {
 			await instance.sendRcon(`/config set ${name} ${value}`);
@@ -199,9 +199,13 @@ export default class Instance extends lib.Link {
 			if (field === "factorio.shutdown_timeout") {
 				this.server.shutdownTimeoutMs = curr as number * 1000;
 			} else if (field === "factorio.settings") {
-				this.updateFactorioSettings(curr as any, prev as any).finally(hook);
+				this.updateFactorioSettings(curr as any, prev as any).catch(err => {
+					this.logger.error(`Error updating server settings:\n${err.stack}`);
+				}).finally(hook);
 			} else if (field === "factorio.enable_whitelist") {
-				this.updateFactorioWhitelist(curr as any).finally(hook);
+				this.updateFactorioWhitelist(curr as any).catch(err => {
+					this.logger.error(`Error updating whitelist:\n${err.stack}`);
+				}).finally(hook);
 			} else {
 				if (field === "factorio.max_concurrent_commands") {
 					this.server.maxConcurrentCommands = curr as number;

--- a/test/host/Instance.js
+++ b/test/host/Instance.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import * as lib from "@clusterio/lib";
 import { PlayerStats, wait } from "@clusterio/lib";
 import Instance from "@clusterio/host/dist/node/src/Instance.js";
-import { MockConnector, MockServer } from "../mock.js";
+import { MockConnector, MockLogger, MockServer } from "../mock.js";
 
 const addr = lib.Address.fromShorthand;
 
@@ -35,6 +35,56 @@ describe("class Instance", function() {
 		});
 		it("should join path with arguments", function() {
 			assert.equal(instance.path("bar"), path.join("dir", "bar"));
+		});
+	});
+
+	describe("config fieldChanged", function() {
+		let errors;
+		let rejections;
+		let hookInvoked;
+		function onRejection(err) { rejections.push(err); }
+		beforeEach(function() {
+			errors = [];
+			rejections = [];
+			instance.logger = new MockLogger();
+			instance.logger.error = message => errors.push(message);
+			instance.server.exampleSettings = async () => ({});
+			hookInvoked = new Promise(resolve => {
+				instance.hooks.instanceConfigFieldChanged.attach("test", field => resolve(field));
+			});
+			process.on("unhandledRejection", onRejection);
+		});
+		afterEach(function() {
+			process.off("unhandledRejection", onRejection);
+		});
+
+		it("should log whitelist update errors and invoke the hook", async function() {
+			instance.server.sendRcon = async () => { throw new Error("Expected state running,stopping"); };
+			instance.config.set("factorio.enable_whitelist", true);
+			assert.equal(await hookInvoked, "factorio.enable_whitelist");
+			await wait(10);
+			assert.deepEqual(rejections, []);
+			assert.equal(errors.length, 1);
+			assert.match(errors[0], /^Error updating whitelist:\nError: Expected state running,stopping/);
+		});
+
+		it("should log server settings update errors and invoke the hook", async function() {
+			instance.server.exampleSettings = async () => { throw new Error("no example settings"); };
+			instance.config.set("factorio.settings", { name: "bar" });
+			assert.equal(await hookInvoked, "factorio.settings");
+			await wait(10);
+			assert.deepEqual(rejections, []);
+			assert.equal(errors.length, 1);
+			assert.match(errors[0], /^Error updating server settings:\nError: no example settings/);
+		});
+
+		it("should apply tags with non-string elements", async function() {
+			instance.config.set("factorio.settings", { tags: [1, "a b"] });
+			await hookInvoked;
+			await wait(10);
+			assert.deepEqual(rejections, []);
+			assert.deepEqual(errors, []);
+			assert.deepEqual(instance.server.rconCommands, ["/config set tags 1 a b"]);
 		});
 	});
 


### PR DESCRIPTION
Changing some instance config fields at the wrong moment kills the whole host process, and every instance on that host goes down with it. `_configFieldChanged` in the `Instance` constructor ran `updateFactorioSettings` and `updateFactorioWhitelist` with only a `finally` attached, and `handleUnhandledErrors` exits on an unhandled rejection.

Both of these were reproduced against a real host running Factorio 2.1.17 (base game), using the requests the web UI config editor sends:

1. Send `InstanceStartRequest`, then straight away `InstanceConfigSetFieldRequest(id, "factorio.enable_whitelist", <flipped value>)`. `updateFactorioWhitelist` calls `sendRcon` before the server has launched and the host exits with `fatal Unhandled rejection: Error: Expected state running,stopping but state is new`. The window is the mod sync before launch, so a mod pack that has to be downloaded makes it wide.
2. On a running instance, set the `factorio.settings` prop `tags` to `[1]`, which the config editor accepts as valid JSON. `applyAsConfig` called `tag.replace` outside its try block and the host exits with `fatal Unhandled rejection: TypeError: tag.replace is not a function`.

Both handlers now log the error on the instance logger and still invoke the hook, and tags are converted with `String()`. I ran the same two sequences against the fuzz cluster with this branch: the host stays up and the instance log shows `Error updating whitelist: Expected state running,stopping but state is new`.

Not changed here, open for input:
- A whitelist toggle during startup is logged and not applied. The server reads `enableWhitelist` when the instance is constructed, so the running server keeps the old setting until the next restart.
- `factorio.settings` props are not validated. With `tags: [1]` saved, the next start fails in Factorio with `Value must be a string in property tree at ROOT.tags[0]`. That error is clear, so I left validation for the TODO in `definitions.ts`.

### Changelog
```
### Fixes
- Fixed the host exiting when an instance's whitelist or server settings config changed while it was starting, or when tags contained non-string values. #1028
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
