### PR TITLE
Keep instances assignable after a failed assign or create

### DIFF
--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -288,6 +288,9 @@ export default class ControlConnection extends BaseConnection {
 	}
 
 	async handleInstanceCreateRequest(request: lib.InstanceCreateRequest) {
+		if ((request.config["instance.assigned_host"] ?? null) !== null) {
+			throw new lib.RequestError("instance.assigned_host must be set through the assign-host interface");
+		}
 		const instanceConfig = new lib.InstanceConfig("controller");
 		if (request.cloneFromId) {
 			const baseInstance = this._controller.instances.get(request.cloneFromId);

--- a/packages/controller/src/InstanceManager.ts
+++ b/packages/controller/src/InstanceManager.ts
@@ -208,9 +208,17 @@ export default class InstanceManager {
 		instance.config.set("instance.assigned_host", hostId);
 
 		if (newHostConnection) {
-			await newHostConnection.send(
-				new lib.InstanceAssignInternalRequest(instanceId, instance.config.toRemote("host")),
-			);
+			try {
+				await newHostConnection.send(
+					new lib.InstanceAssignInternalRequest(instanceId, instance.config.toRemote("host")),
+				);
+			} catch (err) {
+				// Leave unassigned so the assign can be retried
+				instance.config.set("instance.assigned_host", null);
+				instance.status = "unassigned";
+				this.records.set(instance);
+				throw err;
+			}
 		} else {
 			instance.status = "unassigned";
 		}

--- a/test/controller/ControlConnection.test.js
+++ b/test/controller/ControlConnection.test.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { ControlConnection } from "@clusterio/controller";
+import * as lib from "@clusterio/lib";
+import { ControlConnection, InstanceManager } from "@clusterio/controller";
+import { MockController } from "../mock.js";
 
 describe("controller/src/ControlConnection", function() {
 	describe(".handleControllerRestartRequest()", function() {
@@ -36,6 +38,41 @@ describe("controller/src/ControlConnection", function() {
 			await assert.rejects(restart, /Stop the controller before starting the older version manually/);
 			assert.equal(mockController.shouldRestart, false);
 			assert.equal(mockController.stopped, false);
+		});
+	});
+
+	describe(".handleInstanceCreateRequest()", function() {
+		let mockController;
+
+		beforeEach(function() {
+			mockController = new MockController();
+			mockController.mockConfigEntries.set("controller.name", "Test");
+			mockController.instances = new InstanceManager(new lib.SubscribableDatastore(), mockController);
+		});
+
+		async function create(config, cloneFromId) {
+			await ControlConnection.prototype.handleInstanceCreateRequest.call(
+				{ _controller: mockController },
+				new lib.InstanceCreateRequest(config, cloneFromId),
+			);
+		}
+
+		it("rejects instance.assigned_host in the config", async function() {
+			await assert.rejects(
+				create({ "instance.id": 4001, "instance.name": "c1", "instance.assigned_host": 10 }),
+				new lib.RequestError("instance.assigned_host must be set through the assign-host interface"),
+			);
+			assert.equal(mockController.instances.has(4001), false);
+		});
+
+		it("creates an unassigned clone of an assigned instance", async function() {
+			await create({ "instance.id": 4001, "instance.name": "base" });
+			mockController.instances.getMutable(4001).config.set("instance.assigned_host", 10);
+
+			await create({ "instance.id": 4002, "instance.name": "clone", "instance.assigned_host": null }, 4001);
+			const clone = mockController.instances.get(4002);
+			assert.equal(clone.config.get("instance.name"), "clone");
+			assert.equal(clone.config.get("instance.assigned_host"), null);
 		});
 	});
 });

--- a/test/controller/InstanceManager.test.js
+++ b/test/controller/InstanceManager.test.js
@@ -298,6 +298,45 @@ describe("controller/InstanceManager", function () {
 			assert(assignRequest instanceof lib.InstanceAssignInternalRequest);
 			assert.equal(assignRequest.instanceId, 1);
 		});
+
+		it("should leave instance unassigned if the new host fails the assign", async function () {
+			let unassignRequest;
+			controller.wsServer.hostConnections.set(5, {
+				send: async (request) => {
+					unassignRequest = request;
+				},
+				connector: { closing: false },
+			});
+			let failAssign = true;
+			let assignRequest;
+			controller.wsServer.hostConnections.set(6, {
+				send: async (request) => {
+					if (failAssign) {
+						throw new lib.RequestError("EACCES: permission denied");
+					}
+					assignRequest = request;
+				},
+				connector: { closing: false },
+			});
+
+			instance.config.set("instance.assigned_host", 5);
+			instance.status = "stopped";
+			await assert.rejects(
+				() => instances.assignInstance(1, 6),
+				{ message: "EACCES: permission denied" }
+			);
+
+			assert(unassignRequest instanceof lib.InstanceUnassignInternalRequest);
+			const stored = instances.records.get(1);
+			assert.equal(stored.config.get("instance.assigned_host"), null);
+			assert.equal(stored.status, "unassigned");
+
+			failAssign = false;
+			await instances.assignInstance(1, 6);
+			assert.equal(instance.config.get("instance.assigned_host"), 6);
+			assert(assignRequest instanceof lib.InstanceAssignInternalRequest);
+			assert.equal(assignRequest.instanceId, 1);
+		});
 	});
 
 	describe(".unassignInstance()", function () {


### PR DESCRIPTION
Two inputs leave an instance whose `instance.assigned_host` points at a host that does not have it. Assigning it to that host again then returns success and does nothing, because `assignInstance` returns early when the host is unchanged. The web UI assign modal preselects the current host, so clicking Assign looks like it worked.

1. The new host fails `InstanceAssignInternalRequest`. I reproduced this with a real host whose instances directory was read-only (`EACCES: permission denied, mkdir 'instances/a3'`). The controller had already set `assigned_host`, so the instance was left with `assigned_host=10` and status `unassigned`. Retrying after fixing the permissions returned ok, and starting it failed with `Instance with ID 3001 does not exist`.
2. `InstanceCreateRequest` with `"instance.assigned_host": 10` in the config was accepted and gave the same state. The config set requests already reject this field.

A failed send now leaves the instance unassigned before rethrowing, so the assign can be retried. Create rejects a non-null `instance.assigned_host` with the same message as the set requests. Null is still accepted so a client that serialises a whole config keeps working. Neither the web UI nor ctl sends the field on create.

With this branch running as the controller of the same test cluster, the failed assign leaves the instance unassigned, the retry assigns it to host 10 with status `stopped`, and the create request is rejected.

One trade-off to look at: if the host applied the assign but the reply was lost, the controller now treats the instance as unassigned while the host has it. When that host reconnects its `InstancesUpdateRequest` gets an unassign for the instance, the same way other mismatches are resolved.

### Changelog
```
### Fixes
- Fixed instances getting stuck on a host after a failed assign, and instance create requests no longer accept `instance.assigned_host`. #1029
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
