### PR TITLE
Keep the debug dump flag set across session resumes

### DIFF
--- a/packages/controller/src/ControlConnection.ts
+++ b/packages/controller/src/ControlConnection.ts
@@ -48,9 +48,13 @@ export default class ControlConnection extends BaseConnection {
 
 		this._version = registerData.version;
 
-		this.connector.on("connect", () => {
-			this.connector._socket!.clusterio_ignore_dump = Boolean(this.ws_dumper);
-		});
+		// A resume installs a fresh socket, so re-apply the ignore flag or the
+		// dumper's own frames get echoed back into it and recurse forever.
+		for (let event of ["connect", "resume"] as const) {
+			this.connector.on(event, () => {
+				this.connector._socket!.clusterio_ignore_dump = Boolean(this.ws_dumper);
+			});
+		}
 		this.connector.on("close", () => {
 			if (this.logTransport) {
 				logger.remove(this.logTransport);

--- a/test/controller/ControlConnection.test.js
+++ b/test/controller/ControlConnection.test.js
@@ -1,7 +1,40 @@
 import assert from "node:assert/strict";
-import { ControlConnection } from "@clusterio/controller";
+import * as lib from "@clusterio/lib";
+import { Controller, ControlConnection } from "@clusterio/controller";
 
 describe("controller/src/ControlConnection", function() {
+	describe(".handleDebugDumpWsRequest()", function() {
+		function makeConnection() {
+			const controllerConfig = new lib.ControllerConfig("controller");
+			const connector = new lib.VirtualConnector(
+				lib.Address.fromShorthand("controller"),
+				lib.Address.fromShorthand({ controlId: 1 }),
+			);
+			connector._socket = {};
+			const controller = new Controller(lib.logger, [], controllerConfig);
+			const user = controller.users.getOrCreateUser("test");
+			return new ControlConnection({ version: "2.0.0" }, connector, controller, user, 1);
+		}
+
+		it("re-applies clusterio_ignore_dump to the socket on resume", async function() {
+			const connection = makeConnection();
+			await connection.handleDebugDumpWsRequest(new lib.DebugDumpWsRequest());
+			// A resume installs a fresh socket without the flag.
+			const resumedSocket = {};
+			connection.connector._socket = resumedSocket;
+			connection.connector.emit("resume");
+			assert.equal(resumedSocket.clusterio_ignore_dump, true);
+		});
+
+		it("leaves the flag off on resume without a dumper", function() {
+			const connection = makeConnection();
+			const resumedSocket = {};
+			connection.connector._socket = resumedSocket;
+			connection.connector.emit("resume");
+			assert.equal(resumedSocket.clusterio_ignore_dump, false);
+		});
+	});
+
 	describe(".handleControllerRestartRequest()", function() {
 		let mockController;
 


### PR DESCRIPTION
An admin who has the WebSocket debug dump active can crash the controller by dropping and resuming their connection. `DebugDumpWsRequest` marks the socket with `clusterio_ignore_dump` so the `WsServer` send wrapper does not echo the dumper's own frames back into `debugEvents`. That flag is set in the connector "connect" handler, but `WsServerConnector.continue()` installs a fresh socket and emits "resume", not "connect", so a resumed session loses the flag. The next outgoing frame is then echoed to `debugEvents`, `ws_dumper` sends a `DebugWsMessageEvent`, the wrapper echoes that too, and it recurses synchronously until `JSON.stringify` throws `RangeError: Invalid string length`. That is an uncaught exception, so the controller exits.

Confirmed against a running controller: enable the dump, force a socket drop so the session resumes, and the controller dies with a `RangeError` originating in `ControlConnection.ws_dumper`.

Set `clusterio_ignore_dump` on "resume" as well as "connect" (folded into one small loop). With the fix the session resumes and the controller stays up.

Touches the same file as #1027 but a different spot (the constructor's connect handler vs `handleDebugDumpWsRequest`); the two are independent.

### Changelog
```
### Fixes
- Fixed the controller crashing when a control connection with the WebSocket debug dump active was resumed. #1035
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
