### PR TITLE
Deny instead of crashing when a control permission check throws

### DIFF
--- a/packages/lib/src/data/messages_user.ts
+++ b/packages/lib/src/data/messages_user.ts
@@ -2,6 +2,7 @@ import { Type, Static } from "@sinclair/typebox";
 import UserDetails, { IUser } from "./UserDetails.js";
 import { StringEnum, jsonArray, plainJson } from "./composites.js";
 import { MessageRequest } from "./messages_core.js";
+import { PermissionError } from "../errors.js";
 
 export class UserGetRequest {
 	declare ["constructor"]: typeof UserGetRequest;
@@ -276,8 +277,9 @@ export class UserBulkImportRequest {
 					user.checkPermission("core.user.set_whitelisted");
 					break;
 				default:
+					// Unvalidated input during permission check: deny, don't throw a bare Error
 					// @ts-expect-error Unreachable
-					throw new Error(`Unknown import / restore type: ${data.importType}`);
+					throw new PermissionError(`Unknown import / restore type: ${data.importType}`);
 			}
 		}
 	}

--- a/packages/lib/src/link/link.ts
+++ b/packages/lib/src/link/link.ts
@@ -196,16 +196,20 @@ export class Link {
 
 		let entry = this._validateMessage(message);
 		if (entry && this.connector.dst.type === libData.Address.control) {
+			let permissionMessage = message as libData.MessageRequest | libData.MessageEvent;
 			try {
-				this.validatePermission(
-					message as libData.MessageRequest | libData.MessageEvent,
-					entry
-				); // Somewhat hacky, defined in ControlConnection
+				this.validatePermission(permissionMessage, entry); // Somewhat hacky, defined in ControlConnection
 			} catch (err) {
-				if (err instanceof libErrors.PermissionError) {
-					return;
+				// A non-PermissionError means the permission check itself is
+				// broken.  validatePermission (control connections only) already
+				// sent a response error, so log and drop instead of crashing.
+				if (!(err instanceof libErrors.PermissionError)) {
+					logger.error(
+						`Unexpected error checking permission for ${permissionMessage.name}:\n` +
+						`${(err as Error).stack ?? (err as Error).message}`
+					);
 				}
-				throw err;
+				return;
 			}
 		}
 

--- a/test/lib/data/messages_user.test.js
+++ b/test/lib/data/messages_user.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import * as lib from "@clusterio/lib";
+
+describe("lib/data/messages_user", function() {
+	describe("UserBulkImportRequest", function() {
+		// A user that grants every permission, so only the importType switch
+		// can reject the request.
+		function grantAllUser() {
+			const checked = [];
+			return { checked, checkPermission(permission) { checked.push(permission); } };
+		}
+
+		it("should deny an unknown importType with a PermissionError", function() {
+			const user = grantAllUser();
+			assert.throws(
+				() => lib.UserBulkImportRequest.permission(user, { data: { importType: "foo", users: [] } }),
+				lib.PermissionError,
+			);
+		});
+
+		it("should check permissions for a known importType", function() {
+			const user = grantAllUser();
+			lib.UserBulkImportRequest.permission(user, { data: { importType: "admins", users: [] } });
+			assert.deepEqual(user.checked, ["core.user.bulk_import", "core.user.set_admin"]);
+		});
+	});
+});

--- a/test/lib/link/link.js
+++ b/test/lib/link/link.js
@@ -539,6 +539,51 @@ describe("lib/link/link", function() {
 				);
 			});
 
+			describe("permission checking", function() {
+				// A control connection has connector.dst.type === control, which is
+				// what gates permission checking, see link.js _processMessage.
+				function controlSetup() {
+					const connector = new mock.MockConnector(dst, src);
+					const link = new lib.Link(connector);
+					const message = new lib.MessageRequest(1, src, dst, "SimpleRequest");
+					return { connector, link, message };
+				}
+
+				it("should silently deny on PermissionError from the permission check", function() {
+					const { connector, link, message } = controlSetup();
+					let handled = false;
+					let errored = false;
+					connector.on("error", () => { errored = true; });
+					link.handle(SimpleRequest, async () => { handled = true; });
+					link.validatePermission = () => { throw new lib.PermissionError("Denied"); };
+					connector.emit("message", message);
+					assert(!handled, "handler ran despite denial");
+					assert(!errored, "connector emitted error on denial");
+					assert.deepEqual(connector.sentMessages, [], "denial sent a message");
+				});
+
+				it("should not crash when the permission check throws a non-PermissionError", function() {
+					const { connector, link, message } = controlSetup();
+					let handled = false;
+					let errored = false;
+					const logged = [];
+					const originalError = lib.logger.error;
+					lib.logger.error = msg => { logged.push(msg); };
+					connector.on("error", () => { errored = true; });
+					try {
+						link.handle(SimpleRequest, async () => { handled = true; });
+						link.validatePermission = () => { throwSimple("check is broken"); };
+						connector.emit("message", message);
+					} finally {
+						lib.logger.error = originalError;
+					}
+					assert(!errored, "non-PermissionError escaped to the connector error path");
+					assert(!handled, "handler ran after the permission check threw");
+					assert.equal(logged.length, 1);
+					assert(logged[0].startsWith("Unexpected error checking permission for SimpleRequest:\n"));
+				});
+			});
+
 			describe("Broadcast handling", function() {
 				// A broadcast is addressed to every link of the type it targets,
 				// so a link it reaches has to pass it on as well as handle it,


### PR DESCRIPTION
Any authenticated control client can crash the whole controller process with a single request. `UserBulkImportRequest.permission` reads the raw `message.data` (before the request body is schema-validated) and throws a plain `Error` for an unknown `importType`. Permission checks run in `Link._processMessage`, whose catch only swallows `PermissionError` and rethrows everything else. The rethrow reaches the connector "message" listener, which for a non-InvalidMessage error calls `connector.emit("error", err)`; controller-side connectors have no "error" listener, so Node rethrows and `handleUnhandledErrors` exits the process.

Confirmed against a running controller: a control client sends `UserBulkImportRequest` with `importType: "foo"`. The client gets a normal error response ("Unknown import / restore type: foo"), then the controller logs `fatal Uncaught exception` and exits. The permission function runs before validation, so this reaches the throw regardless of the sender's permissions.

Two changes:
- `_processMessage` now logs an unexpected (non-`PermissionError`) error from the permission check and stops processing the request, instead of rethrowing it to the fatal connector path. A real `PermissionError` still denies silently as before. Permission checks only run for control connections, and `ControlConnection.validatePermission` already sends the response error before throwing, so the client is not left hanging.
- `UserBulkImportRequest.permission` throws `PermissionError` for an unknown `importType`, so it is a clean denial on its own.

With the fix the same request returns the error response and the controller stays up.

### Changelog
```
### Fixes
- Fixed the controller exiting when a control message's permission check threw an unexpected error. #1033
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
