### PR TITLE
Stop the host crashing on malformed server log action lines

### DIFF
--- a/packages/host/src/Instance.ts
+++ b/packages/host/src/Instance.ts
@@ -306,7 +306,12 @@ export default class Instance extends lib.Link {
 				return;
 			}
 
-			let name = /^([^ ]+)/.exec(parsed.message)![1];
+			// Guard against lines that classify as actions but lack a name
+			let nameMatch = /^([^ ]+)/.exec(parsed.message);
+			if (!nameMatch) {
+				return;
+			}
+			let name = nameMatch[1];
 
 			// Detect player leave and join
 			if (parsed.action === "JOIN") {
@@ -322,7 +327,9 @@ export default class Instance extends lib.Link {
 
 			// Detect banned and admin state change, whitelist changes are not logged
 			if (parsed.action === "BAN") {
-				const reason = /\. Reason: (.+)\.$/.exec(parsed.message)![1];
+				// Ban lines without a ". Reason: X." tail default to no reason
+				const reasonMatch = /\. Reason: (.+)\.$/.exec(parsed.message);
+				const reason = reasonMatch ? reasonMatch[1] : "";
 				this._recordUserUpdate(parsed.action, name, reason !== "unspecified" ? reason : "");
 			} else if (["UNBANNED", "PROMOTE", "DEMOTE"].includes(parsed.action)) {
 				this._recordUserUpdate(parsed.action as "UNBANNED" | "PROMOTE" | "DEMOTE", name);
@@ -348,8 +355,11 @@ export default class Instance extends lib.Link {
 				return;
 			}
 
-			const name = /^([^ ]+)/.exec(parsed.message)![1];
-			this._recordUserUpdate(parsed.action as "PROMOTE" | "DEMOTE", name);
+			const nameMatch = /^([^ ]+)/.exec(parsed.message);
+			if (!nameMatch) {
+				return;
+			}
+			this._recordUserUpdate(parsed.action as "PROMOTE" | "DEMOTE", nameMatch[1]);
 		});
 	}
 

--- a/test/host/Instance.js
+++ b/test/host/Instance.js
@@ -328,4 +328,37 @@ describe("class Instance", function() {
 			}
 		});
 	});
+
+	describe("_watchServerLogActions()", function() {
+		beforeEach(function() {
+			instance.config.set("factorio.sync_banlist", "bidirectional");
+			instance._watchServerLogActions();
+		});
+		afterEach(function() {
+			clearInterval(instance._playerCheckInterval);
+		});
+		function emitAction(action, message) {
+			instance.server.emit("output", { type: "action", action, message }, "");
+		}
+		it("should record a normal JOIN action", function() {
+			emitAction("JOIN", "player joined the game");
+			assert(instance.playersOnline.has("player"), "player was not added");
+		});
+		it("should parse the reason of a normal BAN action", function() {
+			emitAction("BAN", "player was banned by <server>. Reason: griefing.");
+			assert.deepEqual(
+				connector.sentMessages[0],
+				new lib.MessageEvent(
+					1, src, addr("allInstances"), "InstanceBanlistUpdateEvent",
+					new lib.InstanceBanlistUpdateEvent("player", true, "griefing"),
+				),
+			);
+		});
+		it("should not throw on a BAN action without a reason tail", function() {
+			assert.doesNotThrow(() => emitAction("BAN", "evil"));
+		});
+		it("should not throw on an action whose message starts with a space", function() {
+			assert.doesNotThrow(() => emitAction("JOIN", " "));
+		});
+	});
 });


### PR DESCRIPTION
A control client with `core.instance.send_rcon` can crash the host process. `Instance._watchServerLogActions` parses server output lines classified as actions and dereferences two regex results with `!`: the name match `/^([^ ]+)/` (null when the message starts with a space) and the ban reason match `/\. Reason: (.+)\.$/` (null for a `[BAN]` line without a `. Reason: X.` tail). The output listener runs synchronously off the stdout line splitter, so the throw is an uncaught exception and the whole host exits, taking every instance on it down.

Confirmed against a real host: on an instance with `factorio.enable_save_patching` off (so this watcher is attached; it also runs for any load-scenario start) and script commands on, `/sc print("2000-01-01 00:00:00 [BAN] evil")` reaches stdout, the parser reads it as a dated `[BAN]` action, and the reason regex returns null. Host exits with `TypeError: Cannot read properties of null`. No player needs to be online.

Guard both matches: skip the line when the name does not match, default the ban reason to `""` when the tail is absent. `_watchPlayerPromote` had the same name dereference and gets the same guard. Real join/leave/kick/ban/promote/demote lines still parse.

### Changelog
```
### Fixes
- Fixed the host exiting on server log lines that look like actions but do not match the expected format. #1034
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
