### PR TITLE
Fix Load Scenario modal reading the wrong map settings field

### DIFF
--- a/packages/web_ui/src/components/LoadScenarioModal.tsx
+++ b/packages/web_ui/src/components/LoadScenarioModal.tsx
@@ -44,7 +44,7 @@ export default function LoadScenarioModal(props: LoadScenarioModalProps) {
 		}
 		if (values.mapSettings && values.mapSettings.trim()) {
 			try {
-				mapSettings = JSON.parse(values.mapGenSettings);
+				mapSettings = JSON.parse(values.mapSettings);
 			} catch (err: any) {
 				form.setFields([{ name: "mapSettings", errors: [err.message] }]);
 				return;


### PR DESCRIPTION
The Load Scenario modal parses the wrong field for map settings. In `loadScenario()` the Map Settings block does `mapSettings = JSON.parse(values.mapGenSettings)` instead of `values.mapSettings` (CreateSaveModal has it right). So filling only Map Settings shows `"undefined" is not valid JSON` under the field and the modal won't submit, and filling both sends the map gen JSON as `--map-settings`.

Verified in a browser against a running controller before the fix: with only Map Settings filled the field errored and Load did nothing.

### Changelog
```
### Fixes
- Fixed the Load Scenario modal reading the wrong field for map settings. #1032
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
